### PR TITLE
Fix: do sample source code link

### DIFF
--- a/contents/docs/samples/index.mdx
+++ b/contents/docs/samples/index.mdx
@@ -61,4 +61,4 @@ Same as `zero-hello` and `zero-hello-solid` above, but demonstrates Cloudflare D
 This sample runs `zero-client` within a Durable Object and monitors changes to a Zero query. This can be used to do things like send notifications, update external services, etc.
 
 **Stack:** Vite/Hono/React/Cloudflare Workers<br/>
-**Source:** [https://github.com/rocicorp/hello-zero-do](https://github.com/rocicorp/hello-zero)
+**Source:** [https://github.com/rocicorp/hello-zero-do](https://github.com/rocicorp/hello-zero-do)


### PR DESCRIPTION
Link was pointing to the non DO source code