### PR TITLE
fix(zero-docs): Release notes nav presentation

### DIFF
--- a/contents/docs/release-notes/index.mdx
+++ b/contents/docs/release-notes/index.mdx
@@ -2,11 +2,11 @@
 title: Release Notes
 ---
 
-- [Zero 0.1: First Release](/docs/release-notes/0.1)
-- [Zero 0.2: Skip Mode and Computed PKs](/docs/release-notes/0.2)
-- [Zero 0.3: Schema Migrations and Write Perms](/docs/release-notes/0.3)
-- [Zero 0.4: Compound Filters](/docs/release-notes/0.4)
-- [Zero 0.5: JSON Columns](/docs/release-notes/0.5)
-- [Zero 0.6: Relationship Filters](/docs/release-notes/0.6)
-- [Zero 0.7: Read Perms and Docker](/docs/release-notes/0.7)
 - [Zero 0.8: Schema Autobuild, Result Types, and Enums](/docs/release-notes/0.8)
+- [Zero 0.7: Read Perms and Docker](/docs/release-notes/0.7)
+- [Zero 0.6: Relationship Filters](/docs/release-notes/0.6)
+- [Zero 0.5: JSON Columns](/docs/release-notes/0.5)
+- [Zero 0.4: Compound Filters](/docs/release-notes/0.4)
+- [Zero 0.3: Schema Migrations and Write Perms](/docs/release-notes/0.3)
+- [Zero 0.2: Skip Mode and Computed PKs](/docs/release-notes/0.2)
+- [Zero 0.1: First Release](/docs/release-notes/0.1)

--- a/lib/routes-config.ts
+++ b/lib/routes-config.ts
@@ -58,18 +58,7 @@ export const ROUTES: EachRoute[] = [
     items: [
       {title: 'Roadmap', href: '/roadmap'},
       {title: 'Reporting Bugs', href: '/reporting-bugs'},
-      {
-        title: 'Release Notes',
-        href: '/release-notes',
-        items: [
-          {title: '0.1', href: '/0.1'},
-          {title: '0.2', href: '/0.2'},
-          {title: '0.3', href: '/0.3'},
-          {title: '0.4', href: '/0.4'},
-          {title: '0.5', href: '/0.5'},
-          {title: '0.6', href: '/0.6'},
-        ],
-      },
+      {title: 'Release Notes', href: '/release-notes'},
     ],
   },
 ];


### PR DESCRIPTION
* Removing release note pages from sidebar subnav.
* Adjusting release notes index to show descending order.