### PR TITLE
Update when-to-use.mdx

### DIFF
--- a/contents/docs/when-to-use.mdx
+++ b/contents/docs/when-to-use.mdx
@@ -49,7 +49,7 @@ Zero is written in TypeScript and only supports TypeScript clients.
 
 ### The total backend dataset is > ~1TB
 
-Zero stores a replica of your database (at least the parts that can sync to client) in a SQLite database stored on attached SSD within the Zero server. The ultimate limit of this database size is the size of attached SSD. But 1TB is a reasonable practical limit today.
+Zero stores a replica of your database (at least the parts that can sync to client) in a SQLite database stored on the user's local disc within the Zero server. The ultimate limit of this database size is the size of the user's attached local disc. But 1TB is a reasonable practical limit today.
 
 ## Zero Might Not be a Good Fit **Yet**
 


### PR DESCRIPTION
SSD seems oddly specific. The real point is the local disc, which may be an old spinning platter, or an SSD. Right?