### PR TITLE
hello-zero uses one pg db

### DIFF
--- a/contents/docs/quickstart/index.mdx
+++ b/contents/docs/quickstart/index.mdx
@@ -88,7 +88,7 @@ Here are some things to try:
 - Add a filter using the **From** and **Contains** controls. Notice that filters are fully dynamic and synced.
 - Edit a message by pressing the **pencil icon**. You can only edit messages from the user you’re logged in as. As before you can attempt to bypass by holding shift.
 - Check out the SQL schema for this database in `seed.sql`.
-- Login to the database with `psql postgresql://user:password@127.0.0.1:5430/zstart` (or any other pg viewer) and delete or alter a row. Observe that it deletes from UI automatically.
+- Login to the database with `psql postgresql://user:password@127.0.0.1:5430/postgres` (or any other pg viewer) and delete or alter a row. Observe that it deletes from UI automatically.
 
 ## Detailed Walkthrough
 


### PR DESCRIPTION
Hi! I'm new to Zero and just spun up the hello-zero via quickstart instructions.

I think this docs change is correct to bring this docs repo in line with the hello-zero repo:

Fix quickstart docs to reflect recent change in hello-zero: https://github.com/rocicorp/hello-zero/commit/5bfc4ba7648fb12ef2861ccc7bfa7d1c49d51e29