### PR TITLE
Fix search shortcut (mod+k) conflicting with browser behavior

### DIFF
--- a/components/search.tsx
+++ b/components/search.tsx
@@ -229,7 +229,8 @@ export default function Search() {
   // Toggle the menu when ⌘K is pressed
   useHotkeys(
     'mod+k',
-    () => {
+    (e) => {
+      e.preventDefault();
       setIsOpen(open => !open);
     },
     {enableOnFormTags: true, enableOnContentEditable: true},


### PR DESCRIPTION
### Summary
Prevents the browser’s default action when using the mod+k (or ctrl+k) shortcut to toggle the menu.

### Current Behavior
Pressing ctrl+k opens Chrome’s built-in search bar, which overlays the documentation search bar.

### Updated Behavior
Pressing ctrl+k now prevents the default browser action. The shortcut consistently toggles the documentation search without interference.