### PR TITLE
feature: made toc aside scrollable, add matched state for link

### DIFF
--- a/components/hooks/useHash.ts
+++ b/components/hooks/useHash.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const getHash = () =>
+  typeof window !== "undefined" ? window.location.hash : undefined;
+
+const useHash = () => {
+  const [isClient, setIsClient] = useState(false);
+  const [hash, setHash] = useState(getHash());
+  const params = useParams();
+
+  useEffect(() => {
+    setIsClient(true);
+    setHash(getHash());
+  }, [params]);
+
+  return isClient ? hash : null;
+};
+
+export default useHash;

--- a/components/toc.tsx
+++ b/components/toc.tsx
@@ -1,23 +1,24 @@
-import {getDocsTocs} from '@/lib/markdown';
 import {ScrollArea} from '@/components/ui/scroll-area';
-import Link from 'next/link';
+import {getDocsTocs} from '@/lib/markdown';
 import clsx from 'clsx';
+import {ActiveHashLink} from './ui/ActiveHashLink';
 
 export default async function Toc({path}: {path: string}) {
   const tocs = await getDocsTocs(path);
 
   return (
-    <div className="lg:flex hidden toc flex-[1] min-w-[230px] py-8 sticky top-16 h-[95.95vh]">
-      <div className="flex flex-col gap-3 w-full pl-2">
+    <div className="lg:flex hidden toc flex-[1] min-w-[230px] sticky py-8 top-16 h-[calc(100vh-64px)]">
+      <div className="flex flex-col gap-3 h-full w-full pl-2">
         {tocs.length > 0 && (
           <>
             <h3 className="font-semibold text-sm">On this page</h3>
-            <ScrollArea className="pb-4 pt-0.5">
+            <ScrollArea className="pb-4 h-full pt-0.5">
               <div className="flex flex-col gap-2.5 text-sm dark:text-neutral-300/85 text-neutral-800 ml-0.5">
                 {tocs.map(({href, level, text}) => (
-                  <Link
+                  <ActiveHashLink
                     key={href}
                     href={href}
+                    activeClassName="text-white"
                     className={clsx({
                       'pl-0': level == 2,
                       'pl-4': level == 3,
@@ -25,7 +26,7 @@ export default async function Toc({path}: {path: string}) {
                     })}
                   >
                     {text}
-                  </Link>
+                  </ActiveHashLink>
                 ))}
               </div>
             </ScrollArea>

--- a/components/ui/ActiveHashLink.tsx
+++ b/components/ui/ActiveHashLink.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import clsx from 'clsx';
+import Link from 'next/link';
+import {useParams, usePathname} from 'next/navigation';
+import {useEffect, useMemo, useRef} from 'react';
+import useHash from '../hooks/useHash';
+
+interface ActiveHashLinkProps {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+  activeClassName?: string;
+}
+
+export const ActiveHashLink: React.FC<ActiveHashLinkProps> = ({
+  href,
+  children,
+  className = '',
+  activeClassName = '',
+}) => {
+  const ref = useRef<HTMLAnchorElement>(null);
+  const linkHash = useHash();
+  const isActive = linkHash === href;
+  useEffect(() => {
+    if (isActive && ref.current) {
+      ref.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'start',
+      });
+    }
+  }, [isActive]);
+
+  return (
+    <Link
+      ref={ref}
+      href={href}
+      className={clsx(className, {[activeClassName]: isActive})}
+    >
+      {children}
+    </Link>
+  );
+};


### PR DESCRIPTION
# 📜 Documentation Navigation Improvements

## Background
While using the Zero documentation, I encountered several usability issues with the right-side navigation bar that could impact the reading experience.

## Issues Identified
1. **Non-scrollable Right Bar**
   - The right navigation bar lacks scrolling functionality
   - Some navigation elements can be cut off or hidden when they extend beyond the viewport

2. **Missing Active Link Highlighting**
   - Currently active/matched links don't have visual indicators
   - Makes it difficult to track your current position in the documentation

3. **Browser History Navigation Issues**
   - When using browser back/forward buttons
   - The matched link doesn't automatically scroll into view
   - Users need to manually locate their position

## Proposed Changes
This PR aims to enhance the documentation navigation experience by:
- Adding proper scroll behavior to the right navigation bar
- Implementing active link highlighting for better visual feedback
- Ensuring matched links scroll into view when using browser navigation

## Benefits
These improvements will:
- Make navigation more intuitive
- Reduce user frustration
- Improve overall documentation accessibility

## Video:
old:

https://github.com/user-attachments/assets/efcb4907-244c-4e14-9cab-a430d153e2fe


new:


https://github.com/user-attachments/assets/1e3e1797-858a-4a75-8720-79f797103255

Let me know if you'd like me to make any adjustments to these changes! 🙂