### PR TITLE
Correct link to preloading section of zbugs

### DIFF
--- a/contents/docs/preloading/index.mdx
+++ b/contents/docs/preloading/index.mdx
@@ -46,4 +46,4 @@ For Zero Beta, we will be implementing a consistency model that fixes this. We w
 
 zbugs preloads all issues, their labels, and first ten comments:
 
-https://github.com/rocicorp/mono/blob/main/apps/zbugs/src/zero-setup.ts#L43
+https://github.com/rocicorp/mono/blob/main/apps/zbugs/src/zero-setup.ts#L54


### PR DESCRIPTION
Old link:

![Screenshot 2025-02-11 at 08 47 04](https://github.com/user-attachments/assets/d553293e-abec-40ea-8698-cd1c4923a3b3)


New link:

![Screenshot 2025-02-11 at 08 46 50](https://github.com/user-attachments/assets/82671e14-99fd-46f5-be28-c51cea7e4c06)
