### PR TITLE
update current auth docs to reflect current process

### DIFF
--- a/contents/docs/auth/index.mdx
+++ b/contents/docs/auth/index.mdx
@@ -4,13 +4,19 @@ title: Authentication
 
 Zero uses a JWT-based flow to authenticate connections to zero-cache.
 
-You configure `zero-cache` with a `ZERO_JWT_SECRET` environment variable. During login, your API server encodes the userID and any other useful information into a JWT and signs it with this secret.
+In order to validate JWTs, `zero-cache` must be configured with a `ZERO_JWT_SECRET` environment variable. During login, your API server encodes the userID and any other useful information into a JWT and signs it with this same secret.
 
-The JWT should be sent to your web client and then into the `Zero` client using the `jwtSecret` option.
+The JWT for a user should be sent to your web client and then passed into the `Zero` constructor using the `auth` option.
 
-`Zero` sends the JWT to `zero-cache` during connection, who decodes it to use as an input to [permission rules](permissions).
+```ts
+const zero = new Zero({
+  ...,
+  auth: token, // your JWT
+  userID, // this must match the `sub` field from `token`
+});
+```
 
-<Note type="todo">Diagram needed here.</Note>
+The `zero` instance will send the JWT to `zero-cache` on connect. `Zero-cache` verifies and decodes the JWT to use as an input to [permission rules](permissions).
 
 ## Examples
 


### PR DESCRIPTION
The main typo was this line:

> The JWT should be sent to your web client and then into the `Zero` client using the `jwtSecret` option.

The client takes an `auth` option not `jwtSecret` option.

Cleaned that up and added a TS example.