### PR TITLE
fix: Removing calculated height of left bar

### DIFF
--- a/components/leftbar.tsx
+++ b/components/leftbar.tsx
@@ -15,7 +15,7 @@ import Link from 'next/link';
 
 export function Leftbar() {
   return (
-    <aside className="md:flex hidden flex-[1] min-w-[230px] sticky top-16 h-[calc(100vh-64px)] flex-col py-4">
+    <aside className="md:flex hidden flex-[1] min-w-[230px] sticky top-16 flex-col py-4">
       <ScrollArea className="h-full pr-2">
         <DocsMenu />
       </ScrollArea>


### PR DESCRIPTION
To fix scrolling problem on very small displays on views where the main body content is shorter than the left sidebar.