### PR TITLE
refactor: use explicit year numbers

### DIFF
--- a/contents/docs/roadmap.mdx
+++ b/contents/docs/roadmap.mdx
@@ -2,7 +2,7 @@
 title: Roadmap
 ---
 
-We are working toward a *beta* release of Zero late this year or early next.
+We are working toward a *beta* release of Zero late 2025 or early 2026.
 
 We define beta as the point at which Zero is a good choice for the average new rich web application. 
 


### PR DESCRIPTION
Reading "late this year or early next", I had to pause for a second and do the mental maths of _do they mean late 2025 and early 2026, or are they behind schedule (as happens in software development) and meant early 2025?_.

It is a nit-picky change, but I think numerical years communicate the timeline the clearest. Especially for people who might not be as familiar with Zero.