### PR TITLE
Rename server key in config to cacheServerUrl

### DIFF
--- a/contents/docs/add-to-existing-project.mdx
+++ b/contents/docs/add-to-existing-project.mdx
@@ -142,7 +142,7 @@ import {Zero} from '@rocicorp/zero';
 
 const z = new Zero({
   userID: 'anon',
-  server: 'http://localhost:4848',
+  cacheServerUrl: 'http://localhost:4848',
   schema,
 });
 ```


### PR DESCRIPTION
The `server` key is ambiguous, especially since a web app has a webserver, a push endpoint which might be on a different server, and likely other servers. So, suggest renaming to clarify.

If this is accepted, then I suggest updating example apps to reference the Vite env var like this:

```ts
const z = new Zero({
  userID,
  auth: () => encodedJWT,
  cacheServerUrl: import.meta.env.VITE_ZERO_CACHE_SERVER_URL, 
  schema,
});
```

(hello-zero currently uses VITE_PUBLIC_SERVER which is ambiguous)