### PR TITLE
Use Schema type consistently in custom-mutators.mdx

### DIFF
--- a/contents/docs/custom-mutators.mdx
+++ b/contents/docs/custom-mutators.mdx
@@ -159,7 +159,7 @@ By convention, the client mutators are defined with a function called `createMut
 ```ts
 // mutators.ts
 import {CustomMutatorDefs} from '@rocicorp/zero';
-import {schema} from './schema';
+import {Schema} from './schema';
 
 export function createMutators() {
   return {
@@ -172,7 +172,7 @@ export function createMutators() {
         await tx.mutate.issue.update({id, title});
       },
     },
-  } as const satisfies CustomMutatorDefs<typeof schema>;
+  } as const satisfies CustomMutatorDefs<Schema>;
 }
 ```
 
@@ -232,6 +232,8 @@ See [the CRUD docs](./writing-data) for detailed semantics on these methods.
 You can read data within a client mutator using [ZQL](./reading-data):
 
 ```ts
+import {Schema} from './schema';
+
 export function createMutators() {
   return {
     issue: {
@@ -247,7 +249,7 @@ export function createMutators() {
         await tx.mutate.issue.update({id, title});
       },
     },
-  } as const satisfies CustomMutatorDefs<typeof schema>;
+  } as const satisfies CustomMutatorDefs<Schema>;
 }
 ```
 
@@ -444,10 +446,10 @@ An approach we like is to create a separate `server-mutators.ts` file that wraps
 ```ts
 // server-mutators.ts
 import {CustomMutatorDefs} from '@rocicorp/zero';
-import {schema} from './schema';
+import {Schema} from './schema';
 
 export function createMutators(
-  clientMutators: CustomMutatorDefs<typeof schema>,
+  clientMutators: CustomMutatorDefs<Schema>,
 ) {
   return {
     // Reuse all client mutators except the ones in `issue`
@@ -472,7 +474,7 @@ export function createMutators(
         });
       },
     },
-  } as const satisfies CustomMutatorDefs<typeof schema>;
+  } as const satisfies CustomMutatorDefs<Schema>;
 }
 ```
 
@@ -502,6 +504,8 @@ We hope to build [custom queries](https://bugs.rocicorp.dev/issue/3453) next –
 In order to do permission checks, you'll need to know what user is making the request. You can pass this information to your mutators by adding a `AuthData` parameter to the `createMutators` function:
 
 ```ts
+import {Schema} from './schema';
+
 type AuthData = {
   sub: string;
 };
@@ -523,7 +527,7 @@ export function createMutators(authData: AuthData | undefined) {
         }
       },
     },
-  } as const satisfies CustomMutatorDefs<typeof schema>;
+  } as const satisfies CustomMutatorDefs<Schema>;
 }
 ```
 
@@ -622,6 +626,8 @@ It is bad practice to hold open database transactions while talking over the net
 There is no specific support for this in custom mutators, but since mutators are just code, it’s easy to do:
 
 ```ts
+import {Schema} from './schema';
+
 // server-mutators.ts
 export function createMutators(
   authData: AuthData,
@@ -637,7 +643,7 @@ export function createMutators(
         });
       },
     },
-  } as const satisfies CustomMutatorDefs<typeof schema>;
+  } as const satisfies CustomMutatorDefs<Schema>;
 }
 ```
 


### PR DESCRIPTION
Or, could go the other way and always use `typeof schema`, but this change feels clearer to me. 

