### PR TITLE
docs: deprecate CMs, tweak wording

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -150,18 +150,18 @@ export default function Home() {
 
       <p>
         Where Zero really shines is complex, highly-interactive applications
-        like Linear and Superhuman. With Zero, these apps can be built in a
+        similar to Linear and Superhuman. With Zero, these apps can be built in a
         fraction of the time it would take to build even an old-fashioned
         server-rendered web app.
       </p>
       <p>
-        Zero is currently in public alpha. It's got a few rough edges, and you
+        Zero is currently in public alpha. It has a few rough edges, and you
         have to deploy it yourself, but it's already remarkably fun. We&apos;re
         using it ourselves for Zero's{' '}
         <a className="underline" href="https://bugs.rocicorp.dev/">
           official bug tracker
         </a>{' '}
-        and we find it much more productive than the alternatives.
+        and we find it much more productive than alternatives.
       </p>
       <p>
         Ready to start? You can have your first app in production in about 20

--- a/contents/docs/add-to-existing-project.mdx
+++ b/contents/docs/add-to-existing-project.mdx
@@ -11,8 +11,8 @@ you're using React, Vue, Svelte, Solid, or vanilla JavaScript.
   to Postgres](connecting-to-postgres) for setup instructions.
 - If you are using [TypeScript](https://www.typescriptlang.org/) ensure that
   [`strictNullChecks`](https://www.typescriptlang.org/tsconfig/#strictNullChecks)
-  is set to `true` in [tsconfig.json](https://www.typescriptlang.org/tsconfig/). If this is not set then the advanced types Zero uses do not work
-  as expected.
+  is set to `true` in [tsconfig.json](https://www.typescriptlang.org/tsconfig/). If this is 
+  not set, then the advanced types in Zero will not work as expected.
 
 ## Installation
 
@@ -23,7 +23,7 @@ npm install @rocicorp/zero
 ```
 
 <details>
-<summary id="not-npm">Not using npm?</summary>
+<summary id="not-npm">Using `pnpm`, `bun`, or another package manager?</summary>
 
 Zero's server component depends on `@rocicorp/zero-sqlite3`, which contains a
 binary that requires running a postinstall script. Most alternative package
@@ -131,7 +131,7 @@ export const permissions = definePermissions<unknown, Schema>(schema, () => ({
 }));
 ```
 
-For more details, see [permissions](permissions).
+By default, all permissions are denied. For more details, see [permissions](permissions).
 
 ## Creating a Zero Instance
 
@@ -152,6 +152,28 @@ In production, avoid hardcoding the server URL. Use environment variables like
 
 ## Reading Data
 
+Developers using React, SolidJS, Svelte, Vue, or other frameworks can use
+framework-specific integrations. For more details on how to query,
+see [Reading Data with ZQL](reading-data).
+
+### React
+
+React developers can use the `useZero` hook for seamless integration. See
+[React](react) for more details.
+
+### SolidJS
+
+For SolidJS, use the `createZero` function instead of `new Zero`.
+
+Refer to [SolidJS](solidjs) for additional information.
+
+### Other Frameworks
+
+For other frameworks, see the [UI frameworks](community#ui-frameworks)
+documentation.
+
+### No Framework
+
 To read data, use the `materialize` method on a `Query` from the `Zero`
 instance. This creates a materialized view that listens for real-time updates to
 the data:
@@ -167,35 +189,19 @@ When the view is no longer needed, ensure you clean up by destroying it:
 view.destroy();
 ```
 
-For more details, see [Reading Data with ZQL](reading-data).
-
-### React
-
-React developers can use the `useZero` hook for seamless integration. See
-[Integrations React](react) for more details.
-
-### SolidJS
-
-For SolidJS, use the `createZero` function instead of `new Zero`.
-
-Refer to [Integrations SolidJS](solidjs) for additional information.
-
-### Other Frameworks
-
-For other frameworks, see the [UI frameworks](community#ui-frameworks)
-documentation.
-
 ## Writing Data
 
-Zero supports both simple and advanced data mutations. For basic use cases,
-use the [CRUD mutator](writing-data):
+Zero supports both simple and advanced data mutations. We recommend using
+[custom mutators](custom-mutators) - CRUD mutators are deprecated
+and not recommended for new projects.
+
+The custom mutator API on the client looks something like this:
 
 ```ts
 z.mutate.message.insert({id: nanoid(), body: 'Hello World!'});
 ```
 
-For more complex scenarios, such as custom business logic, use
-[custom mutators](custom-mutators) to define tailored mutation behavior.
+You can fully define the interface for a mutator, as well as its underlying implementation on both the client and server.
 
 ## Server-Side Rendering (SSR)
 
@@ -203,6 +209,5 @@ Zero does not yet support SSR. See [SSR](zql-on-the-server#ssr) for details on d
 
 ## Deployment
 
-Ensure all `.env` variables are set in the production environment. For Zero
-cache deployment, see [Deployment](deployment). For frontend deployment, consult
-your framework's documentation.
+Ensure all environment variables are set in the production environment. For `zero-cache` deployment,
+see [Deployment](deployment). For frontend deployment, consult your framework's documentation.

--- a/contents/docs/custom-mutators.mdx
+++ b/contents/docs/custom-mutators.mdx
@@ -1,10 +1,10 @@
 ---
-title: Custom Mutators
+title: Writing Data with Custom Mutators
 ---
 
-_Custom Mutators_ are a new way to write data in Zero that is much more powerful than the original ["CRUD" mutator API](./writing-data).
+Custom Mutators are how data is written in Zero. They are much more powerful than the original ["CRUD" mutator API](./writing-data).
 
-Instead of having only the few built-in `insert`/`update`/`delete` write operations for each table, custom mutators allow you to _create your own write operations_ using arbitrary code. This makes it possible to do things that are impossible or awkward with other sync engines.
+Custom mutators allow you to _create your own write operations_ using arbitrary code. This makes it possible to do things that are impossible or awkward with other sync engines.
 
 For example, you can create custom mutators that:
 
@@ -19,16 +19,13 @@ Despite their increased power, custom mutators still participate fully in sync. 
 
 <Note
   slug="deprecating-crud"
-  heading="Custom mutators will eventually become Zero's only write API"
+  heading="CRUD mutators are deprecated"
+  type="warning"
 >
-  We're still refining the design of custom mutators. During this phase, the old
-  CRUD mutators will continue to work. But we do want to deprecate CRUD
-  mutators, and eventually remove them. So please try out custom mutators and
-  [let us know](https://discord.rocicorp.dev/) how they work for you, and what
-  improvements you need before the cutover.
+  We have deprecated the old CRUD mutators and they will be removed in a future release.
 </Note>
 
-## Understanding Custom Mutators
+## What are Custom Mutators?
 
 ### Architecture
 
@@ -150,9 +147,7 @@ Now that we understand what client and server mutations are, let's walk through 
 6. Clients receive row updates and apply them to their local cache. Any pending mutations which have been applied to the server have their local effects rolled back.
 7. Client-side queries are updated and the user sees the changes.
 
-## Using Custom Mutators
-
-### Registering Client Mutators
+## Registering Client Mutators
 
 By convention, the client mutators are defined with a function called `createMutators` in a file called `mutators.ts`:
 
@@ -192,9 +187,9 @@ const zero = new Zero({
 });
 ```
 
-### Write Data on the Client
+## Writing Data on the Client
 
-The `Transaction` interface passed to client mutators exposes the same `mutate` API as the existing [CRUD-style mutators](./writing-data):
+The `Transaction` interface passed to client mutators exposes a `mutate` API:
 
 ```ts
 async function myMutator(tx: Transaction) {
@@ -225,9 +220,118 @@ async function myMutator(tx: Transaction) {
 }
 ```
 
-See [the CRUD docs](./writing-data) for detailed semantics on these methods.
+### Insert
 
-### Read Data on the Client
+Create new records with `insert`:
+
+```tsx
+z.mutate.user.insert({
+  id: nanoid(),
+  username: 'sam',
+  language: 'js',
+});
+```
+
+Optional fields can be set to `null` to explicitly set the new field to `null`. They can also be set to `undefined` to take the default value (which is often `null` but can also be some generated value server-side).
+
+```tsx
+// schema.ts
+import {createTableSchema} from '@rocicorp/zero';
+
+const userSchema = createTableSchema({
+  tableName: 'user',
+  columns: {
+    id: {type: 'string'},
+    name: {type: 'string'},
+    language: {type: 'string', optional: true},
+  },
+  primaryKey: ['id'],
+  relationships: {},
+});
+
+// app.tsx
+
+// Sets language to `null` specifically
+z.mutate.user.insert({
+  id: nanoid(),
+  username: 'sam',
+  language: null,
+});
+
+// Sets language to the default server-side value. Could be null, or some
+// generated or constant default value too.
+z.mutate.user.insert({
+  id: nanoid(),
+  username: 'sam',
+});
+
+// Same as above
+z.mutate.user.insert({
+  id: nanoid(),
+  username: 'sam',
+  language: undefined,
+});
+```
+
+### Upsert
+
+Create new records or update existing ones with `upsert`:
+
+```tsx
+z.mutate.user.upsert({
+  id: samID,
+  username: 'sam',
+  language: 'ts',
+});
+```
+
+`upsert` supports the same `null` / `undefined` semantics for optional fields that `insert` does (see above).
+
+### Update
+
+Update an existing record. Does nothing if the specified record (by PK) does not exist.
+
+You can pass a partial, leaving fields out that you don’t want to change. For example here we leave the username the same:
+
+```tsx
+// Leaves username field to previous value.
+z.mutate.user.update({
+  id: samID,
+  language: 'golang',
+});
+
+// Same as above
+z.mutate.user.update({
+  id: samID,
+  username: undefined,
+  language: 'haskell',
+});
+
+// Reset language field to `null`
+z.mutate.user.update({
+  id: samID,
+  language: null,
+});
+```
+
+### Delete
+
+Delete an existing record. Does nothing if specified record does not exist.
+
+```tsx
+z.mutate.user.delete({
+  id: samID,
+});
+```
+
+<Note type="note" heading="Cache Persistence" slug="cache-persistence">
+If you want to remove cached data from the browser you can call the `dropAllDatabases` function provided by Zero.
+
+You can read more about it in [Authentication](/docs/auth#data-storage).
+
+</Note>
+
+## Reading Data on the Client
 
 You can read data within a client mutator using [ZQL](./reading-data):
 
@@ -266,7 +370,7 @@ You can use `run()` within custom mutators, but the `type` argument does nothing
 
 </Note>
 
-### Invoking Client Mutators
+## Invoking Client Mutators
 
 Once you have registered your client mutators, you can call them from your client-side application:
 
@@ -279,9 +383,9 @@ zero.mutate.issue.update({
 
 The result of a call to a mutator is a `Promise`. You do not usually need to `await` this promise as Zero mutators run very fast, usually completing in a tiny fraction of one frame.
 
-However because mutators ocassionally need to access browser storage, they are technically `async`. Reading a row that was written by a mutator immediately after it is written may not return the new data, because the mutator may not have completed writing to storage yet.
+However because mutators occasionally need to access browser storage, they are technically `async`. Reading a row that was written by a mutator immediately after it is written may not return the new data, because the mutator may not have completed writing to storage yet.
 
-### Waiting for Mutator Result
+### Waiting for Results
 
 We typically recommend that you "fire and forget" mutators.
 
@@ -335,7 +439,7 @@ If the client-side mutator fails, the `.server` promise is also rejected with th
   There is not yet a way to return data from mutators in the success case – the type of `.clent` and `.server` is always `Promise<void>`. [Let us know](https://discord.rocicorp.dev/) if you need this.
 </Note>
 
-### Setting Up the Server
+## Server Setup
 
 You will need a server somewhere you can run an endpoint on. This is typically a serverless function on a platform like Vercel or AWS but can really be anything.
 
@@ -396,98 +500,6 @@ export default handle(app);
 
 To reuse the client mutators exactly as-is on the server just pass the result of the same `createMutators` function to `PushProcessor`.
 
-### Server Error Handling
-
-The `PushProcessor` in `@rocicorp/zero/pg` skips any mutations that throw:
-
-```ts
-app.post('/push', async c => {
-  const result = await processor.process({
-    issue: {
-      update: async (tx, data) => {
-        // The mutation is skipped and the next mutation runs as normal.
-        throw new Error('bonk');
-      },
-    },
-  }, ...);
-  return await c.json(result);
-})
-```
-
-`PushProcessor` catches such errors and turns them into a structured response that gets sent back to the client. You can [recover the errors](#waiting-for-mutator-result) and show UI if you want.
-
-It is also of course possible for the entire push endpoint to return an HTTP error, or to not reply at all:
-
-```ts
-app.post('/push', async c => {
-  // This will cause the client to resend all queued mutations.
-  throw new Error('zonk');
-  const result = await processor.process({
-    // ...
-  }, ...);
-  return await c.json(result);
-})
-```
-
-If Zero recieves any response from the push endpoint other than HTTP 200, 401, or 403, it will disconnect, wait a few moments, reconnect, and then retry all unprocessed mutations.
-
-If Zero receives HTTP 401 or 403, the client [refreshes the `auth` token](./auth#refresh) if possible, then retries all queued mutations.
-
-If you want a different behavior, it is possible to [implement your own](#custom-push-implementation) `PushProcessor` and handle errors differently.
-
-### Server-Specific Code
-
-To implement server-specific code, just run different mutators in your push endpoint!
-
-An approach we like is to create a separate `server-mutators.ts` file that wraps the client mutators:
-
-```ts
-// server-mutators.ts
-import {CustomMutatorDefs} from '@rocicorp/zero';
-import {schema} from './schema';
-
-export function createMutators(
-  clientMutators: CustomMutatorDefs<typeof schema>,
-) {
-  return {
-    // Reuse all client mutators except the ones in `issue`
-    ...clientMutators,
-
-    issue: {
-      // Reuse all issue mutators except `update`
-      ...clientMutators.issue,
-
-      update: async (tx, {id, title}: {id: string; title: string}) => {
-        // Call the shared mutator first
-        await clientMutators.issue.update(tx, {id, title});
-
-        // Record a history of this operation happening in an audit
-        // log table.
-        await tx.mutate.auditLog.insert({
-          // Assuming you have an audit log table with fields for
-          // `issueId`, `action`, and `timestamp`.
-          issueId: id,
-          action: 'update-title',
-          timestamp: new Date().toISOString(),
-        });
-      },
-    },
-  } as const satisfies CustomMutatorDefs<typeof schema>;
-}
-```
-
-For simple things, we also expose a `location` field on the transaction object that you can use to branch your code:
-
-```ts
-myMutator: (tx) => {
-  if (tx.location === 'client') {
-    // Client-side code
-  } else {
-    // Server-side code
-  }
-},
-```
-
 ### Permissions
 
 Because custom mutators are just arbitrary TypeScript functions, there is no need for a special permissions system. Therefore, you won't use Zero's [write permissions](./permissions) when you use custom mutators.
@@ -547,6 +559,98 @@ processor.process(
   c.req.query(),
   await c.req.json(),
 );
+```
+
+### Server Error Handling
+
+The `PushProcessor` in `@rocicorp/zero/pg` skips any mutations that throw:
+
+```ts
+app.post('/push', async c => {
+  const result = await processor.process({
+    issue: {
+      update: async (tx, data) => {
+        // The mutation is skipped and the next mutation runs as normal.
+        throw new Error('bonk');
+      },
+    },
+  }, ...);
+  return await c.json(result);
+})
+```
+
+`PushProcessor` catches such errors and turns them into a structured response that gets sent back to the client. You can [recover the errors](#waiting-for-mutator-result) and show UI if you want.
+
+It is also of course possible for the entire push endpoint to return an HTTP error, or to not reply at all:
+
+```ts
+app.post('/push', async c => {
+  // This will cause the client to resend all queued mutations.
+  throw new Error('zonk');
+  const result = await processor.process({
+    // ...
+  }, ...);
+  return await c.json(result);
+})
+```
+
+If Zero receives any response from the push endpoint other than HTTP 200, 401, or 403, it will disconnect, wait a few moments, reconnect, and then retry all unprocessed mutations.
+
+If Zero receives HTTP 401 or 403, the client [refreshes the `auth` token](./auth#refresh) if possible, then retries all queued mutations.
+
+If you want a different behavior, it is possible to [implement your own](#custom-push-implementation) `PushProcessor` and handle errors differently.
+
+### Server-Specific Code
+
+To implement server-specific code, just run different mutators in your push endpoint!
+
+We recommend creating a separate `server-mutators.ts` file that wraps the client mutators:
+
+```ts
+// server-mutators.ts
+import {CustomMutatorDefs} from '@rocicorp/zero';
+import {schema} from './schema';
+
+export function createMutators(
+  clientMutators: CustomMutatorDefs<typeof schema>,
+) {
+  return {
+    // Reuse all client mutators except the ones in `issue`
+    ...clientMutators,
+
+    issue: {
+      // Reuse all issue mutators except `update`
+      ...clientMutators.issue,
+
+      update: async (tx, {id, title}: {id: string; title: string}) => {
+        // Call the shared mutator first
+        await clientMutators.issue.update(tx, {id, title});
+
+        // Record a history of this operation happening in an audit
+        // log table.
+        await tx.mutate.auditLog.insert({
+          // Assuming you have an audit log table with fields for
+          // `issueId`, `action`, and `timestamp`.
+          issueId: id,
+          action: 'update-title',
+          timestamp: new Date().toISOString(),
+        });
+      },
+    },
+  } as const satisfies CustomMutatorDefs<typeof schema>;
+}
+```
+
+For simple things, we also expose a `location` field on the transaction object that you can use to branch your code:
+
+```ts
+myMutator: (tx) => {
+  if (tx.location === 'client') {
+    // Client-side code
+  } else {
+    // Server-side code
+  }
+},
 ```
 
 ### Dropping Down to Raw SQL
@@ -617,7 +721,7 @@ export function createMutators(clientMutators: CustomMutatorDefs<Schema>) {
 
 ### Notifications and Async Work
 
-It is bad practice to hold open database transactions while talking over the network, for example to send notifications. Instead, you should let the db transaction commit and do the work asynchronously.
+It is bad practice to hold open database transactions while talking over the network, e.g. when sending notifications. Instead, you should let the db transaction commit and do the work asynchronously.
 
 There is no specific support for this in custom mutators, but since mutators are just code, it’s easy to do:
 

--- a/contents/docs/introduction.mdx
+++ b/contents/docs/introduction.mdx
@@ -4,10 +4,10 @@ title: Welcome to Zero Alpha
 
 Zero is a new kind of [sync engine](./sync) powered by queries.
 
-Rather than syncing entire tables to the client, or using static rules to carefully specify what to sync, you just write queries directly in your client code. Queries can access the entire backend database.
+Rather than syncing entire tables to the client, or using static rules to carefully specify what to sync, you just write queries directly in your client code. Queries can access the entire backend database and use advanced permissions and relationships.
 
-Zero caches the data for queries locally on the device, and reuses that data automatically to answer future queries whenever possible.
+Zero caches data for queries locally on the device, and reuses that data automatically to answer future queries whenever possible.
 
-For typical applications, the result is that almost all queries are answered locally, instantly. It feels like you have access to the entire backend database directly from the client in memory. Occasionally, when you do a more specific query, Zero falls back to the server. But this happens automatically without any extra work required.
+For typical applications, almost all queries are instantly resolved with local data. It feels like you have access to the entire backend database directly from the client in memory. Occasionally, when you do a more specific query, Zero falls back to the server. But this happens automatically without any extra work required.
 
 Zero is made possible by a custom streaming query engine we built called [ZQL](reading-data), which uses [Incremental View Maintenance](https://www.vldb.org/pvldb/vol16/p1601-budiu.pdf) on both client and server to efficiently keep large, complex queries up to date.

--- a/contents/docs/offline.mdx
+++ b/contents/docs/offline.mdx
@@ -29,7 +29,7 @@ The only way to support offline writes in general is to either:
 2. Support custom UX to allow users to fork and merge conflicts when they occur.
 3. Only support editing from a single device.
 
-None of these is _free_. Buiding a good offline UX is a lot of work, and most of that work is borne by application developers.
+None of these is _free_. Building a good offline UX is a lot of work, and most of that work is borne by application developers.
 
 ## … And a Schema Problem
 
@@ -61,7 +61,7 @@ We would like to revisit this in the future and really think through how to desi
 
 ## Dealing with Offline Today
 
-Until Zero disables offline writes automatically, we recomment using the `onOnlineChange` parameter to the `Zero` constructor to detect connection loss and disable editing manually in your UI.
+Until Zero disables offline writes automatically, we recommend using the `onOnlineChange` parameter to the `Zero` constructor to detect connection loss and disable editing manually in your UI.
 
 ## Even More Information
 

--- a/contents/docs/open-source.mdx
+++ b/contents/docs/open-source.mdx
@@ -8,7 +8,7 @@ https://github.com/rocicorp/mono/blob/main/LICENSE
 
 ## Business Model
 
-We plan to commercialize Zero in the future by offering a hosted `zero-cache` service for people who do not want to run it themselves. We expect to charge prices for this rougly comparable to today's database hosting services. We'll also offer white-glove service to help enterprises run `zero-cache` within their own infrastructure.
+We plan to commercialize Zero in the future by offering a hosted `zero-cache` service for people who do not want to run it themselves. We expect to charge prices for this roughly comparable to today's database hosting services. We'll also offer white-glove service to help enterprises run `zero-cache` within their own infrastructure.
 
 These plans may change as we develop Zero further. For example, we may also build closed-source companion software – similar to how Docker, Inc. charges for team access to Docker Desktop.
 

--- a/contents/docs/permissions.mdx
+++ b/contents/docs/permissions.mdx
@@ -6,7 +6,7 @@ Permissions are expressed using [ZQL](reading-data) and run automatically with e
 
 Permissions are currently row based. Zero will eventually also have column permissions.
 
-## Define Permissions
+## Defining Permissions
 
 Permissions are defined in [`schema.ts`](/docs/zero-schema) using the `definePermissions` function.
 
@@ -48,7 +48,7 @@ export const permissions = definePermissions<AuthData, Schema>(schema, () => {
 
 `definePermission` returns a _policy_ object for each table in the schema. Each policy defines a _ruleset_ for the _operations_ that are possible on a table: `select`, `insert`, `update`, and `delete`.
 
-## Access is Denied by Default
+### Access is Denied by Default
 
 If you don't specify any rules for an operation, it is denied by default. This is an important safety feature that helps ensure data isn't accidentally exposed.
 
@@ -85,7 +85,7 @@ const permissions = definePermissions<AuthData, Schema>(schema, () => {
 });
 ```
 
-## Permission Evaluation
+## Evaluating Permissions
 
 Zero permissions are "compiled" into a JSON-based format at build-time. This file is stored in the `{ZERO_APP_ID}.permissions` table of your upstream database. Like other tables, it replicates live down to `zero-cache`. `zero-cache` then parses this file, and applies the encoded rules to every read and write operation.
 
@@ -102,7 +102,7 @@ Basically only property access is allowed. This is really confusing and we're wo
 
 </Note>
 
-## Permission Deployment
+## Deploying Permissions
 
 During development, permissions are compiled and uploaded to your database completely automatically as part of the `zero-cache-dev` script.
 
@@ -134,7 +134,7 @@ Each operation on a policy has a _ruleset_ containing zero or more _rules_.
 
 A rule is just a TypeScript function that receives the logged in user's `AuthData` and generates a ZQL [where expression](reading-data#compound-filters). At least one rule in a ruleset must return a row for the operation to be allowed.
 
-## Select Permissions
+### Select
 
 You can limit the data a user can read by specifying a `select` ruleset.
 
@@ -161,15 +161,23 @@ definePermissions<AuthData, Schema>(schema, () => {
 
 If the issue table has two rows, one created by the user and one by someone else, the user will only see the row they created in any queries.
 
-### Column permissions
+<Note slug="column-permissions" heading="Column permissions are not supported yet">
+  Zero does not currently support column based permissions - the select permission applies to every column. The recommended approach for now is to factor out private fields into a separate table, e.g. `user_private`. Column permissions are [planned](roadmap#q4-2025) but currently not a high priority.
 
-Zero does not currently support column based permissions. Select permission applies to every column. The recommended approach for now is to factor out private fields into a separate table, e.g. `user_private`. Column permissions are planned but currently not a high priority.
+Although the same limitation applies to declarative insert/update permissions, [custom mutators](/docs/custom-mutators) support arbitrary server-side logic and so can easily control which columns are writable.
 
-Note that although the same limitation applies to declarative insert/update permissions, [custom mutators](/docs/custom-mutators) support arbitrary server-side logic and so can easily control which columns are writable.
+</Note>
 
-## Insert Permissions
+### Insert
 
 You can limit what rows can be inserted and by whom by specifying an `insert` ruleset.
+
+<Note slug="insert-permissions" heading="You might not need insert permissions" type="warning">
+  If you are using [custom mutators](/docs/custom-mutators), you do not need to use insert permissions. You can easily control which columns are writable
+  in the mutators themselves.
+
+Insert permissions are deprecated and will be removed in a future release.
+</Note>
 
 Insert rules are evaluated after the entity is inserted. So if they query the database, they will see the inserted row present. If any rule in the insert ruleset returns a row, the insert is allowed.
 
@@ -192,9 +200,16 @@ definePermissions<AuthData, Schema>(schema, () => {
 });
 ```
 
-## Update Permissions
+### Update
 
 There are two types of update rulesets: `preMutation` and `postMutation`. Both rulesets must pass for an update to be allowed.
+
+<Note slug="update-permissions" heading="You might not need update permissions" type="warning">
+  If you are using [custom mutators](/docs/custom-mutators), you do not need to use update permissions. You can easily control which columns are writable
+  in the mutators themselves.
+
+Update permissions are deprecated and will be removed in a future release.
+</Note>
 
 `preMutation` rules see the version of a row _before_ the mutation is applied. This is useful for things like checking whether a user owns an entity before editing it.
 
@@ -268,7 +283,14 @@ definePermissions<AuthData, Schema>(schema, () => {
 });
 ```
 
-## Delete Permissions
+### Delete
+
+<Note slug="delete-permissions" heading="You might not need delete permissions" type="warning">
+  If you are using [custom mutators](/docs/custom-mutators), you do not need to use delete permissions. You can easily control which rows can be deleted
+  in the mutators themselves.
+
+Delete permissions are deprecated and will be removed in a future release.
+</Note>
 
 Delete permissions work in the same way as `insert` permissions except they run _before_ the delete is applied. So if a delete rule queries the database, it will see that the deleted row is present. If any rule in the ruleset returns a row, the delete is allowed.
 

--- a/contents/docs/quickstart.mdx
+++ b/contents/docs/quickstart.mdx
@@ -8,13 +8,12 @@ title: Quickstart
 - Node 20+
 
 <Note type="note" slug="other-frameworks">
-  This quickstart uses React, but we also have it available for SolidJS. See:
-  [SolidJS](/docs/solidjs).
+  This quickstart uses React, but we also have [one available for SolidJS](/docs/solidjs).
 </Note>
 
 ## Run
 
-In one terminal, install and start the database:
+First, install and start a Postgres database:
 
 ```bash
 git clone https://github.com/rocicorp/hello-zero.git
@@ -24,14 +23,14 @@ npm install
 npm run dev:db-up
 ```
 
-In a second terminal, start `zero-cache`:
+In a separate terminal, start `zero-cache`:
 
 ```bash
 cd hello-zero
 npm run dev:zero-cache
 ```
 
-In a final terminal, start the UI:
+In a final terminal, start the application:
 
 ```bash
 cd hello-zero
@@ -48,7 +47,7 @@ Here are some things to try:
 - Press the **Remove Messages** button to remove messages. Only logged-in users are allowed to remove messages. You can **hold shift** to bypass the UI warning and see that write access control is being enforced server-side – the UI flickers as the optimistic write happens instantly and is then reverted by the server. Press **login** to login as a random user, then the remove button will work.
 - Open two different browsers and see how fast sync propagates changes.
 - Add a filter using the **From** and **Contains** controls. Notice that filters are fully dynamic and synced.
-- Edit a message by pressing the **pencil icon**. You can only edit messages from the user you’re logged in as. As before you can attempt to bypass by holding shift.
+- Edit a message by pressing the **pencil icon**. You can only edit messages from the user you’re logged in as. Similar to the remove button, you can attempt to bypass by holding shift.
 - Check out the SQL schema for this database in `seed.sql`.
 - Login to the database with `psql postgresql://user:password@127.0.0.1:5430/postgres` (or any other pg viewer) and delete or alter a row. Observe that it deletes from UI automatically.
 

--- a/contents/docs/reading-data.mdx
+++ b/contents/docs/reading-data.mdx
@@ -23,7 +23,7 @@ In the future, we'll [`freeze`](https://developer.mozilla.org/en-US/docs/Web/Jav
 
 ## Select
 
-ZQL queries start by selecting a table. There is no way to select a subset of columns; ZQL queries always return the entire row (modulo column permissions).
+ZQL queries start by selecting a table. There is no way to select a subset of columns; ZQL queries always return the entire row, if permissions allow it.
 
 ```tsx
 const z = new Zero(...);
@@ -117,7 +117,7 @@ You can query related rows using _relationships_ that are defined in your [Zero 
 z.query.issue.related('comments');
 ```
 
-Relationships are returned as hierarchical data. In the above example, each row will have a `comments` field which is itself an array of the corresponding comments row.
+Relationships are returned as hierarchical data. In the above example, each row will have a `comments` field, which is an array of the corresponding comments rows.
 
 You can fetch multiple relationships in a single query:
 
@@ -168,7 +168,7 @@ You can filter a query with `where()`:
 z.query.issue.where('priority', '=', 'high');
 ```
 
-The first parameter is always a column name from the table being queried. Intellisense will offer available options (sourced from your [Zero Schema](/docs/zero-schema)).
+The first parameter is always a column name from the table being queried. TypeScript completion will offer available options (sourced from your [Zero Schema](/docs/zero-schema)).
 
 ### Comparison Operators
 
@@ -245,7 +245,7 @@ Your filter can also test properties of relationships. Currently the only suppor
 z.query.organization.whereExists('employees');
 ```
 
-The argument to `whereExists` is a relationship, so just like other relationships it can be refined with a query:
+The argument to `whereExists` is a relationship, so just like other relationships, it can be refined with a query:
 
 ```tsx
 // Find all orgs that have at least one cool employee
@@ -288,9 +288,9 @@ So when you are thinking about whether a query is going to return results instan
 <Note type="note" heading="Caches vs Replicas">
   This is why we often say that despite the name `zero-cache`, Zero is not technically a cache. It's a *replica*.
 
-A cache has a random set of rows with a random set of versions. There is no expectation that the cache any particular rows, or that the rows' have matching versions. Rows are simply updated as they are fetched.
+A cache has a random set of rows with a random set of versions. There is no expectation that the cache has any particular rows, or that the rows have matching versions. Rows are simply updated as they are fetched.
 
-A replica by contrast is eagerly updated, whether or not any client has requested a row. A replica is always very close to up-to-date, and always self-consistent.
+A replica, by contrast, is eagerly updated whether or not any client has requested a row. A replica is always very close to up-to-date, and always self-consistent.
 
 Zero is a _partial_ replica because it only replicates rows that are returned by syncing queries.
 
@@ -347,7 +347,7 @@ We will be reworking this API to be less of a footgun in the next Zero release. 
 
 If the UI re-requests a background query, it becomes an active query again. Since the query was syncing in the background, the very first synchronous result that the UI receives after reactivation will be up-to-date with the server (i.e., it will have `resultType` of `complete`).
 
-Just like other types of queries, the data from background queries is available for use by new queries. A common pattern in to [preload](#preloading) a subset of most commonly needed data with `{ttl: 'forever'}` and then do more specific queries from the UI with, e.g., `{ttl: '1d'}`. Most often the preloaded data will be able to answer user queries, but if not, the new query will be answered by the server and backgrounded for a day in case the user revisits it.
+Just like other types of queries, the data from background queries is available for use by new queries. A common pattern is to [preload](#preloading) a subset of most commonly needed data with `{ttl: 'forever'}` and then do more specific queries from the UI with e.g. `{ttl: '1d'}`. Most often the preloaded data will be able to answer user queries, but if not, the new query will be answered by the server and backgrounded for a day in case the user revisits it.
 
 ### Client Capacity Management
 
@@ -402,7 +402,7 @@ We will be adding more tools over time.
 
 ## Completeness
 
-Zero returns whatever data it has on the client immediately for a query, then falls back to the server for any missing data. Sometimes it's useful to know the difference between these two types of results. To do so, use the `result` from `useQuery`:
+Zero immediately returns the data for a query it has on the client, then falls back to the server for any missing data. Sometimes it's useful to know the difference between these two types of results. To do so, use the `result` from `useQuery`:
 
 ```tsx
 const [issues, issuesResult] = useQuery(z.query.issue);
@@ -517,7 +517,7 @@ z.query.issue
 
 ## Running Queries Once
 
-Usually subscribing to a query is what you want in a reactive UI, but every so often you'll need to run a query just once. To do this, use the `run()` method:
+You usually want to subscribe to a query in a reactive UI, but every so often you'll need to run a query just once. To do this, use the `run()` method:
 
 ```tsx
 const results = await z.query.issue.where('foo', 'bar').run();
@@ -544,17 +544,17 @@ This is the same as saying `run()` or `run({type: 'unknown'})`.
 
 ## Consistency
 
-Zero always syncs a consistent partial replica of the backend database to the client. This avoids many common consistency issues that come up in classic web applications. But there are still some consistency issues to be aware of when using Zero.
+Zero keeps a consistent, partial replica of the backend database on each client. This removes most of the consistency pitfalls that plague traditional web apps, but a few edge cases remain.
 
-For example, imagine that you have a bug database w/ 10k issues. You preload the first 1k issues sorted by created.
+Imagine a bug database with 10 000 issues. You preload the first 1 000 issues ordered by `created`.
 
-The user then does a query of issues assigned to themselves, sorted by created. Among the 1k issues that were preloaded imagine 100 are found that match the query. Since the data we preloaded is in the same order as this query, we are guaranteed that any local results found will be a _prefix_ of the server results.
+Later, the user queries for issues assigned to them, still ordered by `created`. Out of the 1 000 preloaded rows, say 100 match. Because the preload and the query share the same sort, those 100 rows are guaranteed to be a _prefix_ of the full server result.
 
-The UX that result is nice: the user will see initial results to the query instantly. If more results are found server-side, those results are guaranteed to sort below the local results. There's no shuffling of results when the server response comes in.
+That’s great for UX: the user sees those 100 issues immediately, and any extra matches that arrive from the server are appended below—nothing jumps around.
 
-Now imagine that the user switches the sort to ‘sort by modified’. This new query will run locally, and will again find some local matches. But it is now unlikely that the local results found are a prefix of the server results. When the server result comes in, the user will probably see the results shuffle around.
+Now the user switches the sort to `modified`. The query again finds some local rows, but they are no longer guaranteed to be a prefix. When the server responds, new rows may appear above or between the existing ones, causing visible shuffling.
 
-To avoid this annoying effect, what you should do in this example is also preload the first 1k issues sorted by modified desc. In general for any query shape you intend to do, you should preload the first `n` results for that query shape with no filters, in each sort you intend to use.
+The fix is simple: also preload the first 1 000 issues sorted by `modified` (descending). More broadly, for every query shape you plan to run, preload the first `n` rows—without filters—for each sort order you intend to support.
 
 <Note slug="no-duplicate-rows" heading="Zero does not sync duplicate rows">
 Zero syncs the *union* of all active queries' results. You don't have to worry about syncing many sorts of the same query when it's likely the results will overlap heavily.

--- a/contents/docs/samples.mdx
+++ b/contents/docs/samples.mdx
@@ -60,7 +60,7 @@ Simple quickstart for Zero/SolidJS.
 <ImageLightbox src="/images/samples/hello-zero-solid.png" alt="Quickstart" />
 
 **Stack:** Vite/Hono/SolidJS<br/>
-**Source:** https://github.com/rocicorp/hello-zero-solid
+**Source:** https://github.com/rocicorp/hello-zero-solid<br/>
 **Features:** Instant reads and writes, realtime updates, custom mutators.
 
 ## hello-zero-do

--- a/contents/docs/status.mdx
+++ b/contents/docs/status.mdx
@@ -32,12 +32,12 @@ This page describes the current state of Zero at a high level. To understand whe
 
 ## Performance
 
-* We do not have a query analyzer, and do not do any join reordering. It's sometimes, but not always possible to manually reorder. Because of this, some queries (especially `exists`) can be pathological. We are actively working on this.
-* Every query is a hybrid query. We haven't yet implemented "client-only" queries, meaning patterns like typeahead search can easily crush the server if the query is expensive.
-* We have basic CLI tools to understand query performance, but we lack a full-featured inspector to understand at a glance what queries are open or slow.
+* We do not have a query analyzer, and do not do any join reordering. It's not always possible to manually reorder. Because of this, some queries (especially `exists`) can cause worst-case performance. We are actively working on this.
+* Every query goes through the server. We haven't yet implemented "client-only" queries, meaning patterns like typeahead search can easily crush the server if the query is expensive.
+* We have basic CLI tools to understand query performance, but we lack a full-featured inspector to easily understand what queries are open or slow.
 
 ## Miscellaneous
 
 * We do not have a way to limit queries to only expected/allowed forms ([in progress](roadmap)).
-* We do not have a good way to support previews (in progress).
+* We do not have a good way to support preview environments (in progress).
 * Running Zero requires [deploying it yourself](deployment) to AWS or similar. Running in a [multinode](deployment#guide-multi-node-on-sstaws), zero-downtime way is possible (we do it for zbugs), but significant effort. Running [single node](deployment#guide-single-node-on-flyio) is easier, but updating the server takes it down for a minute or so (we are working on a SaaS solution).

--- a/contents/docs/sync.mdx
+++ b/contents/docs/sync.mdx
@@ -20,7 +20,7 @@ Let's say you have some data that you want to read and write from multiple devic
 
 This works, but has downsides:
 
-* **Slow access.** Every read and write has to go to the server, addding hundreds of milliseconds to each interaction.
+* **Slow access.** Every read and write has to go to the server, adding hundreds of milliseconds to each interaction.
 * **Stale data.** API responses are immediately stale. The client has no way to know when to refresh them. Users may make decisions based on old information, and the views on different devices diverge over time.
 * **Online-only.** If the server or the user's network connection is down, the app stops working completely.
 
@@ -39,7 +39,7 @@ The app reads and writes *only to the local copy*, not to the network. The sync 
 <Note emoji="🤔" heading="What about conflicts?">
 If the sync engine allows writes from multiple devices, conflicts can occur. This is a central part of sync engine design, and different sync engines handle conflicts differently.
 
-Zero uses [server reconciliation](./custom-mutators#what-is-a-mutator) – an elegant and flexible technique pionneered by the video game industry.
+Zero uses [server reconciliation](./custom-mutators#what-is-a-mutator) – an elegant and flexible technique pioneered by the video game industry.
 </Note>
 
 This architecture can enable:

--- a/contents/docs/when-to-use.mdx
+++ b/contents/docs/when-to-use.mdx
@@ -4,13 +4,13 @@ title: When To Use Zero (and When Not To)
 
 We are trying to make Zero a great choice for a wide variety of applications. But every tool has tradeoffs, and Zero especially so [while in alpha](./status).
 
-This page will help you understance if Zero is a good fit for you today.
+This page will help you understand if Zero is a good fit for you today.
 
 ## Zero Might be a Good Fit
 
 ### You want to sync only a small subset of data to client
 
-Zero's query-driven sync is a powerful solution for partial sync. You can sync any data you can express as a set of Zero queries. By using partial sync, Zero apps can commonly load in < 1s, yet still maintain the interaction perf of sync.
+Zero's query-driven sync is a powerful solution for partial sync. You can define the data you want to sync with a set of Zero queries. By using partial sync, Zero apps can commonly load in < 1s, yet still maintain the interaction perf of sync.
 
 ### You need fine-grained read or write permissions
 
@@ -48,7 +48,7 @@ Zero is written in TypeScript and only supports TypeScript clients.
 
 ### The total backend dataset is > ~1TB
 
-Zero stores a replica of your database (at least the parts that can sync to client) in a SQLite database stored on attached SSD within the Zero server. The ultimate limit of this database size is the size of attached SSD. But 1TB is a reasonable practical limit today.
+Zero stores a replica of your database (or at least the parts that can sync to the client) in a SQLite database stored on attached SSD within the Zero server. The ultimate limit of this database size is the size of attached SSD. But 1TB is a reasonable practical limit today.
 
 ## Zero Might Not be a Good Fit **Yet**
 

--- a/contents/docs/writing-data.mdx
+++ b/contents/docs/writing-data.mdx
@@ -1,5 +1,5 @@
 ---
-title: Writing Data with Mutators
+title: CRUD Mutators (Deprecated)
 ---
 
 Zero generates basic CRUD mutators for every table you sync. Mutators are available at `zero.mutate.<tablename>`:
@@ -13,10 +13,8 @@ z.mutate.user.insert({
 });
 ```
 
-<Note slug="moar-power" type="warning">
-  To build mutators with more complex logic or server-specific behavior, see the
-  new [Custom Mutators API](./custom-mutators) - we plan to eventually deprecate
-  the basic CRUD mutators in favor of this new API.
+<Note slug="moar-power" heading="CRUD mutators are deprecated" type="warning">
+  This API is now deprecated. Please use [Custom Mutators](./custom-mutators) instead.
 </Note>
 
 ## Insert

--- a/contents/docs/zero-schema.mdx
+++ b/contents/docs/zero-schema.mdx
@@ -23,7 +23,7 @@ This page describes using the schema to define your tables, columns, and relatio
 
 ## Defining the Zero Schema
 
-The Zero schema is encoded in a TypeScript file that is conventionally called `schema.ts` file. For example, see [the schema file for `hello-zero`](https://github.com/rocicorp/hello-zero/blob/main/src/schema.ts).
+The Zero schema is encoded in a TypeScript file that is conventionally named `schema.ts`. For example, see [the schema file for `hello-zero`](https://github.com/rocicorp/hello-zero/blob/main/src/schema.ts).
 
 ## Table Schemas
 
@@ -248,7 +248,7 @@ Zero uses TypeScript-style structural typing to detect schema changes and implem
 
 When the Zero client connects to `zero-cache` it sends a copy of the schema it was constructed with. `zero-cache` compares this schema to the one it has, and rejects the connection with a special error code if the schema is incompatible.
 
-By default, The Zero client handles this error code by calling `location.reload()`. The intent is to to get a newer version of the app that has been updated to handle the new server schema.
+By default, the Zero client handles this error code by calling `location.reload()`. The intent is to request a newer version of the app that has been updated to handle the new server schema.
 
 <Note type="note" heading="Update Order">
 It's important to update the database schema first, then the app. Otherwise a reload loop will occur.
@@ -257,7 +257,7 @@ If a reload loop does occur, Zero uses exponential backoff to avoid overloading 
 
 </Note>
 
-If you want to delay this reload, you can do so by providing the `onUpdateNeeded` constructor parameter:
+If you want to change or delay this reload, you can do so by providing the `onUpdateNeeded` constructor parameter:
 
 ```ts
 const z = new Zero({
@@ -270,18 +270,20 @@ const z = new Zero({
 });
 ```
 
-If the schema changes while a client is running in a compatible way, `zero-cache` syncs the schema change to the client so that it's ready when the app reloads and gets new code that needs it. If the schema changes while a client is running in an incompatible way, `zero-cache` will close the client connection with the same error code as above.
+If the schema changes in a compatible way while a client is running, `zero-cache` syncs the schema change to the client so that it's ready when the app reloads. 
+
+If the schema changes in an incompatible way while a client is running, `zero-cache` will close the client connection with the same error code as above.
 
 ### Schema Change Process
 
-Like other database-backed applications, Zero schema migration generally follow an “expand/migrate/contract” pattern:
+Like other database-backed applications, Zero schema migrations generally follow an “expand/migrate/contract” pattern:
 
 1. Implement and run an “expand” migration on the backend that is backwards compatible with existing schemas. Add new rows, tables, as well as any defaults and triggers needed for backwards compatibility.
 2. Add any new permissions required for the new tables/columns by running [`zero-deploy-permissions`](/docs/permissions#permission-deployment).
 3. Update and deploy the client app to use the new schema.
 4. Optionally, after some grace period, implement and run a “contract” migration on the backend, deleting any obsolete rows/tables.
 
-Steps 1-3 can generally be done as part of one deploy by your CI pipeline, but step 4 would be weeks later when most open clients have refreshed and gotten new code.
+Steps 1-3 can generally be done as part of a single deploy in your CI pipeline, but step 4 should be weeks later, when most open clients have refreshed the application.
 
 <Note type="warning" slug="postgres-special-cases">
   Certain schema changes require special handling in Postgres. See [Schema

--- a/contents/docs/zql-on-the-server.mdx
+++ b/contents/docs/zql-on-the-server.mdx
@@ -2,13 +2,13 @@
 title: ZQL on the Server
 ---
 
-[Custom Mutators](custom-mutators) use ZQL on the server as an implementation detail, but you can also use ZQL on the server directly, outside of Custom Mutators.
+[Mutators](custom-mutators) use ZQL on the server as an implementation detail, but you can also use ZQL on the server directly.
 
 This is useful for a variety of reasons:
 
 - You can use ZQL to implement standard REST endpoints, allowing you to share code with custom mutators.
 - You can use ZQL as part of schema migrations.
-- In the future ([but not yet implemented](#ssr)), this can support server-side rendering
+- In the future ([but not yet implemented](#ssr)), this can support server-side rendering.
 
 Here's a basic example:
 

--- a/lib/routes-config.ts
+++ b/lib/routes-config.ts
@@ -47,10 +47,6 @@ export const ROUTES = [
       {title: 'Reading Data (ZQL)', href: '/reading-data'},
       {
         title: 'Writing Data (Mutators)',
-        href: '/writing-data',
-      },
-      {
-        title: 'Custom Mutators',
         href: '/custom-mutators',
       },
       {title: 'Authentication', href: '/auth'},


### PR DESCRIPTION
This PR includes:
1. The deprecation of Custom Mutators (removed CRUD mutators from nav, updated add to project, etc).
2. A bunch of suggested edits for clarity/spelling.

Feel free to take/leave anything in here.