### PR TITLE
Fix React.js example code

### DIFF
--- a/contents/docs/react/index.mdx
+++ b/contents/docs/react/index.mdx
@@ -5,7 +5,7 @@ title: React
 Zero has built-in support for React. Here’s what basic usage looks like:
 
 ```tsx
-import {useQuery} from "@rocicorp/zero/react";
+import {useQuery, useZero} from "@rocicorp/zero/react";
 
 function IssueList() {
   const z = useZero();


### PR DESCRIPTION
Current React.js example has missing import in it