### PR TITLE
It is now possible to differentiate local vs authoritative results

### DIFF
--- a/contents/docs/reading-data/index.mdx
+++ b/contents/docs/reading-data/index.mdx
@@ -301,10 +301,3 @@ Usually subscribing to a query is what you want in a reactive UI but every so of
 ```tsx
 const results = z.query.issue.where('foo', 'bar').run();
 ```
-
-<Note type="note">
-  Zero does not currently have a way to wait for authoritative results. Because
-  of this, this feature will most likely be useful when the data you’re querying
-  has already been preloaded. See also [Ability to wait for authoritative
-  results](/docs/roadmap).
-</Note>


### PR DESCRIPTION
You can check if the result is authoritative by checking for result.type to be 'complete'

See discussion in https://discord.com/channels/830183651022471199/1323431294620926003

Feel free to close if not accurate! Just found this bit a bit confusing myself!