### PR TITLE
fix typos

### DIFF
--- a/contents/docs/connecting-to-postgres/index.mdx
+++ b/contents/docs/connecting-to-postgres/index.mdx
@@ -19,7 +19,7 @@ Here are some common Postgres options and what we know about their support level
 
 Zero uses Postgres “[Event Triggers](https://www.postgresql.org/docs/current/sql-createeventtrigger.html)” to implement high-quality, efficient [schema migration](migrations). Event Triggers typically requires superuser access to Postgres.
 
-Hosted Postgres provides like Supabase and Neon don’t provide superuser access.
+Hosted Postgres providers like Supabase and Neon don’t provide superuser access.
 
 Zero can still works without Event Triggers, but for correctness, any schema change triggers a full rebuild of all server-side and client-side state. For small databases (< 1GB) this can be OK, but for bigger databases we recommend choosing a provider that grants access to Event Triggers.
 

--- a/contents/docs/introduction/index.mdx
+++ b/contents/docs/introduction/index.mdx
@@ -16,6 +16,6 @@ Zero is made possible by a custom streaming query engine we built called [ZQL](r
 
 Zero is in alpha. There are still some rough edges, and to run it, you need to [deploy it yourself](deployment) to AWS or similar.
 
-Even so, Zero is already quite fun to work with. We are using it ourselves to build our very own [Linear-style bug tracker](https://bugs.rocicorp.dev/). We find that Zero is already much more productive than alternatives, even having to ocassionally work around a missing features.
+Even so, Zero is already quite fun to work with. We are using it ourselves to build our very own [Linear-style bug tracker](https://bugs.rocicorp.dev/). We find that Zero is already much more productive than alternatives, even having to occasionally work around a missing features.
 
 If you are building a new web app that needs to be fast and reactive, and can do the deployment yourself, it's a great time to get started with Zero. We're working toward a [beta release and full production readiness](roadmap) next year.

--- a/contents/docs/permissions/index.mdx
+++ b/contents/docs/permissions/index.mdx
@@ -138,7 +138,7 @@ const definePermissions<AuthData, Schema>(schema, () => {
 });
 ```
 
-And this allows an edit if the the loggged in user is the creator after the edit:
+And this allows an edit if the the logged in user is the creator after the edit:
 
 ```ts
 const definePermissions<AuthData, Schema>(schema, () => {

--- a/contents/docs/reporting-bugs/index.mdx
+++ b/contents/docs/reporting-bugs/index.mdx
@@ -6,7 +6,7 @@ title: Reporting Bugs
 
 You can use [zbugs](https://bugs.rocicorp.dev/)! (password: `zql`)
 
-Our own bugtracker built from the ground up on Zero.
+Our own bug tracker built from the ground up on Zero.
 
 <ImageLightbox src="/images/reporting-bugs/zbugs.png" alt="zbugs" />
 


### PR DESCRIPTION
- `Postgres provides` -> `Postgres providers` in `contents/docs/connecting-to-postgres/index.mdx`
- `ocassionally` -> `occasionally` in `contents/docs/introduction/index.mdx`
- `loggged in user` to `logged in user` in `contents/docs/permissions/index.mdx`
- `bugtracker` to `bug tracker` in `contents/docs/reporting-bugs/index.mdx`