### PR TITLE
chore: update sst deployment example

### DIFF
--- a/contents/docs/deployment.mdx
+++ b/contents/docs/deployment.mdx
@@ -166,7 +166,20 @@ export default $config({
         ZERO_LITESTREAM_BACKUP_URL: $interpolate`s3://${replicationBucket.name}/backup`,
         ZERO_NUM_SYNC_WORKERS: '0',
       },
+      loadBalancer: {
+        public: false,
+        ports: [
+          {
+            listen: '80/http',
+            forward: '4849/http',
+          },
+        ],
+      },
       transform: {
+        service: {
+          // e.g. extend the grace period for initial sync of large databases
+          healthCheckGracePeriodSeconds: 600,
+        }
         target: {
           healthCheck: {
             enabled: true,
@@ -197,12 +210,24 @@ export default $config({
         },
         environment: {
           ...commonEnv,
-          ZERO_CHANGE_STREAMER_MODE: 'discover',
+          ZERO_CHANGE_STREAMER_URI: replicationManager.url,
+        },
+        loadBalancer: {
+          ports: [
+            {
+              listen: '80/http',
+              forward: '4848/http',
+            },
+          ],
         },
         logging: {
           retention: '1 month',
         },
         transform: {
+          service: {
+            // e.g. extend the grace period for initial sync of large databases
+            healthCheckGracePeriodSeconds: 600,
+          }
           target: {
             healthCheck: {
               enabled: true,
@@ -219,11 +244,6 @@ export default $config({
             },
           },
         },
-      },
-      {
-        // Wait for replication-manager to come up first, for breaking changes
-        // to replication-manager interface.
-        dependsOn: [replicationManager],
       },
     );
 


### PR DESCRIPTION
* Use the `ZERO_CHANGE_STREAMER_URI` and load balancer as the recommended service discovery mechanism
* Add the `healthCheckGracePeriodSeconds` to the example, as this trips up a lot of people with large databases
* Remove the inter-service "wait" dependency; it is no longer needed as of 0.22 (https://github.com/rocicorp/mono/pull/4658)