### PR TITLE
Fix broken link to zbugs permissions

### DIFF
--- a/contents/docs/permissions.mdx
+++ b/contents/docs/permissions.mdx
@@ -259,4 +259,4 @@ See [Debugging Permissions](./debug/permissions).
 
 ## Examples
 
-See [hello-zero](https://github.com/rocicorp/hello-zero/blob/main/src/schema.ts) for a simple example of write auth and [zbugs](https://github.com/rocicorp/mono/blob/main/apps/zbugs/schema.ts#L16) for a much more involved one.
+See [hello-zero](https://github.com/rocicorp/hello-zero/blob/main/src/schema.ts) for a simple example of write auth and [zbugs](https://github.com/rocicorp/mono/blob/main/apps/zbugs/shared/schema.ts#L217) for a much more involved one.


### PR DESCRIPTION
The zbugs permissions example link was broken. This commit fixes it by pointing to the correct location of the zbugs schema file at the line where the permissions definition for zbugs begins.