### PR TITLE
docs: fix various typos and code errors

### DIFF
--- a/contents/docs/custom-mutators.mdx
+++ b/contents/docs/custom-mutators.mdx
@@ -35,7 +35,7 @@ Custom mutators introduce a new _server_ component to the Zero architecture.
 
 This server is implemented by you, the developer. It's typically just your existing backend, where you already put auth or other server-side functionality.
 
-The server can be a serverless function, a microservice, or a full stateful server. The only real requirment is that it expose a special _push endpoint_ that `zero-cache` can call to process mutations. This endpoint implements the [push protocol](#custom-push-implementation) and contains your custom logic for each mutation.
+The server can be a serverless function, a microservice, or a full stateful server. The only real requirement is that it expose a special _push endpoint_ that `zero-cache` can call to process mutations. This endpoint implements the [push protocol](#custom-push-implementation) and contains your custom logic for each mutation.
 
 Zero provides utilities in `@rocicorp/zero` that make it really easy implement this endpoint in TypeScript. But you can also implement it yourself if you want. As long as your endpoint fulfills the push protocol, `zero-cache` doesn't care. You can even write it in a different programming language.
 
@@ -163,7 +163,7 @@ export function createMutators() {
     issue: {
       update: async (tx, {id, title}: {id: string; title: string}) => {
         // Validate title length. Legacy issues are exempt.
-        if (e.length > 100) {
+        if (title.length > 100) {
           throw new Error(`Title is too long`);
         }
         await tx.mutate.issue.update({id, title});
@@ -268,7 +268,7 @@ Mutations execute instantly on the client, but it is sometimes useful to know wh
 You can get the server result of a mutation with the `server` property of a mutator's return value:
 
 ```ts
-const serverResult = await zero.mutate.issue.update({
+const { server } = await zero.mutate.issue.update({
   id: 'issue-123',
   title: 'New title',
 }).server;
@@ -343,7 +343,7 @@ import { schema } from "./schema";
 export function createMutators(clientMutators: CustomMutatorDefs<typeof schema>) {
   return {
     // Reuse all client mutators except the ones in `issue`
-    ...clientMutators
+    ...clientMutators,
 
     issue: {
       // Reuse all issue mutators except `update`
@@ -351,14 +351,14 @@ export function createMutators(clientMutators: CustomMutatorDefs<typeof schema>)
 
       update: async (tx, {id, title}: { id: string; title: string }) => {
         // Call the shared mutator first
-        await clientMutators.issue.update(tx, args);
+        await clientMutators.issue.update(tx, {id, title});
 
         // Record a history of this operation happening in an audit
         // log table.
         await tx.mutate.auditLog.insert({
           // Assuming you have an audit log table with fields for
           // `issueId`, `action`, and `timestamp`.
-          issueId: args.id,
+          issueId: id,
           action: 'update-title',
           timestamp: new Date().toISOString(),
         });

--- a/contents/docs/debug/slow-queries.mdx
+++ b/contents/docs/debug/slow-queries.mdx
@@ -27,7 +27,7 @@ Here are some tips to help debug such slow queries.
 
 ## Check `ttl`
 
-If you are seeing the UI unexpected flicker when moving between views, it is likely that the queries backing these views have the default `ttl` of `never`. Set the `ttl` to some longer value to [keep data cached across navigations](https://zero.rocicorp.dev/docs/reading-data#background-queries).
+If you are seeing unexpected UI flicker when moving between views, it is likely that the queries backing these views have the default `ttl` of `never`. Set the `ttl` to some longer value to [keep data cached across navigations](https://zero.rocicorp.dev/docs/reading-data#background-queries).
 
 You may alternately want to [preload some data](https://zero.rocicorp.dev/docs/reading-data#preloading) at app startup.
 

--- a/contents/docs/deployment.mdx
+++ b/contents/docs/deployment.mdx
@@ -8,7 +8,7 @@ To deploy a Zero app, you need to:
 1. Deploy `zero-cache`. We provide a [Docker image](https://hub.docker.com/r/rocicorp/zero) that can work with most Docker hosts.
 1. Deploy your frontend. You can use any hosting service like Vercel or Netlify.
 
-This page described how to deploy `zero-cache`.
+This page describes how to deploy `zero-cache`.
 
 ## Architecture
 
@@ -54,7 +54,7 @@ When run with multiple View Syncer nodes, `zero-cache` supports rolling, downtim
 
 ## Client/Server Version Compatibility
 
-Servers are compatible wth any client of same major version, and with clients one major version back. So for example:
+Servers are compatible with any client of same major version, and with clients one major version back. So for example:
 
 - Server `0.2.*` is compatible with client `0.2.*`
 - Server `0.2.*` is compatible with client `0.1.*`

--- a/contents/docs/permissions.mdx
+++ b/contents/docs/permissions.mdx
@@ -251,7 +251,7 @@ definePermissions<AuthData, Schema>(schema, () => {
 
 ## Delete Permissions
 
-Delete permissions work in the same way as `insert` positions except they run _before_ the delete is applied. So if a delete rule queries the database, it will see that the deleted row is present. If any rule in the ruleset returns a row, the delete is allowed.
+Delete permissions work in the same way as `insert` permissions except they run _before_ the delete is applied. So if a delete rule queries the database, it will see that the deleted row is present. If any rule in the ruleset returns a row, the delete is allowed.
 
 ## Debugging
 

--- a/contents/docs/reading-data.mdx
+++ b/contents/docs/reading-data.mdx
@@ -322,7 +322,7 @@ But it's often useful to keep queries syncing beyond deactivation in case the UI
 const [user] = useQuery(z.query.user.where('id', userId), {ttl: '1d'});
 ```
 
-The `ttl` paramater specifies how long the app developer wishes the query to run inthe background. The following formats are allowed (where `%d` is a positive integer):
+The `ttl` parameter specifies how long the app developer wishes the query to run in the background. The following formats are allowed (where `%d` is a positive integer):
 
 | Format    | Meaning                                                                              |
 | --------- | ------------------------------------------------------------------------------------ |
@@ -395,7 +395,7 @@ Zero returns whatever data it has on the client immediately for a query, then fa
 
 ```tsx
 const [issues, issuesResult] = useQuery(z.query.issue);
-if (issueResult.type === 'complete') {
+if (issuesResult.type === 'complete') {
   console.log('All data is present');
 } else {
   console.log('Some data is missing');

--- a/contents/docs/writing-data.mdx
+++ b/contents/docs/writing-data.mdx
@@ -129,7 +129,7 @@ You can do multiple CRUD mutates in a single _batch_. If any of the mutations fa
 ```tsx
 z.mutateBatch(async tx => {
   const samID = nanoid();
-  tx.user.create({
+  tx.user.insert({
     id: samID,
     username: 'sam',
   });

--- a/contents/docs/zero-schema.mdx
+++ b/contents/docs/zero-schema.mdx
@@ -192,7 +192,7 @@ const issueRelationships = relationships(issue, ({many}) => ({
 ```
 
 <Note>
-  Currently only two levels of chaining are currently supported for
+  Currently only two levels of chaining are supported for
   `relationships`. See https://bugs.rocicorp.dev/issue/3454.
 </Note>
 


### PR DESCRIPTION
Found some typos as well as broken code examples when reading through.