### PR TITLE
Fix small typo: nickname/language

### DIFF
--- a/contents/docs/writing-data/index.mdx
+++ b/contents/docs/writing-data/index.mdx
@@ -49,14 +49,14 @@ const userSchema = createTableSchema({
 
 // app.tsx
 
-// Sets nickname to `null` specifically
+// Sets language to `null` specifically
 z.mutate.user.insert({
   id: nanoid(),
   username: 'sam',
   language: null,
 });
 
-// Sets nickname to the default server-side value. Could be null, or some
+// Sets language to the default server-side value. Could be null, or some
 // generated or constant default value too.
 z.mutate.user.insert({
   id: nanoid(),


### PR DESCRIPTION
Hi! Here's a small typo fix for the docs.

The code examples set the `language` field, but the comments erroneously refer to a `nickname` field.