### PR TITLE
docs: Update inspector documentation

### DIFF
--- a/contents/docs/debug/inspector.mdx
+++ b/contents/docs/debug/inspector.mdx
@@ -13,7 +13,7 @@ This can help figuring out why you hit loading states, how many queries are acti
 
 ## Creating an Inspector
 
-Each `Zero` instance has an `inspect` method that will return the inspector.
+Each `Zero` instance has an `inspect` method that will return the inspector. The `inspect` method is asynchronous because it performs lazy loading of inspect-only related code.
 
 ```ts
 const z = new Zero({
@@ -21,6 +21,19 @@ const z = new Zero({
 });
 const inspector = await z.inspect();
 ```
+
+<Note type="warning">
+  Ensure that code splitting is enabled when bundling your app to prevent
+  loading inspect-related code by default. The `inspect` API is intended for
+  debugging purposes only and should not be used in production applications. It
+  is not efficient and communicates directly with the zero-cache via RPC over a
+  web socket.
+
+If you are using React, you can use
+[`React.lazy`](https://react.dev/reference/react/lazy) to dynamically load
+components that depend on the `inspect` API.
+
+</Note>
 
 Once you have an inspector you can inspect the current client and client group.
 


### PR DESCRIPTION
To make it clearer that it should be used with lazy loading.

https://bugs.rocicorp.dev/issue/3699