### PR TITLE
Fix: Typo in When-To-Use-Zero page

### DIFF
--- a/assets/search-index.json
+++ b/assets/search-index.json
@@ -890,10 +890,10 @@
     "kind": "section"
   },
   {
-    "id": "5-debug/inspector",
+    "id": "5-debug\\inspector",
     "title": "Inspector",
     "searchTitle": "Inspector",
-    "url": "/docs/debug/inspector",
+    "url": "/docs/debug\\inspector",
     "content": "Zero includes a rich inspector API that can help you understand performance or behavior issues you are seeing in your apps. Accessing the Inspector You access the inspector right from the standard developer console in your browser: For convenience, Zero automatically injects itself as __zero on the global scope of every Zero app. Access to the inspector is gated behind the ZERO_ADMIN_PASSWORD config variable in production (when NODE_ENV is set to \"production\"). We require this variable to be set to a non-empty value in production because we want the inspector enabled in all Zero apps without requiring a restart. Clients and Groups Once you have an inspector, you can inspect the current client and client group. For example to see active queries for the current client: let qs = await inspector.client.queries() console.table(qs) To see active queries for the entire group: let qs = await inspector.client.queries() console.table(qs) In Zero, each instance of the Zero class is a client. Each client belongs to a group, which is a set of clients that share the same clientGroupID (typically all clients within a browser profile). Zero syncs all clients in a group together, so they all see the same data. So if you are debugging performance, you often want to look at the queries for the group, since that is what Zero is actually syncing. But if you are trying to understand when particular queries get added, it's convenient to look at the queries for just the current client so that queries from other clients aren't mixed in. Queries The inspector exposes a bunch of useful information about queries. For example, to see the first query for the current client: let qs = await inspector.client.queries() console.log(qs[0]) This outputs something like: Here are some of the more useful fields: Analyzing Queries Use the analyze method to get information about how a query hydrates: await qs[0].analyze() Here are some of the most useful fields in the output: Analyzing Arbitrary ZQL You can also analyze arbitrary ZQL, not just queries that are currently active: await __zero.inspector.analyzeQuery( __builder.issues.whereExists('labels', q => q.id.equals('sync') ) ) This is useful for exploring alternative query constructions to optimize performance. To use this, you will first have to expose your builder as a property of the global object, so that you can access it from the console. For example: // schema.ts // ... const g = globalThis as any g.__builder = builder Analyzing Query Plans A Zero query is composed of one or more single-table queries connected by joins (related, whereExists). Zero delegates the single-table queries to SQLite, which has a sophisticated query planner that chooses the best indexes to use. For the joins, Zero implements its own cost-based planner to choose the best join order and algorithm. To view the plans selected by SQLite, see the sqlitePlans field returned by analyze() or analyzeQuery(). This contains the output of SQLite's EXPLAIN QUERY PLAN command for each SQLite query used: To view the join plan selected by Zero, call analyze() or analyzeQuery() with the joinPlans option set to true and see the joinPlans field in the output: Table Data In addition to information about queries, you can get direct access to the contents of the client side database. const client = __zero.inspector.client // All raw k/v data currently synced to client console.log('client map:') console.log(await client.map()) // kv table extracted into tables // This is same info that is in z.query[tableName].run() for (const tableName of Object.keys(__zero.schema.tables)) { console.log(`table ${tableName}:`) console.table(await client.rows(tableName)) } Server Version Ask the server to confirm what version it is: console.log( 'server version: ', await inspector.serverVersion() )",
     "headings": [
       {
@@ -932,90 +932,90 @@
     "kind": "page"
   },
   {
-    "id": "128-debug/inspector#accessing-the-inspector",
+    "id": "128-debug\\inspector#accessing-the-inspector",
     "title": "Inspector",
     "searchTitle": "Accessing the Inspector",
     "sectionTitle": "Accessing the Inspector",
     "sectionId": "accessing-the-inspector",
-    "url": "/docs/debug/inspector",
+    "url": "/docs/debug\\inspector",
     "content": "You access the inspector right from the standard developer console in your browser: For convenience, Zero automatically injects itself as __zero on the global scope of every Zero app. Access to the inspector is gated behind the ZERO_ADMIN_PASSWORD config variable in production (when NODE_ENV is set to \"production\"). We require this variable to be set to a non-empty value in production because we want the inspector enabled in all Zero apps without requiring a restart.",
     "kind": "section"
   },
   {
-    "id": "129-debug/inspector#clients-and-groups",
+    "id": "129-debug\\inspector#clients-and-groups",
     "title": "Inspector",
     "searchTitle": "Clients and Groups",
     "sectionTitle": "Clients and Groups",
     "sectionId": "clients-and-groups",
-    "url": "/docs/debug/inspector",
+    "url": "/docs/debug\\inspector",
     "content": "Once you have an inspector, you can inspect the current client and client group. For example to see active queries for the current client: let qs = await inspector.client.queries() console.table(qs) To see active queries for the entire group: let qs = await inspector.client.queries() console.table(qs) In Zero, each instance of the Zero class is a client. Each client belongs to a group, which is a set of clients that share the same clientGroupID (typically all clients within a browser profile). Zero syncs all clients in a group together, so they all see the same data. So if you are debugging performance, you often want to look at the queries for the group, since that is what Zero is actually syncing. But if you are trying to understand when particular queries get added, it's convenient to look at the queries for just the current client so that queries from other clients aren't mixed in.",
     "kind": "section"
   },
   {
-    "id": "130-debug/inspector#queries",
+    "id": "130-debug\\inspector#queries",
     "title": "Inspector",
     "searchTitle": "Queries",
     "sectionTitle": "Queries",
     "sectionId": "queries",
-    "url": "/docs/debug/inspector",
+    "url": "/docs/debug\\inspector",
     "content": "The inspector exposes a bunch of useful information about queries. For example, to see the first query for the current client: let qs = await inspector.client.queries() console.log(qs[0]) This outputs something like: Here are some of the more useful fields:",
     "kind": "section"
   },
   {
-    "id": "131-debug/inspector#analyzing-queries",
+    "id": "131-debug\\inspector#analyzing-queries",
     "title": "Inspector",
     "searchTitle": "Analyzing Queries",
     "sectionTitle": "Analyzing Queries",
     "sectionId": "analyzing-queries",
-    "url": "/docs/debug/inspector",
+    "url": "/docs/debug\\inspector",
     "content": "Use the analyze method to get information about how a query hydrates: await qs[0].analyze() Here are some of the most useful fields in the output:",
     "kind": "section"
   },
   {
-    "id": "132-debug/inspector#analyzing-arbitrary-zql",
+    "id": "132-debug\\inspector#analyzing-arbitrary-zql",
     "title": "Inspector",
     "searchTitle": "Analyzing Arbitrary ZQL",
     "sectionTitle": "Analyzing Arbitrary ZQL",
     "sectionId": "analyzing-arbitrary-zql",
-    "url": "/docs/debug/inspector",
+    "url": "/docs/debug\\inspector",
     "content": "You can also analyze arbitrary ZQL, not just queries that are currently active: await __zero.inspector.analyzeQuery( __builder.issues.whereExists('labels', q => q.id.equals('sync') ) ) This is useful for exploring alternative query constructions to optimize performance. To use this, you will first have to expose your builder as a property of the global object, so that you can access it from the console. For example: // schema.ts // ... const g = globalThis as any g.__builder = builder",
     "kind": "section"
   },
   {
-    "id": "133-debug/inspector#analyzing-query-plans",
+    "id": "133-debug\\inspector#analyzing-query-plans",
     "title": "Inspector",
     "searchTitle": "Analyzing Query Plans",
     "sectionTitle": "Analyzing Query Plans",
     "sectionId": "analyzing-query-plans",
-    "url": "/docs/debug/inspector",
+    "url": "/docs/debug\\inspector",
     "content": "A Zero query is composed of one or more single-table queries connected by joins (related, whereExists). Zero delegates the single-table queries to SQLite, which has a sophisticated query planner that chooses the best indexes to use. For the joins, Zero implements its own cost-based planner to choose the best join order and algorithm. To view the plans selected by SQLite, see the sqlitePlans field returned by analyze() or analyzeQuery(). This contains the output of SQLite's EXPLAIN QUERY PLAN command for each SQLite query used: To view the join plan selected by Zero, call analyze() or analyzeQuery() with the joinPlans option set to true and see the joinPlans field in the output:",
     "kind": "section"
   },
   {
-    "id": "134-debug/inspector#table-data",
+    "id": "134-debug\\inspector#table-data",
     "title": "Inspector",
     "searchTitle": "Table Data",
     "sectionTitle": "Table Data",
     "sectionId": "table-data",
-    "url": "/docs/debug/inspector",
+    "url": "/docs/debug\\inspector",
     "content": "In addition to information about queries, you can get direct access to the contents of the client side database. const client = __zero.inspector.client // All raw k/v data currently synced to client console.log('client map:') console.log(await client.map()) // kv table extracted into tables // This is same info that is in z.query[tableName].run() for (const tableName of Object.keys(__zero.schema.tables)) { console.log(`table ${tableName}:`) console.table(await client.rows(tableName)) }",
     "kind": "section"
   },
   {
-    "id": "135-debug/inspector#server-version",
+    "id": "135-debug\\inspector#server-version",
     "title": "Inspector",
     "searchTitle": "Server Version",
     "sectionTitle": "Server Version",
     "sectionId": "server-version",
-    "url": "/docs/debug/inspector",
+    "url": "/docs/debug\\inspector",
     "content": "Ask the server to confirm what version it is: console.log( 'server version: ', await inspector.serverVersion() )",
     "kind": "section"
   },
   {
-    "id": "6-debug/otel",
+    "id": "6-debug\\otel",
     "title": "OpenTelemetry",
     "searchTitle": "OpenTelemetry",
-    "url": "/docs/debug/otel",
+    "url": "/docs/debug\\otel",
     "content": "The zero-cache service embeds the JavaScript OTLP Exporter and can send logs, traces, and metrics to any standard otel collector. To enable otel, set the following environment variables then run zero-cache as normal: OTEL_EXPORTER_OTLP_ENDPOINT=\"<your otel endpoint>\" OTEL_EXPORTER_OTLP_HEADERS=\"<auth headers from your otel collector>\" OTEL_RESOURCE_ATTRIBUTES=\"<resource attributes from your otel collector>\" OTEL_NODE_RESOURCE_DETECTORS=\"env,host,os\" Grafana Cloud Walkthrough Here are instructions to setup Grafana Cloud, but the setup for other otel collectors should be similar. Sign up for Grafana Cloud (Free Tier) Click Connections > Add Connection in the left sidebar add-connection Search for \"OpenTelemetry\" and select it Click \"Quickstart\" quickstart Select \"JavaScript\" javascript Create a new token Copy the environment variables into your .env file or similar copy-env Start zero-cache Look for logs under \"Drilldown\" > \"Logs\" in left sidebar Distributed Tracing You can enable end-to-end trace correlation from your frontend through zero-cache to your API server. This allows you to see the full request flow in your tracing UI. To enable this, provide a getTraceparent callback when creating your Zero client: import {ZeroProvider} from '@rocicorp/zero/react' import {propagation, context} from '@opentelemetry/api' function getTraceparent() { const carrier: Record<string, string> = {} propagation.inject(context.active(), carrier) return carrier.traceparent } return ( <ZeroProvider /* ... other options ... */ getTraceparent={getTraceparent} > <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' import {propagation, context} from '@opentelemetry/api' function getTraceparent() { const carrier: Record<string, string> = {} propagation.inject(context.active(), carrier) return carrier.traceparent } return ( <ZeroProvider /* ... other options ... */ getTraceparent={getTraceparent} > <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import {propagation, context} from '@opentelemetry/api' const zero = new Zero({ // ... other options getTraceparent: () => { const carrier: Record<string, string> = {} propagation.inject(context.active(), carrier) return carrier.traceparent } }) This callback is called before sending WebSocket messages that trigger API server calls (push, changeDesiredQueries, initConnection). The returned W3C traceparent header is forwarded through zero-cache to your API server, where it can be used to continue the trace. Metrics Reference zero.server zero.replica zero.replication zero.sync zero.mutation",
     "headings": [
       {
@@ -1054,99 +1054,99 @@
     "kind": "page"
   },
   {
-    "id": "136-debug/otel#grafana-cloud-walkthrough",
+    "id": "136-debug\\otel#grafana-cloud-walkthrough",
     "title": "OpenTelemetry",
     "searchTitle": "Grafana Cloud Walkthrough",
     "sectionTitle": "Grafana Cloud Walkthrough",
     "sectionId": "grafana-cloud-walkthrough",
-    "url": "/docs/debug/otel",
+    "url": "/docs/debug\\otel",
     "content": "Here are instructions to setup Grafana Cloud, but the setup for other otel collectors should be similar. Sign up for Grafana Cloud (Free Tier) Click Connections > Add Connection in the left sidebar add-connection Search for \"OpenTelemetry\" and select it Click \"Quickstart\" quickstart Select \"JavaScript\" javascript Create a new token Copy the environment variables into your .env file or similar copy-env Start zero-cache Look for logs under \"Drilldown\" > \"Logs\" in left sidebar",
     "kind": "section"
   },
   {
-    "id": "137-debug/otel#distributed-tracing",
+    "id": "137-debug\\otel#distributed-tracing",
     "title": "OpenTelemetry",
     "searchTitle": "Distributed Tracing",
     "sectionTitle": "Distributed Tracing",
     "sectionId": "distributed-tracing",
-    "url": "/docs/debug/otel",
+    "url": "/docs/debug\\otel",
     "content": "You can enable end-to-end trace correlation from your frontend through zero-cache to your API server. This allows you to see the full request flow in your tracing UI. To enable this, provide a getTraceparent callback when creating your Zero client: import {ZeroProvider} from '@rocicorp/zero/react' import {propagation, context} from '@opentelemetry/api' function getTraceparent() { const carrier: Record<string, string> = {} propagation.inject(context.active(), carrier) return carrier.traceparent } return ( <ZeroProvider /* ... other options ... */ getTraceparent={getTraceparent} > <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' import {propagation, context} from '@opentelemetry/api' function getTraceparent() { const carrier: Record<string, string> = {} propagation.inject(context.active(), carrier) return carrier.traceparent } return ( <ZeroProvider /* ... other options ... */ getTraceparent={getTraceparent} > <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import {propagation, context} from '@opentelemetry/api' const zero = new Zero({ // ... other options getTraceparent: () => { const carrier: Record<string, string> = {} propagation.inject(context.active(), carrier) return carrier.traceparent } }) This callback is called before sending WebSocket messages that trigger API server calls (push, changeDesiredQueries, initConnection). The returned W3C traceparent header is forwarded through zero-cache to your API server, where it can be used to continue the trace.",
     "kind": "section"
   },
   {
-    "id": "138-debug/otel#metrics-reference",
+    "id": "138-debug\\otel#metrics-reference",
     "title": "OpenTelemetry",
     "searchTitle": "Metrics Reference",
     "sectionTitle": "Metrics Reference",
     "sectionId": "metrics-reference",
-    "url": "/docs/debug/otel",
+    "url": "/docs/debug\\otel",
     "content": "zero.server zero.replica zero.replication zero.sync zero.mutation",
     "kind": "section"
   },
   {
-    "id": "139-debug/otel#zeroserver",
+    "id": "139-debug\\otel#zeroserver",
     "title": "OpenTelemetry",
     "searchTitle": "zero.server",
     "sectionTitle": "zero.server",
     "sectionId": "zeroserver",
-    "url": "/docs/debug/otel",
+    "url": "/docs/debug\\otel",
     "content": "",
     "kind": "section"
   },
   {
-    "id": "140-debug/otel#zeroreplica",
+    "id": "140-debug\\otel#zeroreplica",
     "title": "OpenTelemetry",
     "searchTitle": "zero.replica",
     "sectionTitle": "zero.replica",
     "sectionId": "zeroreplica",
-    "url": "/docs/debug/otel",
+    "url": "/docs/debug\\otel",
     "content": "",
     "kind": "section"
   },
   {
-    "id": "141-debug/otel#zeroreplication",
+    "id": "141-debug\\otel#zeroreplication",
     "title": "OpenTelemetry",
     "searchTitle": "zero.replication",
     "sectionTitle": "zero.replication",
     "sectionId": "zeroreplication",
-    "url": "/docs/debug/otel",
+    "url": "/docs/debug\\otel",
     "content": "",
     "kind": "section"
   },
   {
-    "id": "142-debug/otel#zerosync",
+    "id": "142-debug\\otel#zerosync",
     "title": "OpenTelemetry",
     "searchTitle": "zero.sync",
     "sectionTitle": "zero.sync",
     "sectionId": "zerosync",
-    "url": "/docs/debug/otel",
+    "url": "/docs/debug\\otel",
     "content": "",
     "kind": "section"
   },
   {
-    "id": "143-debug/otel#zeromutation",
+    "id": "143-debug\\otel#zeromutation",
     "title": "OpenTelemetry",
     "searchTitle": "zero.mutation",
     "sectionTitle": "zero.mutation",
     "sectionId": "zeromutation",
-    "url": "/docs/debug/otel",
+    "url": "/docs/debug\\otel",
     "content": "",
     "kind": "section"
   },
   {
-    "id": "7-debug/query-asts",
+    "id": "7-debug\\query-asts",
     "title": "Query ASTs",
     "searchTitle": "Query ASTs",
-    "url": "/docs/debug/query-asts",
+    "url": "/docs/debug\\query-asts",
     "content": "An AST (Abstract Syntax Tree) is a representation of a query that is used internally by Zero. It is not meant to be human readable, but it sometimes shows up in logs and other places. If you need to read one of these, save the AST to a json file. Then run the following command: cat ast.json | npx ast-to-zql The returned ZQL query will be using server names, rather than client names, to identify columns and tables. If you provide the schema file as an option you will get mapped back to client names: cat ast.json | npx ast-to-zql --schema schema.ts This comes into play if, in your schema.ts, you use the from feature to have different names on the client than your backend DB. The ast-to-zql process is a de-compilation of sorts. Given that, the ZQL string you get back will not be identical to the one you wrote in your application. Regardless, the queries will be semantically equivalent.",
     "headings": [],
     "kind": "page"
   },
   {
-    "id": "8-debug/replication",
+    "id": "8-debug\\replication",
     "title": "Replication",
     "searchTitle": "Replication",
-    "url": "/docs/debug/replication",
+    "url": "/docs/debug\\replication",
     "content": "Resetting During development we all do strange things (unsafely changing schemas, removing files, etc.). If the replica ever gets wedged (stops replicating, acts strange) you can wipe it and start over. If you copied your setup from hello-zero or hello-zero-solid, you can also run npm run dev:clean Otherwise you can run rm /tmp/my-zero-replica.db* (see your .env file for the replica file location) to clear the contents of the replica. It is always safe to wipe the replica. Wiping will have no impact on your upstream database. Downstream zero-clients will get re-synced when they connect. Inspecting For data to be synced to the client it must first be replicated to zero-cache. You can check the contents of zero-cache via: $ npx @rocicorp/zero-sqlite3 /tmp/my-zero-replica.db Zero uses a different version of SQLite that runs in WAL2 mode, which means the database files cannot be opened with standard SQLite tools. To inspect your Zero database, you have two options: Use our pre-compiled SQLite build @rocicorp/zero-sqlite3 as described above Build SQLite from the SQLite bedrock branch yourself This will drop you into a sqlite3 shell with which you can use to explore the contents of the replica. sqlite> .tables _zero.changeLog emoji viewState _zero.replicationConfig issue zero.permissions _zero.replicationState issueLabel zero.schemaVersions _zero.runtimeEvents label zero_0.clients _zero.versionHistory user comment userPref sqlite> .mode qbox sqlite> SELECT * FROM label; ┌─────────────────────────┬──────────────────────────┬────────────┐ │ id │ name │ _0_version │ ├─────────────────────────┼──────────────────────────┼────────────┤ │ 'ic_g-DZTYDApZR_v7Cdcy' │ 'bug' │ '4ehreg' │ ... Miscellaneous If you see FATAL: sorry, too many clients already in logs, it’s because you have two zero-cache instances running against dev. One is probably in a background tab somewhere. In production, zero-cache can run horizontally scaled but on dev it doesn’t run in the config that allows that.",
     "headings": [
       {
@@ -1165,40 +1165,40 @@
     "kind": "page"
   },
   {
-    "id": "144-debug/replication#resetting",
+    "id": "144-debug\\replication#resetting",
     "title": "Replication",
     "searchTitle": "Resetting",
     "sectionTitle": "Resetting",
     "sectionId": "resetting",
-    "url": "/docs/debug/replication",
+    "url": "/docs/debug\\replication",
     "content": "During development we all do strange things (unsafely changing schemas, removing files, etc.). If the replica ever gets wedged (stops replicating, acts strange) you can wipe it and start over. If you copied your setup from hello-zero or hello-zero-solid, you can also run npm run dev:clean Otherwise you can run rm /tmp/my-zero-replica.db* (see your .env file for the replica file location) to clear the contents of the replica. It is always safe to wipe the replica. Wiping will have no impact on your upstream database. Downstream zero-clients will get re-synced when they connect.",
     "kind": "section"
   },
   {
-    "id": "145-debug/replication#inspecting",
+    "id": "145-debug\\replication#inspecting",
     "title": "Replication",
     "searchTitle": "Inspecting",
     "sectionTitle": "Inspecting",
     "sectionId": "inspecting",
-    "url": "/docs/debug/replication",
+    "url": "/docs/debug\\replication",
     "content": "For data to be synced to the client it must first be replicated to zero-cache. You can check the contents of zero-cache via: $ npx @rocicorp/zero-sqlite3 /tmp/my-zero-replica.db Zero uses a different version of SQLite that runs in WAL2 mode, which means the database files cannot be opened with standard SQLite tools. To inspect your Zero database, you have two options: Use our pre-compiled SQLite build @rocicorp/zero-sqlite3 as described above Build SQLite from the SQLite bedrock branch yourself This will drop you into a sqlite3 shell with which you can use to explore the contents of the replica. sqlite> .tables _zero.changeLog emoji viewState _zero.replicationConfig issue zero.permissions _zero.replicationState issueLabel zero.schemaVersions _zero.runtimeEvents label zero_0.clients _zero.versionHistory user comment userPref sqlite> .mode qbox sqlite> SELECT * FROM label; ┌─────────────────────────┬──────────────────────────┬────────────┐ │ id │ name │ _0_version │ ├─────────────────────────┼──────────────────────────┼────────────┤ │ 'ic_g-DZTYDApZR_v7Cdcy' │ 'bug' │ '4ehreg' │ ...",
     "kind": "section"
   },
   {
-    "id": "146-debug/replication#miscellaneous",
+    "id": "146-debug\\replication#miscellaneous",
     "title": "Replication",
     "searchTitle": "Miscellaneous",
     "sectionTitle": "Miscellaneous",
     "sectionId": "miscellaneous",
-    "url": "/docs/debug/replication",
+    "url": "/docs/debug\\replication",
     "content": "If you see FATAL: sorry, too many clients already in logs, it’s because you have two zero-cache instances running against dev. One is probably in a background tab somewhere. In production, zero-cache can run horizontally scaled but on dev it doesn’t run in the config that allows that.",
     "kind": "section"
   },
   {
-    "id": "9-debug/slow-queries",
+    "id": "9-debug\\slow-queries",
     "title": "Slow Queries",
     "searchTitle": "Slow Queries",
-    "url": "/docs/debug/slow-queries",
+    "url": "/docs/debug\\slow-queries",
     "content": "In the zero-cache logs, you may see statements indicating a query is slow: hash=3rhuw19xt9vry transformationHash=1nv7ot74gxfl7 Slow query materialization 325.46865100000286 Or, you may just notice queries taking longer than expected in the UI. Here are some tips to help debug such slow queries. Query Plan The @rocicorp/zero package ships with a CLI to help debug query plans. You can run it with: # see all parameters npx analyze-query --help # analyze a specific query npx analyze-query \\ --schema-path=\"./schema.ts\" \\ --replica-file=\"./zero.db\" \\ --query='albums.where(\"artistId\", \"artist_1\").orderBy(\"createdAt\", \"asc\").limit(10)' This command will output the query plan and time to execute each phase of that plan: $ npx analyze-query \\ --schema-path=\"./schema.ts\" \\ --replica-file=\"./zero.db\" \\ --query='albums.where(\"artistId\", \"artist_1\").orderBy(\"createdAt\", \"asc\").limit(10)' Loading schema from ./schema.ts === Query Stats: === total synced rows: 10 albums vended: { 'SELECT \"id\",\"title\",\"artist_id\",\"release_year\",\"cover_art_url\",\"created_at\",\"_0_version\" FROM \"albums\" WHERE \"artist_id\" = ? ORDER BY \"created_at\" asc, \"id\" asc': 10 } Rows Read (into JS): 10 time: 3.12ms ms === Rows Scanned (by SQLite): === albums: { 'SELECT \"id\",\"title\",\"artist_id\",\"release_year\",\"cover_art_url\",\"created_at\",\"_0_version\" FROM \"albums\" WHERE \"artist_id\" = ? ORDER BY \"created_at\" asc, \"id\" asc': 25 } total rows scanned: 25 === Query Plans: === query SELECT \"id\",\"title\",\"artist_id\",\"release_year\",\"cover_art_url\",\"created_at\",\"_0_version\" FROM \"albums\" WHERE \"artist_id\" = ? ORDER BY \"created_at\" asc, \"id\" asc SCAN albums USE TEMP B-TREE FOR ORDER BY Ideally, run this command on the server where your zero.db replica file is located, so it uses the same disk as zero-cache. Adjust the --schema-path to point to your schema file (you may need to copy this onto the server). The --query arg is the ZQL query you want to analyze. Running locally, the analyzer will use any local .env file to find your environment configuration (so you don't need to manually provide the replica file). Optimizing the Plan You should look for any TEMP B-TREE entries in the query plan. These indicate that the query is not properly indexed in SQLite, and that zero-cache had to create a temporary index to satisfy the query. You should add appropriate indexes upstream to fix this. ZQL adds all primary key columns to the orderBy clause for a predictable total order, but only appends those PK columns which are not already present in the order of the query. This means that upstream indexes must also include the PK columns. Feel free to share your query plans with us in Discord if you need help optimizing them. Check ttl If you are seeing unexpected UI flicker when moving between views, it is possible that the queries backing these views have a ttl of never. Set the ttl to something like 5m to keep data cached across navigations. You may alternately want to preload some data at app startup. Conversely, if you are setting ttl to long values, then you may have many backgrounded queries running that the app is not using. You can see which queries are running using the inspector. Ensure that only expected queries are running. Locality If you see log lines like: flushed cvr ... (124ms) this indicates that zero-cache is likely deployed too far away from your CVR database. If you did not configure a CVR database URL then this will be your product's Postgres DB. A slow CVR flush can slow down Zero, since it must complete the flush before sending query result(s) to clients. Try moving zero-cache to be deployed as close as possible to the CVR database. Check Storage zero-cache is effectively a database. It requires fast (low latency and high bandwidth) disk access to perform well. If you're running on network attached storage with high latency, or on AWS with low IOPS, then this is the most likely culprit. Some hosting providers scale IOPS with vCPU. Increasing the vCPU will increase storage throughput and likely resolve the issue. Fly.io provides physically attached SSDs, even for their smallest VMs. Deploying zero-cache there (or any other provider that offers physically attached SSDs) is another option. /statz zero-cache makes some internal health statistics available via the /statz endpoint of zero-cache. In order to access this, you must configure an admin password.",
     "headings": [
       {
@@ -1229,70 +1229,70 @@
     "kind": "page"
   },
   {
-    "id": "147-debug/slow-queries#query-plan",
+    "id": "147-debug\\slow-queries#query-plan",
     "title": "Slow Queries",
     "searchTitle": "Query Plan",
     "sectionTitle": "Query Plan",
     "sectionId": "query-plan",
-    "url": "/docs/debug/slow-queries",
+    "url": "/docs/debug\\slow-queries",
     "content": "The @rocicorp/zero package ships with a CLI to help debug query plans. You can run it with: # see all parameters npx analyze-query --help # analyze a specific query npx analyze-query \\ --schema-path=\"./schema.ts\" \\ --replica-file=\"./zero.db\" \\ --query='albums.where(\"artistId\", \"artist_1\").orderBy(\"createdAt\", \"asc\").limit(10)' This command will output the query plan and time to execute each phase of that plan: $ npx analyze-query \\ --schema-path=\"./schema.ts\" \\ --replica-file=\"./zero.db\" \\ --query='albums.where(\"artistId\", \"artist_1\").orderBy(\"createdAt\", \"asc\").limit(10)' Loading schema from ./schema.ts === Query Stats: === total synced rows: 10 albums vended: { 'SELECT \"id\",\"title\",\"artist_id\",\"release_year\",\"cover_art_url\",\"created_at\",\"_0_version\" FROM \"albums\" WHERE \"artist_id\" = ? ORDER BY \"created_at\" asc, \"id\" asc': 10 } Rows Read (into JS): 10 time: 3.12ms ms === Rows Scanned (by SQLite): === albums: { 'SELECT \"id\",\"title\",\"artist_id\",\"release_year\",\"cover_art_url\",\"created_at\",\"_0_version\" FROM \"albums\" WHERE \"artist_id\" = ? ORDER BY \"created_at\" asc, \"id\" asc': 25 } total rows scanned: 25 === Query Plans: === query SELECT \"id\",\"title\",\"artist_id\",\"release_year\",\"cover_art_url\",\"created_at\",\"_0_version\" FROM \"albums\" WHERE \"artist_id\" = ? ORDER BY \"created_at\" asc, \"id\" asc SCAN albums USE TEMP B-TREE FOR ORDER BY Ideally, run this command on the server where your zero.db replica file is located, so it uses the same disk as zero-cache. Adjust the --schema-path to point to your schema file (you may need to copy this onto the server). The --query arg is the ZQL query you want to analyze. Running locally, the analyzer will use any local .env file to find your environment configuration (so you don't need to manually provide the replica file). Optimizing the Plan You should look for any TEMP B-TREE entries in the query plan. These indicate that the query is not properly indexed in SQLite, and that zero-cache had to create a temporary index to satisfy the query. You should add appropriate indexes upstream to fix this. ZQL adds all primary key columns to the orderBy clause for a predictable total order, but only appends those PK columns which are not already present in the order of the query. This means that upstream indexes must also include the PK columns. Feel free to share your query plans with us in Discord if you need help optimizing them.",
     "kind": "section"
   },
   {
-    "id": "148-debug/slow-queries#optimizing-the-plan",
+    "id": "148-debug\\slow-queries#optimizing-the-plan",
     "title": "Slow Queries",
     "searchTitle": "Optimizing the Plan",
     "sectionTitle": "Optimizing the Plan",
     "sectionId": "optimizing-the-plan",
-    "url": "/docs/debug/slow-queries",
+    "url": "/docs/debug\\slow-queries",
     "content": "You should look for any TEMP B-TREE entries in the query plan. These indicate that the query is not properly indexed in SQLite, and that zero-cache had to create a temporary index to satisfy the query. You should add appropriate indexes upstream to fix this. ZQL adds all primary key columns to the orderBy clause for a predictable total order, but only appends those PK columns which are not already present in the order of the query. This means that upstream indexes must also include the PK columns. Feel free to share your query plans with us in Discord if you need help optimizing them.",
     "kind": "section"
   },
   {
-    "id": "149-debug/slow-queries#check-ttl",
+    "id": "149-debug\\slow-queries#check-ttl",
     "title": "Slow Queries",
     "searchTitle": "Check ttl",
     "sectionTitle": "Check ttl",
     "sectionId": "check-ttl",
-    "url": "/docs/debug/slow-queries",
+    "url": "/docs/debug\\slow-queries",
     "content": "If you are seeing unexpected UI flicker when moving between views, it is possible that the queries backing these views have a ttl of never. Set the ttl to something like 5m to keep data cached across navigations. You may alternately want to preload some data at app startup. Conversely, if you are setting ttl to long values, then you may have many backgrounded queries running that the app is not using. You can see which queries are running using the inspector. Ensure that only expected queries are running.",
     "kind": "section"
   },
   {
-    "id": "150-debug/slow-queries#locality",
+    "id": "150-debug\\slow-queries#locality",
     "title": "Slow Queries",
     "searchTitle": "Locality",
     "sectionTitle": "Locality",
     "sectionId": "locality",
-    "url": "/docs/debug/slow-queries",
+    "url": "/docs/debug\\slow-queries",
     "content": "If you see log lines like: flushed cvr ... (124ms) this indicates that zero-cache is likely deployed too far away from your CVR database. If you did not configure a CVR database URL then this will be your product's Postgres DB. A slow CVR flush can slow down Zero, since it must complete the flush before sending query result(s) to clients. Try moving zero-cache to be deployed as close as possible to the CVR database.",
     "kind": "section"
   },
   {
-    "id": "151-debug/slow-queries#check-storage",
+    "id": "151-debug\\slow-queries#check-storage",
     "title": "Slow Queries",
     "searchTitle": "Check Storage",
     "sectionTitle": "Check Storage",
     "sectionId": "check-storage",
-    "url": "/docs/debug/slow-queries",
+    "url": "/docs/debug\\slow-queries",
     "content": "zero-cache is effectively a database. It requires fast (low latency and high bandwidth) disk access to perform well. If you're running on network attached storage with high latency, or on AWS with low IOPS, then this is the most likely culprit. Some hosting providers scale IOPS with vCPU. Increasing the vCPU will increase storage throughput and likely resolve the issue. Fly.io provides physically attached SSDs, even for their smallest VMs. Deploying zero-cache there (or any other provider that offers physically attached SSDs) is another option.",
     "kind": "section"
   },
   {
-    "id": "152-debug/slow-queries#statz",
+    "id": "152-debug\\slow-queries#statz",
     "title": "Slow Queries",
     "searchTitle": "/statz",
     "sectionTitle": "/statz",
     "sectionId": "statz",
-    "url": "/docs/debug/slow-queries",
+    "url": "/docs/debug\\slow-queries",
     "content": "zero-cache makes some internal health statistics available via the /statz endpoint of zero-cache. In order to access this, you must configure an admin password.",
     "kind": "section"
   },
   {
-    "id": "10-debug/zero-out",
+    "id": "10-debug\\zero-out",
     "title": "zero-out",
     "searchTitle": "zero-out",
-    "url": "/docs/debug/zero-out",
+    "url": "/docs/debug\\zero-out",
     "content": "Run the zero-out tool to completely remove all traces of Zero from your Postgres database. This is useful for debugging issues with Zero and/or resetting to a clean state. npx zero-out zero-out reads the same config as zero-cache does, so you can just run it where you run zero-cache.",
     "headings": [],
     "kind": "page"
@@ -1476,10 +1476,10 @@
     "kind": "section"
   },
   {
-    "id": "12-deprecated/ad-hoc-queries",
+    "id": "12-deprecated\\ad-hoc-queries",
     "title": "Ad-Hoc Queries (Deprecated)",
     "searchTitle": "Ad-Hoc Queries (Deprecated)",
-    "url": "/docs/deprecated/ad-hoc-queries",
+    "url": "/docs/deprecated\\ad-hoc-queries",
     "content": "It will be removed in a future release of Zero. Please move to the new queries API. Overview Zero generates a query API for every table you sync. To enable, set the enableLegacyQueries option to true in your schema: const schema = createSchema({ // ... enableLegacyQueries: true }) Once enabled, queries are available at z.query.<tablename>. const zero = new Zero(...); const issues = await zero.query.issue.where('priority', 'high').run(); Each table is a ZQL builder object. See ZQL for details.",
     "headings": [
       {
@@ -1490,20 +1490,20 @@
     "kind": "page"
   },
   {
-    "id": "165-deprecated/ad-hoc-queries#overview",
+    "id": "165-deprecated\\ad-hoc-queries#overview",
     "title": "Ad-Hoc Queries (Deprecated)",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
     "sectionId": "overview",
-    "url": "/docs/deprecated/ad-hoc-queries",
+    "url": "/docs/deprecated\\ad-hoc-queries",
     "content": "Zero generates a query API for every table you sync. To enable, set the enableLegacyQueries option to true in your schema: const schema = createSchema({ // ... enableLegacyQueries: true }) Once enabled, queries are available at z.query.<tablename>. const zero = new Zero(...); const issues = await zero.query.issue.where('priority', 'high').run(); Each table is a ZQL builder object. See ZQL for details.",
     "kind": "section"
   },
   {
-    "id": "13-deprecated/crud-mutators",
+    "id": "13-deprecated\\crud-mutators",
     "title": "CRUD Mutators (Deprecated)",
     "searchTitle": "CRUD Mutators (Deprecated)",
-    "url": "/docs/deprecated/crud-mutators",
+    "url": "/docs/deprecated\\crud-mutators",
     "content": "It will be removed in a future release of Zero. Please move to the new mutator API. Overview Zero generates basic CRUD mutators for every table you sync. To enable, set the enableLegacyMutators option to true in your schema: const schema = createSchema({ // ... enableLegacyMutators: true }) Once enabled, mutators are available at z.mutate.<tablename>: const zero = new Zero(...); zero.mutate.user.insert({ id: nanoid(), username: 'abby', language: 'en-us', }); See Writing Data with Mutators for more information. z.mutate contains the same methods as tx.mutate but is available on the Zero instance instead of the Transaction instance.",
     "headings": [
       {
@@ -1514,20 +1514,20 @@
     "kind": "page"
   },
   {
-    "id": "166-deprecated/crud-mutators#overview",
+    "id": "166-deprecated\\crud-mutators#overview",
     "title": "CRUD Mutators (Deprecated)",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
     "sectionId": "overview",
-    "url": "/docs/deprecated/crud-mutators",
+    "url": "/docs/deprecated\\crud-mutators",
     "content": "Zero generates basic CRUD mutators for every table you sync. To enable, set the enableLegacyMutators option to true in your schema: const schema = createSchema({ // ... enableLegacyMutators: true }) Once enabled, mutators are available at z.mutate.<tablename>: const zero = new Zero(...); zero.mutate.user.insert({ id: nanoid(), username: 'abby', language: 'en-us', }); See Writing Data with Mutators for more information. z.mutate contains the same methods as tx.mutate but is available on the Zero instance instead of the Transaction instance.",
     "kind": "section"
   },
   {
-    "id": "14-deprecated/rls-permissions",
+    "id": "14-deprecated\\rls-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "RLS Permissions (Deprecated)",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "It will be removed in a future release of Zero. See Permissions for more information. Permissions are expressed using ZQL and run automatically with every read and write. Permissions are currently row based. Zero will eventually also have column permissions. Define Permissions Permissions are defined in schema.ts using the definePermissions function. Here's an example of limiting reads to members of an organization and deletes to only the creator of an issue: // The decoded value of your JWT. type AuthData = { // The logged-in user. sub: string } export const permissions = definePermissions< AuthData, Schema >(schema, () => { // Checks if the user exists in a related organization const allowIfInOrganization = ( authData: AuthData, eb: ExpressionBuilder<Schema, 'issue'> ) => eb.exists('organization', q => q.whereExists('user', q => q.where('id', authData.sub) ) ) // Checks if the user is the creator const allowIfIssueCreator = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('creatorID', authData.sub) return { issue: { row: { select: [allowIfInOrganization], delete: [allowIfIssueCreator] } } } satisfies PermissionsConfig<AuthData, Schema> }) definePermission returns a policy object for each table in the schema. Each policy defines a ruleset for the operations that are possible on a table: select, insert, update, and delete. Access is Denied by Default If you don't specify any rules for an operation, it is denied by default. This is an important safety feature that helps ensure data isn't accidentally exposed. To enable full access to an action (i.e., during development) use the ANYONE_CAN helper: import {ANYONE_CAN} from '@rocicorp/zero' const permissions = definePermissions<AuthData, Schema>( schema, () => { return { issue: { row: { select: ANYONE_CAN // Other operations are denied by default. } } // Other tables are denied by default. } satisfies PermissionsConfig<AuthData, Schema> } ) To do this for all actions, use ANYONE_CAN_DO_ANYTHING: import {ANYONE_CAN_DO_ANYTHING} from '@rocicorp/zero' const permissions = definePermissions<AuthData, Schema>( schema, () => { return { // All operations on issue are allowed to all users. issue: ANYONE_CAN_DO_ANYTHING // Other tables are denied by default. } satisfies PermissionsConfig<AuthData, Schema> } ) Permission Evaluation Zero permissions are \"compiled\" into a JSON-based format at build-time. This file is stored in the {ZERO_APP_ID}.permissions table of your upstream database. Like other tables, it replicates live down to zero-cache. zero-cache then parses this file, and applies the encoded rules to every read and write operation. The compilation process is very simple-minded (read: dumb). Despite looking like normal TypeScript functions that receive an AuthData parameter, rule functions are not actually invoked at runtime. Instead, they are invoked with a \"placeholder\" AuthData at build time. We track which fields of this placeholder are accessed and construct a ZQL expression that accesses the right field of AuthData at runtime. The end result is that you can't really use most features of JS in these rules. Specifically you cannot: Iterate over properties or array elements in the auth token Use any JS features beyond property access of AuthData Use any conditional or global state Basically only property access is allowed. This is really confusing and we're working on a better solution. Permission Deployment During development, permissions are compiled and uploaded to your database completely automatically as part of the zero-cache-dev script. For production, you need to call npx zero-deploy-permissions within your app to update the permissions in the production database whenever they change. You would typically do this as part of your normal schema migration or CI process. For example, the SST deployment script for zbugs looks like this: new command.local.Command( 'zero-deploy-permissions', { create: `npx zero-deploy-permissions -p ../../src/schema.ts`, // Run the Command on every deploy ... triggers: [Date.now()], environment: { ZERO_UPSTREAM_DB: commonEnv.ZERO_UPSTREAM_DB, // If the application has a non-default App ID ... ZERO_APP_ID: commonEnv.ZERO_APP_ID } }, // after the view-syncer is deployed. {dependsOn: viewSyncer} ) See the SST Deployment Guide for more details. Rules Each operation on a policy has a ruleset containing zero or more rules. A rule is just a TypeScript function that receives the logged in user's AuthData and generates a ZQL where expression. At least one rule in a ruleset must return a row for the operation to be allowed. Select Permissions You can limit the data a user can read by specifying a select ruleset. Select permissions act like filters. If a user does not have permission to read a row, it will be filtered out of the result set. It will not generate an error. For example, imagine a select permission that restricts reads to only issues created by the user: definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueCreator = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('creatorID', authData.sub) return { issue: { row: { select: [allowIfIssueCreator] } } } satisfies PermissionsConfig<AuthData, Schema> }) If the issue table has two rows, one created by the user and one by someone else, the user will only see the row they created in any queries. Select permission applies to every column. The recommended approach for now is to factor out private fields into a separate table, e.g. user_private. Column permissions are planned but currently not a high priority. Note that although the same limitation applies to declarative insert/update permissions, custom mutators support arbitrary server-side logic and so can easily control which columns are writable. Insert Permissions You can limit what rows can be inserted and by whom by specifying an insert ruleset. Insert rules are evaluated after the entity is inserted. So if they query the database, they will see the inserted row present. If any rule in the insert ruleset returns a row, the insert is allowed. Here's an example of an insert rule that disallows inserting users that have the role 'admin'. definePermissions<AuthData, Schema>(schema, () => { const allowIfNonAdmin = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'user'> ) => cmp('role', '!=', 'admin') return { user: { row: { insert: [allowIfNonAdmin] } } } satisfies PermissionsConfig<AuthData, Schema> }) Update Permissions There are two types of update rulesets: preMutation and postMutation. Both rulesets must pass for an update to be allowed. preMutation rules see the version of a row before the mutation is applied. This is useful for things like checking whether a user owns an entity before editing it. postMutation rules see the version of a row after the mutation is applied. This is useful for things like ensuring a user can only mark themselves as the creator of an entity and not other users. Like other rulesets, preMutation and postMutation default to NOBODY_CAN. This means that every table must define both these rulesets in order for any updates to be allowed. For example, the following ruleset allows an issue's owner to edit, but not re-assign the issue. The postMutation rule enforces that the current user still own the issue after edit. definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: [allowIfIssueOwner], postMutation: [allowIfIssueOwner] } } } } satisfies PermissionsConfig<AuthData, Schema> }) This ruleset allows an issue's owner to edit and re-assign the issue: definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: [allowIfIssueOwner], postMutation: ANYONE_CAN } } } } satisfies PermissionsConfig<AuthData, Schema> }) And this allows anyone to edit an issue, but only if they also assign it to themselves. Useful for enforcing \"patches welcome\"? 🙃 definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: ANYONE_CAN, postMutation: [allowIfIssueOwner] } } } } satisfies PermissionsConfig<AuthData, Schema> }) Delete Permissions Delete permissions work in the same way as insert permissions except they run before the delete is applied. So if a delete rule queries the database, it will see that the deleted row is present. If any rule in the ruleset returns a row, the delete is allowed. Permissions Based on Auth Data You can use the cmpLit helper to define permissions based on a field of the authData parameter: definePermissions<AuthData, Schema>(schema, () => { const allowIfAdmin = ( authData: AuthData, {cmpLit}: ExpressionBuilder<Schema, 'issue'> ) => cmpLit(authData.role, 'admin') return { issue: { row: { select: [allowIfAdmin] } } } satisfies PermissionsConfig<AuthData, Schema> }) Debugging Given that permissions are defined in their own file and internally applied to queries, it can be hard to figure out if or why a permission check is failing. Read Permissions You can use the analyze-query utility with the --apply-permissions flag to see the complete query Zero runs, including read permissions. npx analyze-query --schema-path='./shared/schema.ts' --query='issue.related(\"comments\")' --apply-permissions --auth-data='{\"userId\":\"user-123\"}' If the result looks right, the problem may be that Zero is not receiving the AuthData that you think it is. You can retrieve a query hash from websocket or server logs, then ask Zero for the details on that specific query. Run this command with the same environment you run zero-cache with. It will use your upstream or cvr configuration to look up the query hash in the cvr database. npx analyze-query --schema-path='./shared/schema.ts' --hash='3rhuw19xt9vry' --apply-permissions --auth-data='{\"userId\":\"user-123\"}' The printed query can be different than the source ZQL string, because it is rebuilt from the query AST. But it should be logically equivalent to the query you wrote. Write Permissions Look for a WARN level log in the output from zero-cache like this: Permission check failed for {\"op\":\"update\",\"tableName\":\"message\",...}, action update, phase preMutation, authData: {...}, rowPolicies: [...], cellPolicies: [] Zero prints the row, auth data, and permission policies that was applied to any failed writes. The ZQL query is printed in AST format. See Query ASTs to convert it to a more readable format.",
     "headings": [
       {
@@ -1586,132 +1586,132 @@
     "kind": "page"
   },
   {
-    "id": "167-deprecated/rls-permissions#define-permissions",
+    "id": "167-deprecated\\rls-permissions#define-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Define Permissions",
     "sectionTitle": "Define Permissions",
     "sectionId": "define-permissions",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "Permissions are defined in schema.ts using the definePermissions function. Here's an example of limiting reads to members of an organization and deletes to only the creator of an issue: // The decoded value of your JWT. type AuthData = { // The logged-in user. sub: string } export const permissions = definePermissions< AuthData, Schema >(schema, () => { // Checks if the user exists in a related organization const allowIfInOrganization = ( authData: AuthData, eb: ExpressionBuilder<Schema, 'issue'> ) => eb.exists('organization', q => q.whereExists('user', q => q.where('id', authData.sub) ) ) // Checks if the user is the creator const allowIfIssueCreator = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('creatorID', authData.sub) return { issue: { row: { select: [allowIfInOrganization], delete: [allowIfIssueCreator] } } } satisfies PermissionsConfig<AuthData, Schema> }) definePermission returns a policy object for each table in the schema. Each policy defines a ruleset for the operations that are possible on a table: select, insert, update, and delete.",
     "kind": "section"
   },
   {
-    "id": "168-deprecated/rls-permissions#access-is-denied-by-default",
+    "id": "168-deprecated\\rls-permissions#access-is-denied-by-default",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Access is Denied by Default",
     "sectionTitle": "Access is Denied by Default",
     "sectionId": "access-is-denied-by-default",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "If you don't specify any rules for an operation, it is denied by default. This is an important safety feature that helps ensure data isn't accidentally exposed. To enable full access to an action (i.e., during development) use the ANYONE_CAN helper: import {ANYONE_CAN} from '@rocicorp/zero' const permissions = definePermissions<AuthData, Schema>( schema, () => { return { issue: { row: { select: ANYONE_CAN // Other operations are denied by default. } } // Other tables are denied by default. } satisfies PermissionsConfig<AuthData, Schema> } ) To do this for all actions, use ANYONE_CAN_DO_ANYTHING: import {ANYONE_CAN_DO_ANYTHING} from '@rocicorp/zero' const permissions = definePermissions<AuthData, Schema>( schema, () => { return { // All operations on issue are allowed to all users. issue: ANYONE_CAN_DO_ANYTHING // Other tables are denied by default. } satisfies PermissionsConfig<AuthData, Schema> } )",
     "kind": "section"
   },
   {
-    "id": "169-deprecated/rls-permissions#permission-evaluation",
+    "id": "169-deprecated\\rls-permissions#permission-evaluation",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Permission Evaluation",
     "sectionTitle": "Permission Evaluation",
     "sectionId": "permission-evaluation",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "Zero permissions are \"compiled\" into a JSON-based format at build-time. This file is stored in the {ZERO_APP_ID}.permissions table of your upstream database. Like other tables, it replicates live down to zero-cache. zero-cache then parses this file, and applies the encoded rules to every read and write operation. The compilation process is very simple-minded (read: dumb). Despite looking like normal TypeScript functions that receive an AuthData parameter, rule functions are not actually invoked at runtime. Instead, they are invoked with a \"placeholder\" AuthData at build time. We track which fields of this placeholder are accessed and construct a ZQL expression that accesses the right field of AuthData at runtime. The end result is that you can't really use most features of JS in these rules. Specifically you cannot: Iterate over properties or array elements in the auth token Use any JS features beyond property access of AuthData Use any conditional or global state Basically only property access is allowed. This is really confusing and we're working on a better solution.",
     "kind": "section"
   },
   {
-    "id": "170-deprecated/rls-permissions#permission-deployment",
+    "id": "170-deprecated\\rls-permissions#permission-deployment",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Permission Deployment",
     "sectionTitle": "Permission Deployment",
     "sectionId": "permission-deployment",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "During development, permissions are compiled and uploaded to your database completely automatically as part of the zero-cache-dev script. For production, you need to call npx zero-deploy-permissions within your app to update the permissions in the production database whenever they change. You would typically do this as part of your normal schema migration or CI process. For example, the SST deployment script for zbugs looks like this: new command.local.Command( 'zero-deploy-permissions', { create: `npx zero-deploy-permissions -p ../../src/schema.ts`, // Run the Command on every deploy ... triggers: [Date.now()], environment: { ZERO_UPSTREAM_DB: commonEnv.ZERO_UPSTREAM_DB, // If the application has a non-default App ID ... ZERO_APP_ID: commonEnv.ZERO_APP_ID } }, // after the view-syncer is deployed. {dependsOn: viewSyncer} ) See the SST Deployment Guide for more details.",
     "kind": "section"
   },
   {
-    "id": "171-deprecated/rls-permissions#rules",
+    "id": "171-deprecated\\rls-permissions#rules",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Rules",
     "sectionTitle": "Rules",
     "sectionId": "rules",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "Each operation on a policy has a ruleset containing zero or more rules. A rule is just a TypeScript function that receives the logged in user's AuthData and generates a ZQL where expression. At least one rule in a ruleset must return a row for the operation to be allowed.",
     "kind": "section"
   },
   {
-    "id": "172-deprecated/rls-permissions#select-permissions",
+    "id": "172-deprecated\\rls-permissions#select-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Select Permissions",
     "sectionTitle": "Select Permissions",
     "sectionId": "select-permissions",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "You can limit the data a user can read by specifying a select ruleset. Select permissions act like filters. If a user does not have permission to read a row, it will be filtered out of the result set. It will not generate an error. For example, imagine a select permission that restricts reads to only issues created by the user: definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueCreator = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('creatorID', authData.sub) return { issue: { row: { select: [allowIfIssueCreator] } } } satisfies PermissionsConfig<AuthData, Schema> }) If the issue table has two rows, one created by the user and one by someone else, the user will only see the row they created in any queries. Select permission applies to every column. The recommended approach for now is to factor out private fields into a separate table, e.g. user_private. Column permissions are planned but currently not a high priority. Note that although the same limitation applies to declarative insert/update permissions, custom mutators support arbitrary server-side logic and so can easily control which columns are writable.",
     "kind": "section"
   },
   {
-    "id": "173-deprecated/rls-permissions#insert-permissions",
+    "id": "173-deprecated\\rls-permissions#insert-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Insert Permissions",
     "sectionTitle": "Insert Permissions",
     "sectionId": "insert-permissions",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "You can limit what rows can be inserted and by whom by specifying an insert ruleset. Insert rules are evaluated after the entity is inserted. So if they query the database, they will see the inserted row present. If any rule in the insert ruleset returns a row, the insert is allowed. Here's an example of an insert rule that disallows inserting users that have the role 'admin'. definePermissions<AuthData, Schema>(schema, () => { const allowIfNonAdmin = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'user'> ) => cmp('role', '!=', 'admin') return { user: { row: { insert: [allowIfNonAdmin] } } } satisfies PermissionsConfig<AuthData, Schema> })",
     "kind": "section"
   },
   {
-    "id": "174-deprecated/rls-permissions#update-permissions",
+    "id": "174-deprecated\\rls-permissions#update-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Update Permissions",
     "sectionTitle": "Update Permissions",
     "sectionId": "update-permissions",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "There are two types of update rulesets: preMutation and postMutation. Both rulesets must pass for an update to be allowed. preMutation rules see the version of a row before the mutation is applied. This is useful for things like checking whether a user owns an entity before editing it. postMutation rules see the version of a row after the mutation is applied. This is useful for things like ensuring a user can only mark themselves as the creator of an entity and not other users. Like other rulesets, preMutation and postMutation default to NOBODY_CAN. This means that every table must define both these rulesets in order for any updates to be allowed. For example, the following ruleset allows an issue's owner to edit, but not re-assign the issue. The postMutation rule enforces that the current user still own the issue after edit. definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: [allowIfIssueOwner], postMutation: [allowIfIssueOwner] } } } } satisfies PermissionsConfig<AuthData, Schema> }) This ruleset allows an issue's owner to edit and re-assign the issue: definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: [allowIfIssueOwner], postMutation: ANYONE_CAN } } } } satisfies PermissionsConfig<AuthData, Schema> }) And this allows anyone to edit an issue, but only if they also assign it to themselves. Useful for enforcing \"patches welcome\"? 🙃 definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: ANYONE_CAN, postMutation: [allowIfIssueOwner] } } } } satisfies PermissionsConfig<AuthData, Schema> })",
     "kind": "section"
   },
   {
-    "id": "175-deprecated/rls-permissions#delete-permissions",
+    "id": "175-deprecated\\rls-permissions#delete-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Delete Permissions",
     "sectionTitle": "Delete Permissions",
     "sectionId": "delete-permissions",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "Delete permissions work in the same way as insert permissions except they run before the delete is applied. So if a delete rule queries the database, it will see that the deleted row is present. If any rule in the ruleset returns a row, the delete is allowed.",
     "kind": "section"
   },
   {
-    "id": "176-deprecated/rls-permissions#permissions-based-on-auth-data",
+    "id": "176-deprecated\\rls-permissions#permissions-based-on-auth-data",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Permissions Based on Auth Data",
     "sectionTitle": "Permissions Based on Auth Data",
     "sectionId": "permissions-based-on-auth-data",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "You can use the cmpLit helper to define permissions based on a field of the authData parameter: definePermissions<AuthData, Schema>(schema, () => { const allowIfAdmin = ( authData: AuthData, {cmpLit}: ExpressionBuilder<Schema, 'issue'> ) => cmpLit(authData.role, 'admin') return { issue: { row: { select: [allowIfAdmin] } } } satisfies PermissionsConfig<AuthData, Schema> })",
     "kind": "section"
   },
   {
-    "id": "177-deprecated/rls-permissions#debugging",
+    "id": "177-deprecated\\rls-permissions#debugging",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Debugging",
     "sectionTitle": "Debugging",
     "sectionId": "debugging",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "Given that permissions are defined in their own file and internally applied to queries, it can be hard to figure out if or why a permission check is failing. Read Permissions You can use the analyze-query utility with the --apply-permissions flag to see the complete query Zero runs, including read permissions. npx analyze-query --schema-path='./shared/schema.ts' --query='issue.related(\"comments\")' --apply-permissions --auth-data='{\"userId\":\"user-123\"}' If the result looks right, the problem may be that Zero is not receiving the AuthData that you think it is. You can retrieve a query hash from websocket or server logs, then ask Zero for the details on that specific query. Run this command with the same environment you run zero-cache with. It will use your upstream or cvr configuration to look up the query hash in the cvr database. npx analyze-query --schema-path='./shared/schema.ts' --hash='3rhuw19xt9vry' --apply-permissions --auth-data='{\"userId\":\"user-123\"}' The printed query can be different than the source ZQL string, because it is rebuilt from the query AST. But it should be logically equivalent to the query you wrote. Write Permissions Look for a WARN level log in the output from zero-cache like this: Permission check failed for {\"op\":\"update\",\"tableName\":\"message\",...}, action update, phase preMutation, authData: {...}, rowPolicies: [...], cellPolicies: [] Zero prints the row, auth data, and permission policies that was applied to any failed writes. The ZQL query is printed in AST format. See Query ASTs to convert it to a more readable format.",
     "kind": "section"
   },
   {
-    "id": "178-deprecated/rls-permissions#read-permissions",
+    "id": "178-deprecated\\rls-permissions#read-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Read Permissions",
     "sectionTitle": "Read Permissions",
     "sectionId": "read-permissions",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "You can use the analyze-query utility with the --apply-permissions flag to see the complete query Zero runs, including read permissions. npx analyze-query --schema-path='./shared/schema.ts' --query='issue.related(\"comments\")' --apply-permissions --auth-data='{\"userId\":\"user-123\"}' If the result looks right, the problem may be that Zero is not receiving the AuthData that you think it is. You can retrieve a query hash from websocket or server logs, then ask Zero for the details on that specific query. Run this command with the same environment you run zero-cache with. It will use your upstream or cvr configuration to look up the query hash in the cvr database. npx analyze-query --schema-path='./shared/schema.ts' --hash='3rhuw19xt9vry' --apply-permissions --auth-data='{\"userId\":\"user-123\"}' The printed query can be different than the source ZQL string, because it is rebuilt from the query AST. But it should be logically equivalent to the query you wrote.",
     "kind": "section"
   },
   {
-    "id": "179-deprecated/rls-permissions#write-permissions",
+    "id": "179-deprecated\\rls-permissions#write-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Write Permissions",
     "sectionTitle": "Write Permissions",
     "sectionId": "write-permissions",
-    "url": "/docs/deprecated/rls-permissions",
+    "url": "/docs/deprecated\\rls-permissions",
     "content": "Look for a WARN level log in the output from zero-cache like this: Permission check failed for {\"op\":\"update\",\"tableName\":\"message\",...}, action update, phase preMutation, authData: {...}, rowPolicies: [...], cellPolicies: [] Zero prints the row, auth data, and permission policies that was applied to any failed writes. The ZQL query is printed in AST format. See Query ASTs to convert it to a more readable format.",
     "kind": "section"
   },
@@ -1720,7 +1720,7 @@
     "title": "Install Zero",
     "searchTitle": "Install Zero",
     "url": "/docs/install",
-    "content": "This guide walks you through adding Zero to any TypeScript-based web app. It should take about 20 minutes to complete. When you're done, you'll have Zero up and running and will understand its core ideas. Integrate Zero Set Up Your Database You'll need a local Postgres database for development. If you don't have a preferred method, we recommend using Docker: docker run -d --name zero-postgres \\ -e POSTGRES_PASSWORD=\"password\" \\ -p 5432:5432 \\ postgres:16-alpine \\ # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica postgres -c wal_level=logical This will start a Postgres database running in the background. See Connecting to Postgres for more details on what Postgres features are required for Zero to work. Install and Run Zero-Cache Add Zero to your project: npm install @rocicorp/zeropnpm add @rocicorp/zero # Note: pnpm disables postinstall scripts by default for security. # Either approve the build: pnpm approve-builds # Or add to package.json: # \"pnpm\": { # \"onlyBuiltDependencies\": [\"@rocicorp/zero-sqlite3\"] # }bun add @rocicorp/zero # Note: Bun disables postinstall scripts by default for security. # Add to package.json: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero Start the development zero-cache by running the following command: export ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" yarn exec zero-cache-dev Zero works by continuously replicating your upstream database into a SQLite replica. Zero-cache runs client queries against the replica. If there are tables or columns that will not be queried by Zero clients ever, you can exclude them. You can use the zero-sqlite3 tool to explore zero.db. Try it out by connecting to Postgres and the Zero replica in two different terminals. If you change something in Postgres, you'll see it immediately show up in the replica: Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate schema.ts automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate// zero/schema.ts import {table, string, createSchema} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string() // ... other columns ... }) .primaryKey('id') // ... more tables and relationships ... // See \"Schema\" page in left nav for complete schema API. export const schema = createSchema({ tables: [user] }) // Register the schema for type safety declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Zero has some restrictions on the Postgres features it supports. You can continue this tutorial with a sample schema and seed data to evaluate it. Set Up the Zero Client Zero has first-class support for React and SolidJS, and community support for Svelte and Vue. There is also a low-level API you can use in any TypeScript-based project. // root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) } // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' function MyComponent() { const zero = useZero() console.log('clientID', zero.clientID) }// root.tsx import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) } // mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' function MyComponent() { const zero = useZero() console.log('clientID', zero().clientID) }// zero.ts import {Zero} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) console.log('clientID', zero.clientID) export {zero} Sync Data Define Query Alright, let's sync some data! In Zero, we do this with queries. Queries are conventionally found in a queries.ts file. Here is an example of how queries are defined - you can adapt this to your own schema: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema.ts' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistID: z.string()}), ({args: {artistID}}) => zql.albums .where('artistId', artistID) .orderBy('createdAt', 'asc') .limit(10) .related('artist', q => q.one()) ) } }) Use zql from schema.ts to construct and return a ZQL query. ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: See queries for more information on defining queries. Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: // mycomponent.tsx import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' function MyComponent() { const [albums] = useQuery( queries.albums.byArtist({artistID: 'artist_1'}) ) return albums.map(a => <div key={a.id}>{a.title}</div>) }// mycomponent.tsx import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' function MyComponent() { const [albums] = useQuery(() => queries.albums.byArtist({artistID: 'artist_1'}) ) return ( <For each={albums()}> {album => <div key={album.id}>{album.title}</div>} </For> ) }// albums.ts import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const albums = await zero.run( queries.albums.byArtist({artistID: 'artist_1'}) ) console.log('albums', albums) When you reload your app, you should see an error like: > npx zero-cache-dev ... no ZERO_QUERY_URL is configured for Zero Cache> pnpm exec zero-cache-dev ... no ZERO_QUERY_URL is configured for Zero Cache> bunx zero-cache-dev ... no ZERO_QUERY_URL is configured for Zero Cache> yarn exec zero-cache-dev ... no ZERO_QUERY_URL is configured for Zero Cache This is expected. We now need to implement a queries endpoint so that zero-cache can get the ZQL for the albums.byArtist query. Implement Query Backend Zero doesn't allow clients to run any arbitrary ZQL against zero-cache, for both security and performance reasons. Instead, Zero sends the name and arguments of the query to a queries endpoint on your server that is responsible for transforming the named query into ZQL. Zero provides utilities to make it easy to implement the queries endpoint in any full-stack framework: // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries.ts' import {schema} from '../zero/schema.ts' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Stop and re-run zero-cache with the URL of the queries endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" yarn exec zero-cache-dev If you reload the page, you will see data! Zero queries update live, so if you edit data in Postgres directly, you will see it update in the Zero replica AND the UI: More about Queries You now know the basics, but there are a few more important pieces you'll need to learn for your first real app: How authentication and permissions work. Preloading queries to create instantly responsive UI. For these details and more, see Reading Data. But for now, let's move on to writes! Mutate Data Define Mutators Data is written in Zero apps using mutators. Similar to queries, we use a shared mutators.ts file: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistID: z.string(), title: z.string(), year: z.number(), createdAt: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ id: args.id, artistId: args.artistID, title: args.title, releaseYear: args.year, createdAt: args.createdAt }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Mutators almost always run in the same frame on the client, against local data. The reason mutators are marked async is because on the server, reading from the tx object goes over the network to Postgres. Also, in edge cases on the client, reads and writes can go to local storage (IndexedDB or SQLite). Once you've defined your mutators, you must register them with Zero before you can use them: import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, etc. // add mutators mutators } Invoke Mutators You can now call mutators via zero.mutate: // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const result = zero.mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const result = zero().mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// albums.ts import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' const result = await zero.mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } Client-generated random IDs (from libraries like uuid, ulid, or nanoid) work much better than auto-incrementing integers in sync engines like Zero. Learn more. If you run this app now, you should be able to see the UI update optimistically, but you'll also see an error in zero-cache: > npx zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> pnpm exec zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> bunx zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> yarn exec zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations Similar to queries, we need to wire up a mutate endpoint in our API. Let's do that now. Implement Mutate Endpoint Zero requires a mutate endpoint which runs on your server and connects directly to your Postgres database. Zero provides helpers to implement this easily. Use the Zero Postgres adapters to create a dbProvider instance: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' // pass a prisma client instance. for example: const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then, use the dbProvider to handle the mutate request: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' import {mustGetMutator} from '@rocicorp/zero' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) These examples have only public queries and mutators, so they does not pass a context or user ID. In authenticated apps, validate auth in the request, derive userID from the session, and pass the context to the mutate and query handlers. See Authentication. Restart zero-cache to tell it about this new endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" yarn exec zero-cache-dev If you refresh the page, your mutation should commit to the database and sync to other clients: More about Mutators Just as with queries, the separate server implementation of mutators extends elegantly to enable write permissions. Zero also has built-in helpers to do work after a mutator runs on the server, like send notifications. For these details and more, see Writing Data. That's It! Congratulations! You now know the basics for building with Zero 🤯. Possible next steps: Learn about authentication and permissions See some samples of built-out Zero apps Learn how to deploy your app to production",
+    "content": "This guide walks you through adding Zero to any TypeScript-based web app. It should take about 20 minutes to complete. When you're done, you'll have Zero up and running and will understand its core ideas. Integrate Zero Set Up Your Database You'll need a local Postgres database for development. If you don't have a preferred method, we recommend using Docker: docker run -d --name zero-postgres \\ -e POSTGRES_PASSWORD=\"password\" \\ -p 5432:5432 \\ postgres:16-alpine \\ # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica postgres -c wal_level=logical This will start a Postgres database running in the background. See Connecting to Postgres for more details on what Postgres features are required for Zero to work. Install and Run Zero-Cache Add Zero to your project: npm install @rocicorp/zeropnpm add @rocicorp/zero # Note: pnpm disables postinstall scripts by default for security. # Either approve the build: pnpm approve-builds # Or add to package.json: # \"pnpm\": { # \"onlyBuiltDependencies\": [\"@rocicorp/zero-sqlite3\"] # }bun add @rocicorp/zero # Note: Bun disables postinstall scripts by default for security. # Add to package.json: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero Start the development zero-cache by running the following command: export ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" yarn exec zero-cache-dev Zero works by continuously replicating your upstream database into a SQLite replica. Zero-cache runs client queries against the replica. If there are tables or columns that will not be queried by Zero clients ever, you can exclude them. You can use the zero-sqlite3 tool to explore zero.db. Try it out by connecting to Postgres and the Zero replica in two different terminals. If you change something in Postgres, you'll see it immediately show up in the replica: Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate schema.ts automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate// zero/schema.ts import {table, string, createSchema} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string() // ... other columns ... }) .primaryKey('id') // ... more tables and relationships ... // See \"Schema\" page in left nav for complete schema API. export const schema = createSchema({ tables: [user] }) // Register the schema for type safety declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Zero has some restrictions on the Postgres features it supports. You can continue this tutorial with a sample schema and seed data to evaluate it. Set Up the Zero Client Zero has first-class support for React and SolidJS, and community support for Svelte and Vue. There is also a low-level API you can use in any TypeScript-based project. // root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) } // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' function MyComponent() { const zero = useZero() console.log('clientID', zero.clientID) }// root.tsx import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) } // mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' function MyComponent() { const zero = useZero() console.log('clientID', zero().clientID) }// zero.ts import {Zero} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) console.log('clientID', zero.clientID) export {zero} Sync Data Define Query Alright, let's sync some data! In Zero, we do this with queries. Queries are conventionally found in a queries.ts file. Here is an example of how queries are defined - you can adapt this to your own schema: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema.ts' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistID: z.string()}), ({args: {artistID}}) => zql.albums .where('artistId', artistID) .orderBy('createdAt', 'asc') .limit(10) .related('artist', q => q.one()) ) } }) Use zql from schema.ts to construct and return a ZQL query. ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: See queries for more information on defining queries. Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: // mycomponent.tsx import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' function MyComponent() { const [albums] = useQuery( queries.albums.byArtist({artistID: 'artist_1'}) ) return albums.map(a => <div key={a.id}>{a.title}</div>) }// mycomponent.tsx import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' function MyComponent() { const [albums] = useQuery(() => queries.albums.byArtist({artistID: 'artist_1'}) ) return ( <For each={albums()}> {album => <div key={album.id}>{album.title}</div>} </For> ) }// albums.ts import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const albums = await zero.run( queries.albums.byArtist({artistID: 'artist_1'}) ) console.log('albums', albums) When you reload your app, you should see an error like: > npx zero-cache-dev ... no ZERO_QUERY_URL is configured for Zero Cache> pnpm exec zero-cache-dev ... no ZERO_QUERY_URL is configured for Zero Cache> bunx zero-cache-dev ... no ZERO_QUERY_URL is configured for Zero Cache> yarn exec zero-cache-dev ... no ZERO_QUERY_URL is configured for Zero Cache This is expected. We now need to implement a queries endpoint so that zero-cache can get the ZQL for the albums.byArtist query. Implement Query Backend Zero doesn't allow clients to run any arbitrary ZQL against zero-cache, for both security and performance reasons. Instead, Zero sends the name and arguments of the query to a queries endpoint on your server that is responsible for transforming the named query into ZQL. Zero provides utilities to make it easy to implement the queries endpoint in any full-stack framework: // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries.ts' import {schema} from '../zero/schema.ts' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Stop and re-run zero-cache with the URL of the queries endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" yarn exec zero-cache-dev If you reload the page, you will see data! Zero queries update live, so if you edit data in Postgres directly, you will see it update in the Zero replica AND the UI: More about Queries You now know the basics, but there are a few more important pieces you'll need to learn for your first real app: How authentication and permissions work. Preloading queries to create instantly responsive UI. For these details and more, see Reading Data. But for now, let's move on to writes! Mutate Data Define Mutators Data is written in Zero apps using mutators. Similar to queries, we use a shared mutators.ts file: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistID: z.string(), title: z.string(), year: z.number(), createdAt: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ id: args.id, artistId: args.artistID, title: args.title, releaseYear: args.year, createdAt: args.createdAt }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Mutators almost always run in the same frame on the client, against local data. The reason mutators are marked async is because on the server, reading from the tx object goes over the network to Postgres. Also, in edge cases on the client, reads and writes can go to local storage (IndexedDB or SQLite). Once you've defined your mutators, you must register them with Zero before you can use them: import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, etc. // add mutators mutators } Invoke Mutators You can now call mutators via zero.mutate: // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const result = zero.mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const result = zero().mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// albums.ts import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' const result = await zero.mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } Client-generated random IDs (from libraries like uuid, ulid, or nanoid) work much better than auto-incrementing integers in sync engines like Zero. Learn more. If you run this app now, you should be able to see the UI update optimistically, but you'll also see an error in zero-cache: > npx zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> pnpm exec zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> bunx zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> yarn exec zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations Similar to queries, we need to wire up a mutate endpoint in our API. Let's do that now. Implement Mutate Endpoint Zero requires a mutate endpoint which runs on your server and connects directly to your Postgres database. Zero provides helpers to implement this easily. Use the Zero Postgres adapters to create a dbProvider instance: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' // pass a prisma client instance. for example: const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then, use the dbProvider to handle the mutate request: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' import {mustGetMutator} from '@rocicorp/zero' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Restart zero-cache to tell it about this new endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" yarn exec zero-cache-dev If you refresh the page, your mutation should commit to the database and sync to other clients: More about Mutators Just as with queries, the separate server implementation of mutators extends elegantly to enable write permissions. Zero also has built-in helpers to do work after a mutator runs on the server, like send notifications. For these details and more, see Writing Data. That's It! Congratulations! You now know the basics for building with Zero 🤯. Possible next steps: Learn about authentication and permissions See some samples of built-out Zero apps Learn how to deploy your app to production",
     "headings": [
       {
         "text": "Integrate Zero",
@@ -1896,7 +1896,7 @@
     "sectionTitle": "Mutate Data",
     "sectionId": "mutate-data",
     "url": "/docs/install",
-    "content": "Define Mutators Data is written in Zero apps using mutators. Similar to queries, we use a shared mutators.ts file: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistID: z.string(), title: z.string(), year: z.number(), createdAt: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ id: args.id, artistId: args.artistID, title: args.title, releaseYear: args.year, createdAt: args.createdAt }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Mutators almost always run in the same frame on the client, against local data. The reason mutators are marked async is because on the server, reading from the tx object goes over the network to Postgres. Also, in edge cases on the client, reads and writes can go to local storage (IndexedDB or SQLite). Once you've defined your mutators, you must register them with Zero before you can use them: import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, etc. // add mutators mutators } Invoke Mutators You can now call mutators via zero.mutate: // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const result = zero.mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const result = zero().mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// albums.ts import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' const result = await zero.mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } Client-generated random IDs (from libraries like uuid, ulid, or nanoid) work much better than auto-incrementing integers in sync engines like Zero. Learn more. If you run this app now, you should be able to see the UI update optimistically, but you'll also see an error in zero-cache: > npx zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> pnpm exec zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> bunx zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> yarn exec zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations Similar to queries, we need to wire up a mutate endpoint in our API. Let's do that now. Implement Mutate Endpoint Zero requires a mutate endpoint which runs on your server and connects directly to your Postgres database. Zero provides helpers to implement this easily. Use the Zero Postgres adapters to create a dbProvider instance: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' // pass a prisma client instance. for example: const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then, use the dbProvider to handle the mutate request: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' import {mustGetMutator} from '@rocicorp/zero' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) These examples have only public queries and mutators, so they does not pass a context or user ID. In authenticated apps, validate auth in the request, derive userID from the session, and pass the context to the mutate and query handlers. See Authentication. Restart zero-cache to tell it about this new endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" yarn exec zero-cache-dev If you refresh the page, your mutation should commit to the database and sync to other clients: More about Mutators Just as with queries, the separate server implementation of mutators extends elegantly to enable write permissions. Zero also has built-in helpers to do work after a mutator runs on the server, like send notifications. For these details and more, see Writing Data.",
+    "content": "Define Mutators Data is written in Zero apps using mutators. Similar to queries, we use a shared mutators.ts file: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistID: z.string(), title: z.string(), year: z.number(), createdAt: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ id: args.id, artistId: args.artistID, title: args.title, releaseYear: args.year, createdAt: args.createdAt }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Mutators almost always run in the same frame on the client, against local data. The reason mutators are marked async is because on the server, reading from the tx object goes over the network to Postgres. Also, in edge cases on the client, reads and writes can go to local storage (IndexedDB or SQLite). Once you've defined your mutators, you must register them with Zero before you can use them: import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, etc. // add mutators mutators } Invoke Mutators You can now call mutators via zero.mutate: // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const result = zero.mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const result = zero().mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// albums.ts import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' const result = await zero.mutate( mutators.albums.create({ id: nanoid(), artistID: 'artist_1', title: 'Please Please Me', year: 1963, createdAt: Date.now() }) ) const clientResult = await result.client if (clientResult.type === 'error') { console.error( 'Failed to create album', clientResult.error.message ) } else { console.log('Album created!') } Client-generated random IDs (from libraries like uuid, ulid, or nanoid) work much better than auto-incrementing integers in sync engines like Zero. Learn more. If you run this app now, you should be able to see the UI update optimistically, but you'll also see an error in zero-cache: > npx zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> pnpm exec zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> bunx zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations> yarn exec zero-cache-dev ... A ZERO_MUTATE_URL must be set in order to process mutations Similar to queries, we need to wire up a mutate endpoint in our API. Let's do that now. Implement Mutate Endpoint Zero requires a mutate endpoint which runs on your server and connects directly to your Postgres database. Zero provides helpers to implement this easily. Use the Zero Postgres adapters to create a dbProvider instance: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' // pass a prisma client instance. for example: const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then, use the dbProvider to handle the mutate request: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' import {mustGetMutator} from '@rocicorp/zero' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Restart zero-cache to tell it about this new endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" yarn exec zero-cache-dev If you refresh the page, your mutation should commit to the database and sync to other clients: More about Mutators Just as with queries, the separate server implementation of mutators extends elegantly to enable write permissions. Zero also has built-in helpers to do work after a mutator runs on the server, like send notifications. For these details and more, see Writing Data.",
     "kind": "section"
   },
   {
@@ -1926,7 +1926,7 @@
     "sectionTitle": "Implement Mutate Endpoint",
     "sectionId": "implement-mutate-endpoint",
     "url": "/docs/install",
-    "content": "Zero requires a mutate endpoint which runs on your server and connects directly to your Postgres database. Zero provides helpers to implement this easily. Use the Zero Postgres adapters to create a dbProvider instance: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' // pass a prisma client instance. for example: const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then, use the dbProvider to handle the mutate request: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' import {mustGetMutator} from '@rocicorp/zero' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) These examples have only public queries and mutators, so they does not pass a context or user ID. In authenticated apps, validate auth in the request, derive userID from the session, and pass the context to the mutate and query handlers. See Authentication. Restart zero-cache to tell it about this new endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" yarn exec zero-cache-dev If you refresh the page, your mutation should commit to the database and sync to other clients:",
+    "content": "Zero requires a mutate endpoint which runs on your server and connects directly to your Postgres database. Zero provides helpers to implement this easily. Use the Zero Postgres adapters to create a dbProvider instance: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' // pass a prisma client instance. for example: const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then, use the dbProvider to handle the mutate request: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' import {mustGetMutator} from '@rocicorp/zero' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Restart zero-cache to tell it about this new endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:password@localhost:5432/postgres\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" yarn exec zero-cache-dev If you refresh the page, your mutation should commit to the database and sync to other clients:",
     "kind": "section"
   },
   {
@@ -3187,10 +3187,10 @@
     "kind": "section"
   },
   {
-    "id": "25-release-notes/0.1",
+    "id": "25-release-notes\\0.1",
     "title": "Zero 0.1",
     "searchTitle": "Zero 0.1",
-    "url": "/docs/release-notes/0.1",
+    "url": "/docs/release-notes\\0.1",
     "content": "Breaking changes The name of some config keys in zero.config.json changed: upstreamUri → upstreamDBConnStr cvrDbUri → cvrDBConnStr changeDbUri → changeDBConnStr replicaDbFile → replicaDBFile Changed default port of zero-cache to 4848 . So your app startup should look like VITE_PUBLIC_SERVER=\"http://localhost:4848\". Features Print a warning to js console when Zero constructor server param is null or undefined zero-cache should now correctly bind to both ipv4 and ipv6 loopback addresses. This should fix the issue where using localhost to connect to zero-cache on some systems did not work. Check for presence of WebSocket early in startup of Zero. Print a clear error to catch people accidentally running Zero under SSR. Fix annoying error in js console in React strict mode from constructing and closing Replicache in quick succession. Source tree fixes These only apply if you were working in the Rocicorp monorepo. Fixed issue where zbugs didn’t rebuild when zero dependency changed - generally zbugs build normally again The zero binary has the right permissions bit so you don’t have to chmod u+x after build Remove overloaded name snapshot in use-query.tsx (thanks Scott 🙃)",
     "headings": [
       {
@@ -3209,40 +3209,40 @@
     "kind": "page"
   },
   {
-    "id": "278-release-notes/0.1#breaking-changes",
+    "id": "278-release-notes\\0.1#breaking-changes",
     "title": "Zero 0.1",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.1",
+    "url": "/docs/release-notes\\0.1",
     "content": "The name of some config keys in zero.config.json changed: upstreamUri → upstreamDBConnStr cvrDbUri → cvrDBConnStr changeDbUri → changeDBConnStr replicaDbFile → replicaDBFile Changed default port of zero-cache to 4848 . So your app startup should look like VITE_PUBLIC_SERVER=\"http://localhost:4848\".",
     "kind": "section"
   },
   {
-    "id": "279-release-notes/0.1#features",
+    "id": "279-release-notes\\0.1#features",
     "title": "Zero 0.1",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.1",
+    "url": "/docs/release-notes\\0.1",
     "content": "Print a warning to js console when Zero constructor server param is null or undefined zero-cache should now correctly bind to both ipv4 and ipv6 loopback addresses. This should fix the issue where using localhost to connect to zero-cache on some systems did not work. Check for presence of WebSocket early in startup of Zero. Print a clear error to catch people accidentally running Zero under SSR. Fix annoying error in js console in React strict mode from constructing and closing Replicache in quick succession.",
     "kind": "section"
   },
   {
-    "id": "280-release-notes/0.1#source-tree-fixes",
+    "id": "280-release-notes\\0.1#source-tree-fixes",
     "title": "Zero 0.1",
     "searchTitle": "Source tree fixes",
     "sectionTitle": "Source tree fixes",
     "sectionId": "source-tree-fixes",
-    "url": "/docs/release-notes/0.1",
+    "url": "/docs/release-notes\\0.1",
     "content": "These only apply if you were working in the Rocicorp monorepo. Fixed issue where zbugs didn’t rebuild when zero dependency changed - generally zbugs build normally again The zero binary has the right permissions bit so you don’t have to chmod u+x after build Remove overloaded name snapshot in use-query.tsx (thanks Scott 🙃)",
     "kind": "section"
   },
   {
-    "id": "26-release-notes/0.10",
+    "id": "26-release-notes\\0.10",
     "title": "Zero 0.10",
     "searchTitle": "Zero 0.10",
-    "url": "/docs/release-notes/0.10",
+    "url": "/docs/release-notes\\0.10",
     "content": "Install npm install @rocicorp/zero@0.10 Features None. Fixes Remove top-level await from zero-client. Various logging improvements. Don't throw error when WebSocket unavailable on server. Support building on Windows (running on Windows still doesn't work) Breaking Changes None.",
     "headings": [
       {
@@ -3265,50 +3265,50 @@
     "kind": "page"
   },
   {
-    "id": "281-release-notes/0.10#install",
+    "id": "281-release-notes\\0.10#install",
     "title": "Zero 0.10",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.10",
+    "url": "/docs/release-notes\\0.10",
     "content": "npm install @rocicorp/zero@0.10",
     "kind": "section"
   },
   {
-    "id": "282-release-notes/0.10#features",
+    "id": "282-release-notes\\0.10#features",
     "title": "Zero 0.10",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.10",
+    "url": "/docs/release-notes\\0.10",
     "content": "None.",
     "kind": "section"
   },
   {
-    "id": "283-release-notes/0.10#fixes",
+    "id": "283-release-notes\\0.10#fixes",
     "title": "Zero 0.10",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.10",
+    "url": "/docs/release-notes\\0.10",
     "content": "Remove top-level await from zero-client. Various logging improvements. Don't throw error when WebSocket unavailable on server. Support building on Windows (running on Windows still doesn't work)",
     "kind": "section"
   },
   {
-    "id": "284-release-notes/0.10#breaking-changes",
+    "id": "284-release-notes\\0.10#breaking-changes",
     "title": "Zero 0.10",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.10",
+    "url": "/docs/release-notes\\0.10",
     "content": "None.",
     "kind": "section"
   },
   {
-    "id": "27-release-notes/0.11",
+    "id": "27-release-notes\\0.11",
     "title": "Zero 0.11",
     "searchTitle": "Zero 0.11",
-    "url": "/docs/release-notes/0.11",
+    "url": "/docs/release-notes\\0.11",
     "content": "Install npm install @rocicorp/zero@0.11 Features Windows should work a lot better now. Thank you very much to aexylus and Sergio Leon for the testing and contributions here. Support nested property access in JWT auth tokens (docs). Make initial sync configurable (docs). Add query result type to SolidJS (docs) Docker image now contains native amd64 and arm64 binaries. Add storageKey constructor parameter to enable multiple Zero instances for same userID. Fixes Many, many fixes, including: Fix downstream replication of primitive values Fix replication of TRUNCATE messages Fix large storage use for idle pg instances Add runtime sanity checks for when a table is referenced but not synced Fix zero-cache-dev for multitenant Breaking Changes The addition of result types to SolidJS is a breaking API change on SolidJS only. See the changes to hello-zero-solid for upgrade example.",
     "headings": [
       {
@@ -3331,50 +3331,50 @@
     "kind": "page"
   },
   {
-    "id": "285-release-notes/0.11#install",
+    "id": "285-release-notes\\0.11#install",
     "title": "Zero 0.11",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.11",
+    "url": "/docs/release-notes\\0.11",
     "content": "npm install @rocicorp/zero@0.11",
     "kind": "section"
   },
   {
-    "id": "286-release-notes/0.11#features",
+    "id": "286-release-notes\\0.11#features",
     "title": "Zero 0.11",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.11",
+    "url": "/docs/release-notes\\0.11",
     "content": "Windows should work a lot better now. Thank you very much to aexylus and Sergio Leon for the testing and contributions here. Support nested property access in JWT auth tokens (docs). Make initial sync configurable (docs). Add query result type to SolidJS (docs) Docker image now contains native amd64 and arm64 binaries. Add storageKey constructor parameter to enable multiple Zero instances for same userID.",
     "kind": "section"
   },
   {
-    "id": "287-release-notes/0.11#fixes",
+    "id": "287-release-notes\\0.11#fixes",
     "title": "Zero 0.11",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.11",
+    "url": "/docs/release-notes\\0.11",
     "content": "Many, many fixes, including: Fix downstream replication of primitive values Fix replication of TRUNCATE messages Fix large storage use for idle pg instances Add runtime sanity checks for when a table is referenced but not synced Fix zero-cache-dev for multitenant",
     "kind": "section"
   },
   {
-    "id": "288-release-notes/0.11#breaking-changes",
+    "id": "288-release-notes\\0.11#breaking-changes",
     "title": "Zero 0.11",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.11",
+    "url": "/docs/release-notes\\0.11",
     "content": "The addition of result types to SolidJS is a breaking API change on SolidJS only. See the changes to hello-zero-solid for upgrade example.",
     "kind": "section"
   },
   {
-    "id": "28-release-notes/0.12",
+    "id": "28-release-notes\\0.12",
     "title": "Zero 0.12",
     "searchTitle": "Zero 0.12",
-    "url": "/docs/release-notes/0.12",
+    "url": "/docs/release-notes\\0.12",
     "content": "Install npm install @rocicorp/zero@0.12 Features Schemas now support circular relationships (docs). Added one() and many() schema helpers to default relationship type (docs). Support for syncing tables without a primary key as long as there is a unique index. This enables Prisma's implicit many-to-many relations (docs). Zero has been confirmed to work with Aurora and Google Cloud SQL (docs) Client bundle size reduced from 55kb to 47kb (-15%). Fixes Windows: zero-cache was spawning emptying terminals and leaving listeners connected on exit. Incorrect warning in zero-cache about enums not being supported. Failure to handle the primary key of Postgres tables changing. Incorrect results when whereExists() is before where() in query (bug). Error: The inferred type of '...' cannot be named without a reference to .... Error: insufficient upstream connections. Several causes of flicker in React. Incorrect values for ResultType when unloading and loading a query quickly (bug). Error: Postgres is missing the column '...' but that column was part of a row. Pointless initial empty render in React when data is already available in memory. Error: Expected string at ... Got array during auth. where() incorrectly allows comparing to null with the = operator (bug). SolidJS: Only call setState once per transaction. Breaking Changes The schema definition syntax has changed to support circular relationships. See the changes to hello-zero and hello-zero-solid for upgrade examples.",
     "headings": [
       {
@@ -3397,50 +3397,50 @@
     "kind": "page"
   },
   {
-    "id": "289-release-notes/0.12#install",
+    "id": "289-release-notes\\0.12#install",
     "title": "Zero 0.12",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.12",
+    "url": "/docs/release-notes\\0.12",
     "content": "npm install @rocicorp/zero@0.12",
     "kind": "section"
   },
   {
-    "id": "290-release-notes/0.12#features",
+    "id": "290-release-notes\\0.12#features",
     "title": "Zero 0.12",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.12",
+    "url": "/docs/release-notes\\0.12",
     "content": "Schemas now support circular relationships (docs). Added one() and many() schema helpers to default relationship type (docs). Support for syncing tables without a primary key as long as there is a unique index. This enables Prisma's implicit many-to-many relations (docs). Zero has been confirmed to work with Aurora and Google Cloud SQL (docs) Client bundle size reduced from 55kb to 47kb (-15%).",
     "kind": "section"
   },
   {
-    "id": "291-release-notes/0.12#fixes",
+    "id": "291-release-notes\\0.12#fixes",
     "title": "Zero 0.12",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.12",
+    "url": "/docs/release-notes\\0.12",
     "content": "Windows: zero-cache was spawning emptying terminals and leaving listeners connected on exit. Incorrect warning in zero-cache about enums not being supported. Failure to handle the primary key of Postgres tables changing. Incorrect results when whereExists() is before where() in query (bug). Error: The inferred type of '...' cannot be named without a reference to .... Error: insufficient upstream connections. Several causes of flicker in React. Incorrect values for ResultType when unloading and loading a query quickly (bug). Error: Postgres is missing the column '...' but that column was part of a row. Pointless initial empty render in React when data is already available in memory. Error: Expected string at ... Got array during auth. where() incorrectly allows comparing to null with the = operator (bug). SolidJS: Only call setState once per transaction.",
     "kind": "section"
   },
   {
-    "id": "292-release-notes/0.12#breaking-changes",
+    "id": "292-release-notes\\0.12#breaking-changes",
     "title": "Zero 0.12",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.12",
+    "url": "/docs/release-notes\\0.12",
     "content": "The schema definition syntax has changed to support circular relationships. See the changes to hello-zero and hello-zero-solid for upgrade examples.",
     "kind": "section"
   },
   {
-    "id": "29-release-notes/0.13",
+    "id": "29-release-notes\\0.13",
     "title": "Zero 0.13",
     "searchTitle": "Zero 0.13",
-    "url": "/docs/release-notes/0.13",
+    "url": "/docs/release-notes\\0.13",
     "content": "Install npm install @rocicorp/zero@0.13 Features Multinode deployment for horizontal scalability and zero-downtime deploys (docs). SST Deployment Guide (docs). Plain AWS Deployment Guide (docs). Various exports for external libraries Remove build hash from docker version for consistency with npm (discussion) Fixes Move heartbeat monitoring to separate path, not port Type instantiation is excessively deep and possibly infinite (bug). 20x improvement to whereExists performance (discussion) Breaking Changes Removing the hash from the version is a breaking change if you had scripts relying on that. Moving the heartbeat monitor to a path is a breaking change for deployments that were using that.",
     "headings": [
       {
@@ -3463,50 +3463,50 @@
     "kind": "page"
   },
   {
-    "id": "293-release-notes/0.13#install",
+    "id": "293-release-notes\\0.13#install",
     "title": "Zero 0.13",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.13",
+    "url": "/docs/release-notes\\0.13",
     "content": "npm install @rocicorp/zero@0.13",
     "kind": "section"
   },
   {
-    "id": "294-release-notes/0.13#features",
+    "id": "294-release-notes\\0.13#features",
     "title": "Zero 0.13",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.13",
+    "url": "/docs/release-notes\\0.13",
     "content": "Multinode deployment for horizontal scalability and zero-downtime deploys (docs). SST Deployment Guide (docs). Plain AWS Deployment Guide (docs). Various exports for external libraries Remove build hash from docker version for consistency with npm (discussion)",
     "kind": "section"
   },
   {
-    "id": "295-release-notes/0.13#fixes",
+    "id": "295-release-notes\\0.13#fixes",
     "title": "Zero 0.13",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.13",
+    "url": "/docs/release-notes\\0.13",
     "content": "Move heartbeat monitoring to separate path, not port Type instantiation is excessively deep and possibly infinite (bug). 20x improvement to whereExists performance (discussion)",
     "kind": "section"
   },
   {
-    "id": "296-release-notes/0.13#breaking-changes",
+    "id": "296-release-notes\\0.13#breaking-changes",
     "title": "Zero 0.13",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.13",
+    "url": "/docs/release-notes\\0.13",
     "content": "Removing the hash from the version is a breaking change if you had scripts relying on that. Moving the heartbeat monitor to a path is a breaking change for deployments that were using that.",
     "kind": "section"
   },
   {
-    "id": "30-release-notes/0.14",
+    "id": "30-release-notes\\0.14",
     "title": "Zero 0.14",
     "searchTitle": "Zero 0.14",
-    "url": "/docs/release-notes/0.14",
+    "url": "/docs/release-notes\\0.14",
     "content": "Install npm install @rocicorp/zero@0.14 Features Use from() to map column or tables to a different name (docs). Sync from muliple Postgres schemas (docs) Fixes useQuery not working when server unset (bug) Error: \"single output already exists\" in hello-zero-solid (bug) Row helper doesn't work with query having one() (bug) Partitioned Postgres tables not replicating Breaking Changes None.",
     "headings": [
       {
@@ -3529,50 +3529,50 @@
     "kind": "page"
   },
   {
-    "id": "297-release-notes/0.14#install",
+    "id": "297-release-notes\\0.14#install",
     "title": "Zero 0.14",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.14",
+    "url": "/docs/release-notes\\0.14",
     "content": "npm install @rocicorp/zero@0.14",
     "kind": "section"
   },
   {
-    "id": "298-release-notes/0.14#features",
+    "id": "298-release-notes\\0.14#features",
     "title": "Zero 0.14",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.14",
+    "url": "/docs/release-notes\\0.14",
     "content": "Use from() to map column or tables to a different name (docs). Sync from muliple Postgres schemas (docs)",
     "kind": "section"
   },
   {
-    "id": "299-release-notes/0.14#fixes",
+    "id": "299-release-notes\\0.14#fixes",
     "title": "Zero 0.14",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.14",
+    "url": "/docs/release-notes\\0.14",
     "content": "useQuery not working when server unset (bug) Error: \"single output already exists\" in hello-zero-solid (bug) Row helper doesn't work with query having one() (bug) Partitioned Postgres tables not replicating",
     "kind": "section"
   },
   {
-    "id": "300-release-notes/0.14#breaking-changes",
+    "id": "300-release-notes\\0.14#breaking-changes",
     "title": "Zero 0.14",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.14",
+    "url": "/docs/release-notes\\0.14",
     "content": "None.",
     "kind": "section"
   },
   {
-    "id": "31-release-notes/0.15",
+    "id": "31-release-notes\\0.15",
     "title": "Zero 0.15",
     "searchTitle": "Zero 0.15",
-    "url": "/docs/release-notes/0.15",
+    "url": "/docs/release-notes\\0.15",
     "content": "Install npm install @rocicorp/zero@0.15 Upgrade Guide This release changes the way that permissions are sent to the server. Before, permissions were sent to the server by setting the ZERO_SCHEMA_JSON or ZERO_SCHEMA_FILE environment variables, which include the permissions. In 0.15, these variables go away and are replaced by a new command: npx zero-deploy-permissions. This command writes the permissions to a new table in the upstream database. This design allows live permission updates, without restarting the server. It also solves problems with max env var size that users were seeing. This release also flips the default permission from allow to deny for all rules. To upgrade your app: See the changes to hello-zero or hello-zero-solid for how to update your permissions. Remove the ZERO_SCHEMA_JSON and ZERO_SCHEMA_FILE environment variables from your setup. They aren't used anymore. Use npx zero-deploy-permissions to deploy permissions when necessary. You can hook this up to your CI to automate it. See the zbugs implementation as an example. Features Live-updating permissions (docs). Permissions now default to deny rather than allow (docs). Fixes Multiple whereExists in same query not working (PR) Allow overlapped mutators (bug) \"Immutable type too deep\" error (PR) Log server version at startup (PR) Eliminate quadratic CVR writes (PR) Handle numeric in the replication stream (PR) Make the auto-reset required error more prominent (PR) Add \"type\":\"module\" recommendation when schema load fails (PR) Throw error if multiple auth options set (PR) Handle NULL characters in JSON columns (PR) Breaking Changes Making permissions deny by default breaks existing apps. To fix add ANYONE_CAN or other appropriate permissions for your tables. See docs. The ZERO_SCHEMA_JSON and ZERO_SCHEMA_FILE environment variables are no longer used. Remove them from your setup and use npx zero-deploy-permissions instead.",
     "headings": [
       {
@@ -3599,60 +3599,60 @@
     "kind": "page"
   },
   {
-    "id": "301-release-notes/0.15#install",
+    "id": "301-release-notes\\0.15#install",
     "title": "Zero 0.15",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.15",
+    "url": "/docs/release-notes\\0.15",
     "content": "npm install @rocicorp/zero@0.15",
     "kind": "section"
   },
   {
-    "id": "302-release-notes/0.15#upgrade-guide",
+    "id": "302-release-notes\\0.15#upgrade-guide",
     "title": "Zero 0.15",
     "searchTitle": "Upgrade Guide",
     "sectionTitle": "Upgrade Guide",
     "sectionId": "upgrade-guide",
-    "url": "/docs/release-notes/0.15",
+    "url": "/docs/release-notes\\0.15",
     "content": "This release changes the way that permissions are sent to the server. Before, permissions were sent to the server by setting the ZERO_SCHEMA_JSON or ZERO_SCHEMA_FILE environment variables, which include the permissions. In 0.15, these variables go away and are replaced by a new command: npx zero-deploy-permissions. This command writes the permissions to a new table in the upstream database. This design allows live permission updates, without restarting the server. It also solves problems with max env var size that users were seeing. This release also flips the default permission from allow to deny for all rules. To upgrade your app: See the changes to hello-zero or hello-zero-solid for how to update your permissions. Remove the ZERO_SCHEMA_JSON and ZERO_SCHEMA_FILE environment variables from your setup. They aren't used anymore. Use npx zero-deploy-permissions to deploy permissions when necessary. You can hook this up to your CI to automate it. See the zbugs implementation as an example.",
     "kind": "section"
   },
   {
-    "id": "303-release-notes/0.15#features",
+    "id": "303-release-notes\\0.15#features",
     "title": "Zero 0.15",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.15",
+    "url": "/docs/release-notes\\0.15",
     "content": "Live-updating permissions (docs). Permissions now default to deny rather than allow (docs).",
     "kind": "section"
   },
   {
-    "id": "304-release-notes/0.15#fixes",
+    "id": "304-release-notes\\0.15#fixes",
     "title": "Zero 0.15",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.15",
+    "url": "/docs/release-notes\\0.15",
     "content": "Multiple whereExists in same query not working (PR) Allow overlapped mutators (bug) \"Immutable type too deep\" error (PR) Log server version at startup (PR) Eliminate quadratic CVR writes (PR) Handle numeric in the replication stream (PR) Make the auto-reset required error more prominent (PR) Add \"type\":\"module\" recommendation when schema load fails (PR) Throw error if multiple auth options set (PR) Handle NULL characters in JSON columns (PR)",
     "kind": "section"
   },
   {
-    "id": "305-release-notes/0.15#breaking-changes",
+    "id": "305-release-notes\\0.15#breaking-changes",
     "title": "Zero 0.15",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.15",
+    "url": "/docs/release-notes\\0.15",
     "content": "Making permissions deny by default breaks existing apps. To fix add ANYONE_CAN or other appropriate permissions for your tables. See docs. The ZERO_SCHEMA_JSON and ZERO_SCHEMA_FILE environment variables are no longer used. Remove them from your setup and use npx zero-deploy-permissions instead.",
     "kind": "section"
   },
   {
-    "id": "32-release-notes/0.16",
+    "id": "32-release-notes\\0.16",
     "title": "Zero 0.16",
     "searchTitle": "Zero 0.16",
-    "url": "/docs/release-notes/0.16",
+    "url": "/docs/release-notes\\0.16",
     "content": "Install npm install @rocicorp/zero@0.16 Upgrading See the upgrade from hello-zero or hello-zero-solid for an example. Features Documented how to use lambdas to deploy permissions in SST, rather than needing CI/CD to have access to Postgres. (doc – search for \"permissionsDeployer\"). Added simple debugging logs for read and write permissions (doc). Fixes Improve performance of initial sync about 2x (PR 1, PR 2). IN should allow readonly array arguments (Report, PR). Export ANYONE_CAN_DO_ANYTHING (Report). Fix false-positive in schema change detection (Report, PR). Fix writes of numeric types (Report, PR) Fix bug where litestream was creating way too many files in s3 (PR) Fix memory leak in change-streamer noticeable under high write load (PR) Fix query already registered error (PR) Correctly handle optional booleans (PR) Ignore indexes with unpublished columns (PR) Breaking Changes None.",
     "headings": [
       {
@@ -3679,60 +3679,60 @@
     "kind": "page"
   },
   {
-    "id": "306-release-notes/0.16#install",
+    "id": "306-release-notes\\0.16#install",
     "title": "Zero 0.16",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.16",
+    "url": "/docs/release-notes\\0.16",
     "content": "npm install @rocicorp/zero@0.16",
     "kind": "section"
   },
   {
-    "id": "307-release-notes/0.16#upgrading",
+    "id": "307-release-notes\\0.16#upgrading",
     "title": "Zero 0.16",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
     "sectionId": "upgrading",
-    "url": "/docs/release-notes/0.16",
+    "url": "/docs/release-notes\\0.16",
     "content": "See the upgrade from hello-zero or hello-zero-solid for an example.",
     "kind": "section"
   },
   {
-    "id": "308-release-notes/0.16#features",
+    "id": "308-release-notes\\0.16#features",
     "title": "Zero 0.16",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.16",
+    "url": "/docs/release-notes\\0.16",
     "content": "Documented how to use lambdas to deploy permissions in SST, rather than needing CI/CD to have access to Postgres. (doc – search for \"permissionsDeployer\"). Added simple debugging logs for read and write permissions (doc).",
     "kind": "section"
   },
   {
-    "id": "309-release-notes/0.16#fixes",
+    "id": "309-release-notes\\0.16#fixes",
     "title": "Zero 0.16",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.16",
+    "url": "/docs/release-notes\\0.16",
     "content": "Improve performance of initial sync about 2x (PR 1, PR 2). IN should allow readonly array arguments (Report, PR). Export ANYONE_CAN_DO_ANYTHING (Report). Fix false-positive in schema change detection (Report, PR). Fix writes of numeric types (Report, PR) Fix bug where litestream was creating way too many files in s3 (PR) Fix memory leak in change-streamer noticeable under high write load (PR) Fix query already registered error (PR) Correctly handle optional booleans (PR) Ignore indexes with unpublished columns (PR)",
     "kind": "section"
   },
   {
-    "id": "310-release-notes/0.16#breaking-changes",
+    "id": "310-release-notes\\0.16#breaking-changes",
     "title": "Zero 0.16",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.16",
+    "url": "/docs/release-notes\\0.16",
     "content": "None.",
     "kind": "section"
   },
   {
-    "id": "33-release-notes/0.17",
+    "id": "33-release-notes\\0.17",
     "title": "Zero 0.17",
     "searchTitle": "Zero 0.17",
-    "url": "/docs/release-notes/0.17",
+    "url": "/docs/release-notes\\0.17",
     "content": "Install npm install @rocicorp/zero@0.17 Upgrading See the upgrade from hello-zero or hello-zero-solid for an example. Features Queries now take an optional ttl argument. This argument backgrounds queries for some time after the app stops using them. Background queries continue syncing so they are instantly ready if the UI re-requests them. The data from background queries is also available to be used by new queries where possible (doc). Structural schema versioning. This is TypeScript, why are we versioning with numbers like cave-people?? We got rid of schemaVersion concept entirely and now determine schema compatibility completely automatically, TS-stylie (doc). Permissions now scoped to \"apps\". You can now have different Zero \"apps\" talking to the same upstream database. Each app gets completely separate configuration and permissions. This should also enable previewing zero-cache (each preview would be its own app). Apps replace the existing \"shard\" concept (doc). Initial replication is over 5x faster, up to about 50MB/second or 15k row/second in our tests. Added warnings for slow hydration in both client and server (doc). auto-reset is now enabled by default for databases that don't support event triggers (doc). Default cvr and change databases to upstream, so that you don't have to specify them in the common case where they are the same as upstream. This docs site now has search! Fixes Certain kinds of many:many joins were causing node already exists assertions Certain kinds of or queries were causing consistency issues Support replica identity full for PostgreSQL tables We now print a stack trace during close at debug level to enable debugging errors where Zero is accessed after close. We now print a warning when IndexedDB is missing rather than throwing. This makes it a little easier to use Zero in SSR setups. We now reset zero-cache implicitly in a few edge cases rather than halting replication. Fixed a deadlock in change-streamer. Breaking Changes query.run() now returns its result via promise. This is required for compatibility with upcoming custom mutators, but also will allow us to wait for server results in the future (though that (still 😢) doesn't exist yet).",
     "headings": [
       {
@@ -3759,60 +3759,60 @@
     "kind": "page"
   },
   {
-    "id": "311-release-notes/0.17#install",
+    "id": "311-release-notes\\0.17#install",
     "title": "Zero 0.17",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.17",
+    "url": "/docs/release-notes\\0.17",
     "content": "npm install @rocicorp/zero@0.17",
     "kind": "section"
   },
   {
-    "id": "312-release-notes/0.17#upgrading",
+    "id": "312-release-notes\\0.17#upgrading",
     "title": "Zero 0.17",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
     "sectionId": "upgrading",
-    "url": "/docs/release-notes/0.17",
+    "url": "/docs/release-notes\\0.17",
     "content": "See the upgrade from hello-zero or hello-zero-solid for an example.",
     "kind": "section"
   },
   {
-    "id": "313-release-notes/0.17#features",
+    "id": "313-release-notes\\0.17#features",
     "title": "Zero 0.17",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.17",
+    "url": "/docs/release-notes\\0.17",
     "content": "Queries now take an optional ttl argument. This argument backgrounds queries for some time after the app stops using them. Background queries continue syncing so they are instantly ready if the UI re-requests them. The data from background queries is also available to be used by new queries where possible (doc). Structural schema versioning. This is TypeScript, why are we versioning with numbers like cave-people?? We got rid of schemaVersion concept entirely and now determine schema compatibility completely automatically, TS-stylie (doc). Permissions now scoped to \"apps\". You can now have different Zero \"apps\" talking to the same upstream database. Each app gets completely separate configuration and permissions. This should also enable previewing zero-cache (each preview would be its own app). Apps replace the existing \"shard\" concept (doc). Initial replication is over 5x faster, up to about 50MB/second or 15k row/second in our tests. Added warnings for slow hydration in both client and server (doc). auto-reset is now enabled by default for databases that don't support event triggers (doc). Default cvr and change databases to upstream, so that you don't have to specify them in the common case where they are the same as upstream. This docs site now has search!",
     "kind": "section"
   },
   {
-    "id": "314-release-notes/0.17#fixes",
+    "id": "314-release-notes\\0.17#fixes",
     "title": "Zero 0.17",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.17",
+    "url": "/docs/release-notes\\0.17",
     "content": "Certain kinds of many:many joins were causing node already exists assertions Certain kinds of or queries were causing consistency issues Support replica identity full for PostgreSQL tables We now print a stack trace during close at debug level to enable debugging errors where Zero is accessed after close. We now print a warning when IndexedDB is missing rather than throwing. This makes it a little easier to use Zero in SSR setups. We now reset zero-cache implicitly in a few edge cases rather than halting replication. Fixed a deadlock in change-streamer.",
     "kind": "section"
   },
   {
-    "id": "315-release-notes/0.17#breaking-changes",
+    "id": "315-release-notes\\0.17#breaking-changes",
     "title": "Zero 0.17",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.17",
+    "url": "/docs/release-notes\\0.17",
     "content": "query.run() now returns its result via promise. This is required for compatibility with upcoming custom mutators, but also will allow us to wait for server results in the future (though that (still 😢) doesn't exist yet).",
     "kind": "section"
   },
   {
-    "id": "34-release-notes/0.18",
+    "id": "34-release-notes\\0.18",
     "title": "Zero 0.18",
     "searchTitle": "Zero 0.18",
-    "url": "/docs/release-notes/0.18",
+    "url": "/docs/release-notes\\0.18",
     "content": "Install npm install @rocicorp/zero@0.18 Upgrading To try out custom mutators, see the changes to hello-zero-solid. Features Custom Mutators! Finally! Define arbitrary write operations in code (doc). Added inspector API for debugging sync, queries, and client storage (doc). Added analyze-query tool to debug query performance (doc). Added transform-query tool to debug permissions (doc). Added ast-to-zql script to prettify Zero's internal AST format (doc). Fixes Added backpressure to replication-manager to protect against Postgres moving faster than we can push to clients (PR). @rocicorp/zero/advanced has been deprecated. AdvancedQuery got folded into Query and ZeroAdvancedOptions got folded into ZeroOptions (PR). Support ALTER SCHEMA DDL changes (PR) Allow replication-manager to continue running while a new one re-replicates. (PR). Improve replication performance for some schema changes (PR). Make the log level of zero-deploy-permissions configurable (PR) Bind exists to the expression builder (PR) Fix single output already exists error (PR) Fix getBrowserGlobal('window')?.addEventListener not a function in Expo (thanks @andrewcoelho!) (PR). Fix Vue bindings ref counting bug. Bindings no longer need to pass RefCountMap (PR). Fix CVR ownership takeover race conditions (PR). Support REPLICA IDENTITY FULL in degraded-mode pg providers (PR). Handle corrupt sqlite db by re-replicating (PR). Don't send useless pokes to clients that are unchanged (PR). Add limit(1) to queries using a relation that is marked one() (PR). Export UseQueryOptions Breaking Changes None.",
     "headings": [
       {
@@ -3839,60 +3839,60 @@
     "kind": "page"
   },
   {
-    "id": "316-release-notes/0.18#install",
+    "id": "316-release-notes\\0.18#install",
     "title": "Zero 0.18",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.18",
+    "url": "/docs/release-notes\\0.18",
     "content": "npm install @rocicorp/zero@0.18",
     "kind": "section"
   },
   {
-    "id": "317-release-notes/0.18#upgrading",
+    "id": "317-release-notes\\0.18#upgrading",
     "title": "Zero 0.18",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
     "sectionId": "upgrading",
-    "url": "/docs/release-notes/0.18",
+    "url": "/docs/release-notes\\0.18",
     "content": "To try out custom mutators, see the changes to hello-zero-solid.",
     "kind": "section"
   },
   {
-    "id": "318-release-notes/0.18#features",
+    "id": "318-release-notes\\0.18#features",
     "title": "Zero 0.18",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.18",
+    "url": "/docs/release-notes\\0.18",
     "content": "Custom Mutators! Finally! Define arbitrary write operations in code (doc). Added inspector API for debugging sync, queries, and client storage (doc). Added analyze-query tool to debug query performance (doc). Added transform-query tool to debug permissions (doc). Added ast-to-zql script to prettify Zero's internal AST format (doc).",
     "kind": "section"
   },
   {
-    "id": "319-release-notes/0.18#fixes",
+    "id": "319-release-notes\\0.18#fixes",
     "title": "Zero 0.18",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.18",
+    "url": "/docs/release-notes\\0.18",
     "content": "Added backpressure to replication-manager to protect against Postgres moving faster than we can push to clients (PR). @rocicorp/zero/advanced has been deprecated. AdvancedQuery got folded into Query and ZeroAdvancedOptions got folded into ZeroOptions (PR). Support ALTER SCHEMA DDL changes (PR) Allow replication-manager to continue running while a new one re-replicates. (PR). Improve replication performance for some schema changes (PR). Make the log level of zero-deploy-permissions configurable (PR) Bind exists to the expression builder (PR) Fix single output already exists error (PR) Fix getBrowserGlobal('window')?.addEventListener not a function in Expo (thanks @andrewcoelho!) (PR). Fix Vue bindings ref counting bug. Bindings no longer need to pass RefCountMap (PR). Fix CVR ownership takeover race conditions (PR). Support REPLICA IDENTITY FULL in degraded-mode pg providers (PR). Handle corrupt sqlite db by re-replicating (PR). Don't send useless pokes to clients that are unchanged (PR). Add limit(1) to queries using a relation that is marked one() (PR). Export UseQueryOptions",
     "kind": "section"
   },
   {
-    "id": "320-release-notes/0.18#breaking-changes",
+    "id": "320-release-notes\\0.18#breaking-changes",
     "title": "Zero 0.18",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.18",
+    "url": "/docs/release-notes\\0.18",
     "content": "None.",
     "kind": "section"
   },
   {
-    "id": "35-release-notes/0.19",
+    "id": "35-release-notes\\0.19",
     "title": "Zero 0.19",
     "searchTitle": "Zero 0.19",
-    "url": "/docs/release-notes/0.19",
+    "url": "/docs/release-notes\\0.19",
     "content": "Install npm install @rocicorp/zero@0.19 Upgrading If you use custom mutators, please see hello-zero-solid for how to update your push endpoint. If you use SolidJS, please switch to createQuery. If you are awaiting z.mutate.foo.bar(), you should switch to await z.mutate.foo.bar().client to be consistent with .server. If you were using a 0.19 canary, the .server property returns error by rejection again (like 0.18 did). Sorry about the thrash here. Features Add a type param to query.run() so it can wait for server results (doc, bug) await z.mutate.foo.bar() is now await z.mutate.foo.bar().client for consistency with .server, old API still works but deprecated (doc) Improve speed of litestream restore by about 7x Increase replication speed when using JSON by about 25% Add options to analyze-query to apply permissions and auth data (doc). Add option to --lazy-startup to zero-cache to delay connecting to upstram until first connection (doc) Add /statz endpoint for getting some health statistics from a running Zero instance (doc) Fixes Support passing Request to PushProccesor.process() (PR) Fix layering in PushProcessor to better support custom db implementations (thanks Erik Munson!) (PR) Fix socket disconnects in GCP (PR) Quote Postgres enum types to preserve casing (report) z2s: Return undefined for empty result set when using query.one() z2s: Allow accessing tables in non-public schemas z2s: Allow tx.foo.update({bar: undefined}) where bar is optional to match client behavior Fix broken replication when updating a key that is part of a unique (but non-PK) index solid: Rename useQuery to createQuery to fit Solid naming conventions (old name deprecated) Resync when publications are missing (PR) Fix missing NOT LIKE in query.where() (PR) Fix timezone shift when writing to timestamp/timestamptz and server is non-UTC timezone (thanks Tom Jenkinson!) (PR) Bound time spent in incremental updates to 1/2 hydration time Fix ttl being off by 1000 in some cases 😬 (PR) z2s: Relationships nested in a junction relationship were not working correctly (PR) Custom mutators: Due to multitab, client can receive multiple responses for same mutation Fix deadlock that could happen when pushing on a closed websocket (PR) Fix incorrect shutdown under heavy CPU load (thanks Erik Munson!) (PR) Fix case where deletes were getting reverted (thanks for reproduction Marc MacLeod!) (PR) z2s: Incorrect handling of self-join, and not exists not(exists()) is not supported on the client re-auth on 401s returned by push endpoint Added push.queryParams constructor parameter to allow passing query params to the push endpoint (doc) Breaking Changes The structure of setting up a PushProcesor has changed slightly. See push endpoint setup or upgrade guide. Not technically a breaking change from 0.18, but if you were using 0.19 canaries, the .server property returns error by rejection again (like 0.18 did) (doc).",
     "headings": [
       {
@@ -3919,60 +3919,60 @@
     "kind": "page"
   },
   {
-    "id": "321-release-notes/0.19#install",
+    "id": "321-release-notes\\0.19#install",
     "title": "Zero 0.19",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.19",
+    "url": "/docs/release-notes\\0.19",
     "content": "npm install @rocicorp/zero@0.19",
     "kind": "section"
   },
   {
-    "id": "322-release-notes/0.19#upgrading",
+    "id": "322-release-notes\\0.19#upgrading",
     "title": "Zero 0.19",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
     "sectionId": "upgrading",
-    "url": "/docs/release-notes/0.19",
+    "url": "/docs/release-notes\\0.19",
     "content": "If you use custom mutators, please see hello-zero-solid for how to update your push endpoint. If you use SolidJS, please switch to createQuery. If you are awaiting z.mutate.foo.bar(), you should switch to await z.mutate.foo.bar().client to be consistent with .server. If you were using a 0.19 canary, the .server property returns error by rejection again (like 0.18 did). Sorry about the thrash here.",
     "kind": "section"
   },
   {
-    "id": "323-release-notes/0.19#features",
+    "id": "323-release-notes\\0.19#features",
     "title": "Zero 0.19",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.19",
+    "url": "/docs/release-notes\\0.19",
     "content": "Add a type param to query.run() so it can wait for server results (doc, bug) await z.mutate.foo.bar() is now await z.mutate.foo.bar().client for consistency with .server, old API still works but deprecated (doc) Improve speed of litestream restore by about 7x Increase replication speed when using JSON by about 25% Add options to analyze-query to apply permissions and auth data (doc). Add option to --lazy-startup to zero-cache to delay connecting to upstram until first connection (doc) Add /statz endpoint for getting some health statistics from a running Zero instance (doc)",
     "kind": "section"
   },
   {
-    "id": "324-release-notes/0.19#fixes",
+    "id": "324-release-notes\\0.19#fixes",
     "title": "Zero 0.19",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.19",
+    "url": "/docs/release-notes\\0.19",
     "content": "Support passing Request to PushProccesor.process() (PR) Fix layering in PushProcessor to better support custom db implementations (thanks Erik Munson!) (PR) Fix socket disconnects in GCP (PR) Quote Postgres enum types to preserve casing (report) z2s: Return undefined for empty result set when using query.one() z2s: Allow accessing tables in non-public schemas z2s: Allow tx.foo.update({bar: undefined}) where bar is optional to match client behavior Fix broken replication when updating a key that is part of a unique (but non-PK) index solid: Rename useQuery to createQuery to fit Solid naming conventions (old name deprecated) Resync when publications are missing (PR) Fix missing NOT LIKE in query.where() (PR) Fix timezone shift when writing to timestamp/timestamptz and server is non-UTC timezone (thanks Tom Jenkinson!) (PR) Bound time spent in incremental updates to 1/2 hydration time Fix ttl being off by 1000 in some cases 😬 (PR) z2s: Relationships nested in a junction relationship were not working correctly (PR) Custom mutators: Due to multitab, client can receive multiple responses for same mutation Fix deadlock that could happen when pushing on a closed websocket (PR) Fix incorrect shutdown under heavy CPU load (thanks Erik Munson!) (PR) Fix case where deletes were getting reverted (thanks for reproduction Marc MacLeod!) (PR) z2s: Incorrect handling of self-join, and not exists not(exists()) is not supported on the client re-auth on 401s returned by push endpoint Added push.queryParams constructor parameter to allow passing query params to the push endpoint (doc)",
     "kind": "section"
   },
   {
-    "id": "325-release-notes/0.19#breaking-changes",
+    "id": "325-release-notes\\0.19#breaking-changes",
     "title": "Zero 0.19",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.19",
+    "url": "/docs/release-notes\\0.19",
     "content": "The structure of setting up a PushProcesor has changed slightly. See push endpoint setup or upgrade guide. Not technically a breaking change from 0.18, but if you were using 0.19 canaries, the .server property returns error by rejection again (like 0.18 did) (doc).",
     "kind": "section"
   },
   {
-    "id": "36-release-notes/0.2",
+    "id": "36-release-notes\\0.2",
     "title": "Zero 0.2",
     "searchTitle": "Zero 0.2",
-    "url": "/docs/release-notes/0.2",
+    "url": "/docs/release-notes\\0.2",
     "content": "Breaking changes None Features “Skip mode”: zero-cache now skips columns with unsupported datatypes. A warning is printed out when this happens: This makes it easy to use zero-cache with existing schemas that have columns Zero can’t handle. You can pair this with Postgres triggers to easily translate unsupported types into something Zero can sync. Zero now supports compound primary keys. You no longer need to include an extraneous id column on the junction tables. Fixes Change the way Zero detects unsupported environments to work in One (and any other supported env). Before, Zero was looking for WebSocket and indexedDB early on, but indexedDB won’t be present on RN as SQLite will be used. Instead look for indexedDB only at use. Require Node v20 explicitly in package.json to prevent accidentally compiling better-sqlite3 with different Node version than running with. Ensure error messages early in startup get printed out before shutting down in multiprocess mode. Docs Factored out the sample app from the docs into its own Github repo so you can just download it and poke around if you prefer that. Source tree fixes Run zero-cache from source. You no longer have to build zero before running zbugs, it picks up the changes automatically. zbugs Numerous polish/styling fixes Change default to ‘open’ bugs Add ‘assignee’ field",
     "headings": [
       {
@@ -4003,70 +4003,70 @@
     "kind": "page"
   },
   {
-    "id": "326-release-notes/0.2#breaking-changes",
+    "id": "326-release-notes\\0.2#breaking-changes",
     "title": "Zero 0.2",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.2",
+    "url": "/docs/release-notes\\0.2",
     "content": "None",
     "kind": "section"
   },
   {
-    "id": "327-release-notes/0.2#features",
+    "id": "327-release-notes\\0.2#features",
     "title": "Zero 0.2",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.2",
+    "url": "/docs/release-notes\\0.2",
     "content": "“Skip mode”: zero-cache now skips columns with unsupported datatypes. A warning is printed out when this happens: This makes it easy to use zero-cache with existing schemas that have columns Zero can’t handle. You can pair this with Postgres triggers to easily translate unsupported types into something Zero can sync. Zero now supports compound primary keys. You no longer need to include an extraneous id column on the junction tables.",
     "kind": "section"
   },
   {
-    "id": "328-release-notes/0.2#fixes",
+    "id": "328-release-notes\\0.2#fixes",
     "title": "Zero 0.2",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.2",
+    "url": "/docs/release-notes\\0.2",
     "content": "Change the way Zero detects unsupported environments to work in One (and any other supported env). Before, Zero was looking for WebSocket and indexedDB early on, but indexedDB won’t be present on RN as SQLite will be used. Instead look for indexedDB only at use. Require Node v20 explicitly in package.json to prevent accidentally compiling better-sqlite3 with different Node version than running with. Ensure error messages early in startup get printed out before shutting down in multiprocess mode.",
     "kind": "section"
   },
   {
-    "id": "329-release-notes/0.2#docs",
+    "id": "329-release-notes\\0.2#docs",
     "title": "Zero 0.2",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
     "sectionId": "docs",
-    "url": "/docs/release-notes/0.2",
+    "url": "/docs/release-notes\\0.2",
     "content": "Factored out the sample app from the docs into its own Github repo so you can just download it and poke around if you prefer that.",
     "kind": "section"
   },
   {
-    "id": "330-release-notes/0.2#source-tree-fixes",
+    "id": "330-release-notes\\0.2#source-tree-fixes",
     "title": "Zero 0.2",
     "searchTitle": "Source tree fixes",
     "sectionTitle": "Source tree fixes",
     "sectionId": "source-tree-fixes",
-    "url": "/docs/release-notes/0.2",
+    "url": "/docs/release-notes\\0.2",
     "content": "Run zero-cache from source. You no longer have to build zero before running zbugs, it picks up the changes automatically.",
     "kind": "section"
   },
   {
-    "id": "331-release-notes/0.2#zbugs",
+    "id": "331-release-notes\\0.2#zbugs",
     "title": "Zero 0.2",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
     "sectionId": "zbugs",
-    "url": "/docs/release-notes/0.2",
+    "url": "/docs/release-notes\\0.2",
     "content": "Numerous polish/styling fixes Change default to ‘open’ bugs Add ‘assignee’ field",
     "kind": "section"
   },
   {
-    "id": "37-release-notes/0.20",
+    "id": "37-release-notes\\0.20",
     "title": "Zero 0.20",
     "searchTitle": "Zero 0.20",
-    "url": "/docs/release-notes/0.20",
+    "url": "/docs/release-notes\\0.20",
     "content": "Install npm install @rocicorp/zero@0.20 Upgrading There are two config changes for multinode deployments: Required: Remove view-syncer's ZERO_CHANGE_STREAMER_URI env var and replace it with ZERO_CHANGE_STREAMER_MODE: \"discover\". Optional: Change the ZERO_LITESTREAM_BACKUP_URL env var from being passed to both replication-manager and view-syncer nodes to being passed only to replication-manager. This config is no longer needed by view-syncer (and is ignored by it). See hello-zero for an upgrade example using SST. Additionally, the ZERO_TENANTS_JSON, feature was removed. We do not think anyone was using it, but if you were please reach out to us for options. Features Supabase is now fully supported. After upgrading, you should see that schema changes are incremental and don't reset the replica (docs). Improve performance of single-key reads on client. Scale depends on size of data but 100x improvement is common (PR). Implement short-circuiting for or queries. Because of permissions, one or more branches of or would often be empty, turning the entire or into a full-table scan. 100x improvement on chinook test dataset (PR). Remove DNF conversion. This was intended to make consistency easier in the future, but was resulting in some queries exploding in size (PR, bug). Autodiscovery for replication-manager. view-syncer nodes now find replication-manager using the Postgres changedb database, and no longer need an internal load balancer. See the new ZERO_CHANGE_STREAMER_MODE: \"discover\" config in the deployment docs (PR). Make ZERO_LITESTREAM_BACKUP_URL specific to replication-manager. view-syncer nodes now ignore this config and learn it from replication-manager instead. This makes restarting replication less error-prone (PR, discussion). OpenTelemetry support (docs). Fixes Allow dots in column names (only works with custom mutators) (PR). Fix websocket liveness check to avoid false negatives when busy (PR). Fix unhandled exception in zero-cache when processing query eviction (PR). Keep microsecond precision across timezones (PR). Fix unhandled exception in zero-cache during handleClose (PR). Fix NOT IN in z2s (PR). Mutators: assert provided columns actually exist (PR). Fix ordering of columns in replicated index (PR). Use a shorter keepalive for replication stream for compat with Neon (PR). Allow destructuring where in query.related (PR). Add flow control for large change DB transactions (PR). Fix z2s handling of pg types with params (char, varchar, numeric, etc) (PR). Support from and --schema-path in analyze-query (PR). Breaking Changes The autodiscovery feature for replication-manager is a breaking change for multinode deployments. See the upgrade instructions for details. The ZERO_TENANTS_JSON config was removed 🫗. The ZERO_INITIAL_SYNC_ROW_BATCH_SIZE config was removed. It is no longer needed because initial sync now adapts to available memory automatically.",
     "headings": [
       {
@@ -4093,60 +4093,60 @@
     "kind": "page"
   },
   {
-    "id": "332-release-notes/0.20#install",
+    "id": "332-release-notes\\0.20#install",
     "title": "Zero 0.20",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.20",
+    "url": "/docs/release-notes\\0.20",
     "content": "npm install @rocicorp/zero@0.20",
     "kind": "section"
   },
   {
-    "id": "333-release-notes/0.20#upgrading",
+    "id": "333-release-notes\\0.20#upgrading",
     "title": "Zero 0.20",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
     "sectionId": "upgrading",
-    "url": "/docs/release-notes/0.20",
+    "url": "/docs/release-notes\\0.20",
     "content": "There are two config changes for multinode deployments: Required: Remove view-syncer's ZERO_CHANGE_STREAMER_URI env var and replace it with ZERO_CHANGE_STREAMER_MODE: \"discover\". Optional: Change the ZERO_LITESTREAM_BACKUP_URL env var from being passed to both replication-manager and view-syncer nodes to being passed only to replication-manager. This config is no longer needed by view-syncer (and is ignored by it). See hello-zero for an upgrade example using SST. Additionally, the ZERO_TENANTS_JSON, feature was removed. We do not think anyone was using it, but if you were please reach out to us for options.",
     "kind": "section"
   },
   {
-    "id": "334-release-notes/0.20#features",
+    "id": "334-release-notes\\0.20#features",
     "title": "Zero 0.20",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.20",
+    "url": "/docs/release-notes\\0.20",
     "content": "Supabase is now fully supported. After upgrading, you should see that schema changes are incremental and don't reset the replica (docs). Improve performance of single-key reads on client. Scale depends on size of data but 100x improvement is common (PR). Implement short-circuiting for or queries. Because of permissions, one or more branches of or would often be empty, turning the entire or into a full-table scan. 100x improvement on chinook test dataset (PR). Remove DNF conversion. This was intended to make consistency easier in the future, but was resulting in some queries exploding in size (PR, bug). Autodiscovery for replication-manager. view-syncer nodes now find replication-manager using the Postgres changedb database, and no longer need an internal load balancer. See the new ZERO_CHANGE_STREAMER_MODE: \"discover\" config in the deployment docs (PR). Make ZERO_LITESTREAM_BACKUP_URL specific to replication-manager. view-syncer nodes now ignore this config and learn it from replication-manager instead. This makes restarting replication less error-prone (PR, discussion). OpenTelemetry support (docs).",
     "kind": "section"
   },
   {
-    "id": "335-release-notes/0.20#fixes",
+    "id": "335-release-notes\\0.20#fixes",
     "title": "Zero 0.20",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.20",
+    "url": "/docs/release-notes\\0.20",
     "content": "Allow dots in column names (only works with custom mutators) (PR). Fix websocket liveness check to avoid false negatives when busy (PR). Fix unhandled exception in zero-cache when processing query eviction (PR). Keep microsecond precision across timezones (PR). Fix unhandled exception in zero-cache during handleClose (PR). Fix NOT IN in z2s (PR). Mutators: assert provided columns actually exist (PR). Fix ordering of columns in replicated index (PR). Use a shorter keepalive for replication stream for compat with Neon (PR). Allow destructuring where in query.related (PR). Add flow control for large change DB transactions (PR). Fix z2s handling of pg types with params (char, varchar, numeric, etc) (PR). Support from and --schema-path in analyze-query (PR).",
     "kind": "section"
   },
   {
-    "id": "336-release-notes/0.20#breaking-changes",
+    "id": "336-release-notes\\0.20#breaking-changes",
     "title": "Zero 0.20",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.20",
+    "url": "/docs/release-notes\\0.20",
     "content": "The autodiscovery feature for replication-manager is a breaking change for multinode deployments. See the upgrade instructions for details. The ZERO_TENANTS_JSON config was removed 🫗. The ZERO_INITIAL_SYNC_ROW_BATCH_SIZE config was removed. It is no longer needed because initial sync now adapts to available memory automatically.",
     "kind": "section"
   },
   {
-    "id": "38-release-notes/0.21",
+    "id": "38-release-notes\\0.21",
     "title": "Zero 0.21",
     "searchTitle": "Zero 0.21",
-    "url": "/docs/release-notes/0.21",
+    "url": "/docs/release-notes\\0.21",
     "content": "Install npm install @rocicorp/zero@0.21 Upgrading There is one breaking change in this release, but we think it is unlikely to affect anyone since the results were wrong already – the change just makes the error explicit. See hello-zero for an example of using arrays and the new ZeroProvider features. Features New \"ztunes\" sample using TanStack, Drizzle, Better Auth, and Fly.io (docs). Add initial support for Postgres arrays (docs, bug). Improved React lifecycle management with ZeroProvider (docs, PR). Expose Zero instances automatically at __zero (docs, PR). Add --output-{synced|vended}-rows to analyze-query (PR). Technically a bug fix, but this was so annoying I'm calling it a feature: zero-sqlite3 now correctly supports the up/down arrow keys (commit). Another super annoying fix: logs from zero-cache are now level-colored (PR). Fixes Lazy-load otel. This was causing problems with pnpm (PR). Initial replication is now memory-bounded (PR). Change the way otel starts up in zero-cache-dev to not rely on npx (PR). Use existing --log-slow-hydrate-threshold as the threshold for --query-hydration-stats rather than hardcoded 200ms. Fix race condition starting up in multinode deployments (PR). Avoid site-local IPv6 addresses in auto-discovery (PR). Many z2s fixes found by fuzzing (PRs: 4415, 4416, 4417, 4421, 4422, 4423). Don't load prettier in analyze-query. This was causing problems when prettier config was cjs. (PR). Don't hydrate system relationships in analyze-query. This was causing incorrect results. (PR). Fix memory leaks from not cleaning up pusher and mutagen (PR). Fix handling of invalid websocket requests that were crashing server. (PR). Remove red error text when .env missing (PR). Allow zero-cache to startup without schema file, but print a warning (PR). Log a warning when auth token exceeds max allowed header size (PR). Breaking Changes Using order by and limit in many-to-many relationships now throws an error. It didn't work before but did the wrong thing silently. Now it throws a runtime error. See docs, bug.",
     "headings": [
       {
@@ -4173,60 +4173,60 @@
     "kind": "page"
   },
   {
-    "id": "337-release-notes/0.21#install",
+    "id": "337-release-notes\\0.21#install",
     "title": "Zero 0.21",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.21",
+    "url": "/docs/release-notes\\0.21",
     "content": "npm install @rocicorp/zero@0.21",
     "kind": "section"
   },
   {
-    "id": "338-release-notes/0.21#upgrading",
+    "id": "338-release-notes\\0.21#upgrading",
     "title": "Zero 0.21",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
     "sectionId": "upgrading",
-    "url": "/docs/release-notes/0.21",
+    "url": "/docs/release-notes\\0.21",
     "content": "There is one breaking change in this release, but we think it is unlikely to affect anyone since the results were wrong already – the change just makes the error explicit. See hello-zero for an example of using arrays and the new ZeroProvider features.",
     "kind": "section"
   },
   {
-    "id": "339-release-notes/0.21#features",
+    "id": "339-release-notes\\0.21#features",
     "title": "Zero 0.21",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.21",
+    "url": "/docs/release-notes\\0.21",
     "content": "New \"ztunes\" sample using TanStack, Drizzle, Better Auth, and Fly.io (docs). Add initial support for Postgres arrays (docs, bug). Improved React lifecycle management with ZeroProvider (docs, PR). Expose Zero instances automatically at __zero (docs, PR). Add --output-{synced|vended}-rows to analyze-query (PR). Technically a bug fix, but this was so annoying I'm calling it a feature: zero-sqlite3 now correctly supports the up/down arrow keys (commit). Another super annoying fix: logs from zero-cache are now level-colored (PR).",
     "kind": "section"
   },
   {
-    "id": "340-release-notes/0.21#fixes",
+    "id": "340-release-notes\\0.21#fixes",
     "title": "Zero 0.21",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.21",
+    "url": "/docs/release-notes\\0.21",
     "content": "Lazy-load otel. This was causing problems with pnpm (PR). Initial replication is now memory-bounded (PR). Change the way otel starts up in zero-cache-dev to not rely on npx (PR). Use existing --log-slow-hydrate-threshold as the threshold for --query-hydration-stats rather than hardcoded 200ms. Fix race condition starting up in multinode deployments (PR). Avoid site-local IPv6 addresses in auto-discovery (PR). Many z2s fixes found by fuzzing (PRs: 4415, 4416, 4417, 4421, 4422, 4423). Don't load prettier in analyze-query. This was causing problems when prettier config was cjs. (PR). Don't hydrate system relationships in analyze-query. This was causing incorrect results. (PR). Fix memory leaks from not cleaning up pusher and mutagen (PR). Fix handling of invalid websocket requests that were crashing server. (PR). Remove red error text when .env missing (PR). Allow zero-cache to startup without schema file, but print a warning (PR). Log a warning when auth token exceeds max allowed header size (PR).",
     "kind": "section"
   },
   {
-    "id": "341-release-notes/0.21#breaking-changes",
+    "id": "341-release-notes\\0.21#breaking-changes",
     "title": "Zero 0.21",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.21",
+    "url": "/docs/release-notes\\0.21",
     "content": "Using order by and limit in many-to-many relationships now throws an error. It didn't work before but did the wrong thing silently. Now it throws a runtime error. See docs, bug.",
     "kind": "section"
   },
   {
-    "id": "39-release-notes/0.22",
+    "id": "39-release-notes\\0.22",
     "title": "Zero 0.22",
     "searchTitle": "Zero 0.22",
-    "url": "/docs/release-notes/0.22",
+    "url": "/docs/release-notes\\0.22",
     "content": "Install npm install @rocicorp/zero@0.22 Upgrading This release simplifies the concept of TTLs in Zero. See hello-zero, hello-zero-solid, or ztunes for example upgrades. This release also adds anonymous telemetry collection. You can opt-out with the DO_NOT_TRACK=1 environment variable. Though we hope you will not, as it helps us improve Zero. How TTLs Used to Work Previously, the TTL of a query simply measured normal \"wall clock time\" from when a query inactivated, including any time the app wasn't running at all. With experience, we realized this was a misfeature because it encouraged the use of very long or infinite TTLs, especially for preload queries. Developers always want preload queries registered, but since they do not know how long the app will be offline, they had no real choice but to use the TTL forever. These infinite TTLs would remain registered even after the app's code changed such that it no longer wanted them, slowing connections and incremental updates to process queries that the app was not even using. Worse, the prevalence of infinite TTLs in turns meant we needed some way to limit the size of the client cache. We introduced the \"client row limit\" for this. But developers would frequently accidentally blow through this limit, causing cache thrash. How TTLs Work Now Now, query TTLs measure \"TTL time\" which only elapses while Zero is running. This means that preload queries usually don't need a TTL at all, since they run the entire time Zero is active. This in turn means we can clamp TTLs to low values, which means queries evict naturally, which means we no longer need the client row limit either. Using New TTLs You don't need to do anything specific to upgrade. Zero will clamp your TTLs at 10m and print a warning. But for best results, please review the new TTL documentation. In particular, see how to set your TTLs (TL;DR: You can often just remove them – the defaults usually just work). Features Rework and simplify query TTLs (docs, upgrading). SolidJS bindings are now fine-grained, improving performance (PR). Restore ZERO_CHANGE_STREAMER_URI option (doc, PR). Add useZeroOnline to React and SolidJS bindings (doc). Add ttl to run() (PR). Allow client to specify push.url in the Zero constructor (doc). Add anonymous telemetry collection to zero-cache (doc). Fixes Handle public in aliases, like .from('public.table') (PR). Sorting by columns with null values was incorrect in some cases (PR). Fix fencepost issue editing queries with limits (PR). Fix copy runner to more reliably reuse connections (PR). Queries early in startup could not contain non-latin chars (PR). SolidJS: Export createUseZero (PR). Support parallel rollouts of replication-manager and view-syncer (PR). Fix upgrade path for already replicated array types (PR). Breaking Changes Require Node v22+ (see discussion)",
     "headings": [
       {
@@ -4265,90 +4265,90 @@
     "kind": "page"
   },
   {
-    "id": "342-release-notes/0.22#install",
+    "id": "342-release-notes\\0.22#install",
     "title": "Zero 0.22",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.22",
+    "url": "/docs/release-notes\\0.22",
     "content": "npm install @rocicorp/zero@0.22",
     "kind": "section"
   },
   {
-    "id": "343-release-notes/0.22#upgrading",
+    "id": "343-release-notes\\0.22#upgrading",
     "title": "Zero 0.22",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
     "sectionId": "upgrading",
-    "url": "/docs/release-notes/0.22",
+    "url": "/docs/release-notes\\0.22",
     "content": "This release simplifies the concept of TTLs in Zero. See hello-zero, hello-zero-solid, or ztunes for example upgrades. This release also adds anonymous telemetry collection. You can opt-out with the DO_NOT_TRACK=1 environment variable. Though we hope you will not, as it helps us improve Zero. How TTLs Used to Work Previously, the TTL of a query simply measured normal \"wall clock time\" from when a query inactivated, including any time the app wasn't running at all. With experience, we realized this was a misfeature because it encouraged the use of very long or infinite TTLs, especially for preload queries. Developers always want preload queries registered, but since they do not know how long the app will be offline, they had no real choice but to use the TTL forever. These infinite TTLs would remain registered even after the app's code changed such that it no longer wanted them, slowing connections and incremental updates to process queries that the app was not even using. Worse, the prevalence of infinite TTLs in turns meant we needed some way to limit the size of the client cache. We introduced the \"client row limit\" for this. But developers would frequently accidentally blow through this limit, causing cache thrash. How TTLs Work Now Now, query TTLs measure \"TTL time\" which only elapses while Zero is running. This means that preload queries usually don't need a TTL at all, since they run the entire time Zero is active. This in turn means we can clamp TTLs to low values, which means queries evict naturally, which means we no longer need the client row limit either. Using New TTLs You don't need to do anything specific to upgrade. Zero will clamp your TTLs at 10m and print a warning. But for best results, please review the new TTL documentation. In particular, see how to set your TTLs (TL;DR: You can often just remove them – the defaults usually just work).",
     "kind": "section"
   },
   {
-    "id": "344-release-notes/0.22#how-ttls-used-to-work",
+    "id": "344-release-notes\\0.22#how-ttls-used-to-work",
     "title": "Zero 0.22",
     "searchTitle": "How TTLs Used to Work",
     "sectionTitle": "How TTLs Used to Work",
     "sectionId": "how-ttls-used-to-work",
-    "url": "/docs/release-notes/0.22",
+    "url": "/docs/release-notes\\0.22",
     "content": "Previously, the TTL of a query simply measured normal \"wall clock time\" from when a query inactivated, including any time the app wasn't running at all. With experience, we realized this was a misfeature because it encouraged the use of very long or infinite TTLs, especially for preload queries. Developers always want preload queries registered, but since they do not know how long the app will be offline, they had no real choice but to use the TTL forever. These infinite TTLs would remain registered even after the app's code changed such that it no longer wanted them, slowing connections and incremental updates to process queries that the app was not even using. Worse, the prevalence of infinite TTLs in turns meant we needed some way to limit the size of the client cache. We introduced the \"client row limit\" for this. But developers would frequently accidentally blow through this limit, causing cache thrash.",
     "kind": "section"
   },
   {
-    "id": "345-release-notes/0.22#how-ttls-work-now",
+    "id": "345-release-notes\\0.22#how-ttls-work-now",
     "title": "Zero 0.22",
     "searchTitle": "How TTLs Work Now",
     "sectionTitle": "How TTLs Work Now",
     "sectionId": "how-ttls-work-now",
-    "url": "/docs/release-notes/0.22",
+    "url": "/docs/release-notes\\0.22",
     "content": "Now, query TTLs measure \"TTL time\" which only elapses while Zero is running. This means that preload queries usually don't need a TTL at all, since they run the entire time Zero is active. This in turn means we can clamp TTLs to low values, which means queries evict naturally, which means we no longer need the client row limit either.",
     "kind": "section"
   },
   {
-    "id": "346-release-notes/0.22#using-new-ttls",
+    "id": "346-release-notes\\0.22#using-new-ttls",
     "title": "Zero 0.22",
     "searchTitle": "Using New TTLs",
     "sectionTitle": "Using New TTLs",
     "sectionId": "using-new-ttls",
-    "url": "/docs/release-notes/0.22",
+    "url": "/docs/release-notes\\0.22",
     "content": "You don't need to do anything specific to upgrade. Zero will clamp your TTLs at 10m and print a warning. But for best results, please review the new TTL documentation. In particular, see how to set your TTLs (TL;DR: You can often just remove them – the defaults usually just work).",
     "kind": "section"
   },
   {
-    "id": "347-release-notes/0.22#features",
+    "id": "347-release-notes\\0.22#features",
     "title": "Zero 0.22",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.22",
+    "url": "/docs/release-notes\\0.22",
     "content": "Rework and simplify query TTLs (docs, upgrading). SolidJS bindings are now fine-grained, improving performance (PR). Restore ZERO_CHANGE_STREAMER_URI option (doc, PR). Add useZeroOnline to React and SolidJS bindings (doc). Add ttl to run() (PR). Allow client to specify push.url in the Zero constructor (doc). Add anonymous telemetry collection to zero-cache (doc).",
     "kind": "section"
   },
   {
-    "id": "348-release-notes/0.22#fixes",
+    "id": "348-release-notes\\0.22#fixes",
     "title": "Zero 0.22",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.22",
+    "url": "/docs/release-notes\\0.22",
     "content": "Handle public in aliases, like .from('public.table') (PR). Sorting by columns with null values was incorrect in some cases (PR). Fix fencepost issue editing queries with limits (PR). Fix copy runner to more reliably reuse connections (PR). Queries early in startup could not contain non-latin chars (PR). SolidJS: Export createUseZero (PR). Support parallel rollouts of replication-manager and view-syncer (PR). Fix upgrade path for already replicated array types (PR).",
     "kind": "section"
   },
   {
-    "id": "349-release-notes/0.22#breaking-changes",
+    "id": "349-release-notes\\0.22#breaking-changes",
     "title": "Zero 0.22",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.22",
+    "url": "/docs/release-notes\\0.22",
     "content": "Require Node v22+ (see discussion)",
     "kind": "section"
   },
   {
-    "id": "40-release-notes/0.23",
+    "id": "40-release-notes\\0.23",
     "title": "Zero 0.23",
     "searchTitle": "Zero 0.23",
-    "url": "/docs/release-notes/0.23",
+    "url": "/docs/release-notes\\0.23",
     "content": "Install npm install @rocicorp/zero@0.23 Upgrading For example upgrades, see ztunes or hello-zero-solid. Please note the breaking changes below. They are minor this time. To try synced queries, please refer to the docs, or the zslack / hello-zero-solid repos which have sample implementations. We will update the rest of the samples to synced queries and custom mutators in September. Features Synced Queries (previously known as \"custom queries\") (docs). First-class React Native support (thanks Austin and Chase) (docs). New \"zslack\" sample featuring React Native and Synced Queries (doc). PlanetScale for Postgres is now fully supported (docs). Suspense support for React (thanks Lewis) (docs). Flag to disable CRUD mutators (docs). New query metrics in inspector (docs). Fixes Large connection headers should not throw (PR). Remove verbose stats from /statz that were crashing larger instances (PR). Fix zero-sqlite3 in Docker container (PR). GC inactive CVRs (PR). Refuse or halt replication for unsupported replica identities (PR). Disable DB-level statement_timeout for zero-cache connections (PR). Handle resync after partial state drop (PR). Fix logging color output on light terminals (PR). Use TableSource with analyze-query to better match production (PR). zero-cache now logs its version on startup (PR). \"Go to definition\" works on custom mutators if you set enableLegacyMutators: false (bug). zbugs zbugs now supports image uploads! (PR). Breaking Changes ZeroProvider now required in SolidJS, just like in React (docs, PR). The tx parameter in custom mutators now requires an explicit type (PR). The CustomMutatorDefs type no longer accepts template parameters (PR) The delegate() method on the Query class was removed. Use zero.run, zero.preload, or zero.materialize instead (PR).",
     "headings": [
       {
@@ -4379,70 +4379,70 @@
     "kind": "page"
   },
   {
-    "id": "350-release-notes/0.23#install",
+    "id": "350-release-notes\\0.23#install",
     "title": "Zero 0.23",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.23",
+    "url": "/docs/release-notes\\0.23",
     "content": "npm install @rocicorp/zero@0.23",
     "kind": "section"
   },
   {
-    "id": "351-release-notes/0.23#upgrading",
+    "id": "351-release-notes\\0.23#upgrading",
     "title": "Zero 0.23",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
     "sectionId": "upgrading",
-    "url": "/docs/release-notes/0.23",
+    "url": "/docs/release-notes\\0.23",
     "content": "For example upgrades, see ztunes or hello-zero-solid. Please note the breaking changes below. They are minor this time. To try synced queries, please refer to the docs, or the zslack / hello-zero-solid repos which have sample implementations. We will update the rest of the samples to synced queries and custom mutators in September.",
     "kind": "section"
   },
   {
-    "id": "352-release-notes/0.23#features",
+    "id": "352-release-notes\\0.23#features",
     "title": "Zero 0.23",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.23",
+    "url": "/docs/release-notes\\0.23",
     "content": "Synced Queries (previously known as \"custom queries\") (docs). First-class React Native support (thanks Austin and Chase) (docs). New \"zslack\" sample featuring React Native and Synced Queries (doc). PlanetScale for Postgres is now fully supported (docs). Suspense support for React (thanks Lewis) (docs). Flag to disable CRUD mutators (docs). New query metrics in inspector (docs).",
     "kind": "section"
   },
   {
-    "id": "353-release-notes/0.23#fixes",
+    "id": "353-release-notes\\0.23#fixes",
     "title": "Zero 0.23",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.23",
+    "url": "/docs/release-notes\\0.23",
     "content": "Large connection headers should not throw (PR). Remove verbose stats from /statz that were crashing larger instances (PR). Fix zero-sqlite3 in Docker container (PR). GC inactive CVRs (PR). Refuse or halt replication for unsupported replica identities (PR). Disable DB-level statement_timeout for zero-cache connections (PR). Handle resync after partial state drop (PR). Fix logging color output on light terminals (PR). Use TableSource with analyze-query to better match production (PR). zero-cache now logs its version on startup (PR). \"Go to definition\" works on custom mutators if you set enableLegacyMutators: false (bug).",
     "kind": "section"
   },
   {
-    "id": "354-release-notes/0.23#zbugs",
+    "id": "354-release-notes\\0.23#zbugs",
     "title": "Zero 0.23",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
     "sectionId": "zbugs",
-    "url": "/docs/release-notes/0.23",
+    "url": "/docs/release-notes\\0.23",
     "content": "zbugs now supports image uploads! (PR).",
     "kind": "section"
   },
   {
-    "id": "355-release-notes/0.23#breaking-changes",
+    "id": "355-release-notes\\0.23#breaking-changes",
     "title": "Zero 0.23",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.23",
+    "url": "/docs/release-notes\\0.23",
     "content": "ZeroProvider now required in SolidJS, just like in React (docs, PR). The tx parameter in custom mutators now requires an explicit type (PR). The CustomMutatorDefs type no longer accepts template parameters (PR) The delegate() method on the Query class was removed. Use zero.run, zero.preload, or zero.materialize instead (PR).",
     "kind": "section"
   },
   {
-    "id": "41-release-notes/0.24",
+    "id": "41-release-notes\\0.24",
     "title": "Zero 0.24",
     "searchTitle": "Zero 0.24",
-    "url": "/docs/release-notes/0.24",
+    "url": "/docs/release-notes\\0.24",
     "content": "Installation npm install @rocicorp/zero@0.24 Features Join Flipping: Dramatically improves the performance of whereExists() in many common cases. Join flipping is a form of manual query planning that tells Zero the order to evaluate joins. An automatic planner will follow in a future release. Simplified Auth: If you are using custom mutators and synced queries, you no longer need to use JWT auth. You can use opaque tokens or even better, plain old cookies. This even means you can use HTTP-only cookies. In our demo apps this eliminated hundreds of lines of code. It's a big improvement. Full Preview Support: We tried to get this out in 0.23 but it didn't quite make it. You can now dynamically configure Zero with the location of your mutator and query endpoints. This allows easily using preview URLs on platforms like Vercel. Analyze Query from Inspector: No more npx zero-analyze-query or ssh'ing into production. You can analyze any query right from the dev tools of your browser. On by default in every Zero app. Simplified Metrics Output in Inspector: No more .metrics[\"long-name-i-cant-remember\"].quantile(0.99). The most important metrics – hydration and update time – are right on the query object. Also, you don't have to (await __zero.inspect()).client.queries anymore. It's just __zero.inspector.client.queries(). New Type helpers: QueryResultType and QueryRowType are handy ways to get the type of a query result or one of its rows. Faster storage for React Native via op-sqlite: The op-sqlite bindings are faster than the expo built-in ones. We now provide this built-in to Zero. Brand New Cloudflare Sample: Turned the old hello-zero-do sample into a complete Cloudflare sample using workers for everything. Improved ZQL server-side APIs: More convenient setup, and added node-postgres and Drizzle support. Fixes Expose server errors from get-queries endpoint to client Correctly map primary keys to server names in some edge cases Reduce some OTEL error logging to warn Fix a case of deadlock related to CVR cleanup Fix hang on shutdown under Bun CLI (thanks David!) Fix \"View already exists\" error, Discord Fix rows sometimes missing from startAt queries Improve performance of CVR cleanup Disable statement-level timeouts that were preventing CVR cleanup Fix WAL growth when no connected clients Fix exception with local-only queries and enableLegacyQueries:false Fix inability to use --flags with zero-cache-dev (thanks Alizain!). Reduce ping timeouts during slow queries with better time-slicing Improve handling of ownership changes in the change-streamer Breaking Changes If you are using the push.url param to the Zero constructor, rename it to mutateURL (more info). If you are using the ZERO_PUSH_URL config param, rename it to ZERO_MUTATE_URL (more info). If you are awaiting queries directly without calling run(), like await z.query.foo.where(...), or await tx.query.foo.where(...), add .run() to the end, like await z.query.foo.where(...).run() or await tx.query.foo.where(...).run().. This is most common in custom mutator implementations (more info) If you are building for React Native, change your import path from @rocicorp/zero/react-native to @rocicorp/zero/expo-sqlite (more info) Add a ZERO_ADMIN_PASSWORD env var to your production config. This is now required (more info) Example Upgrades ztunes zslack hello-zero-solid hello-zero – Note that we are keeping hello-zero on the legacy query and mutator APIs until they are deprecated, for testing reasons. So this PR doesn't include custom mutator, synced query, or auth-related changes.",
     "headings": [
       {
@@ -4469,60 +4469,60 @@
     "kind": "page"
   },
   {
-    "id": "356-release-notes/0.24#installation",
+    "id": "356-release-notes\\0.24#installation",
     "title": "Zero 0.24",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
     "sectionId": "installation",
-    "url": "/docs/release-notes/0.24",
+    "url": "/docs/release-notes\\0.24",
     "content": "npm install @rocicorp/zero@0.24",
     "kind": "section"
   },
   {
-    "id": "357-release-notes/0.24#features",
+    "id": "357-release-notes\\0.24#features",
     "title": "Zero 0.24",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.24",
+    "url": "/docs/release-notes\\0.24",
     "content": "Join Flipping: Dramatically improves the performance of whereExists() in many common cases. Join flipping is a form of manual query planning that tells Zero the order to evaluate joins. An automatic planner will follow in a future release. Simplified Auth: If you are using custom mutators and synced queries, you no longer need to use JWT auth. You can use opaque tokens or even better, plain old cookies. This even means you can use HTTP-only cookies. In our demo apps this eliminated hundreds of lines of code. It's a big improvement. Full Preview Support: We tried to get this out in 0.23 but it didn't quite make it. You can now dynamically configure Zero with the location of your mutator and query endpoints. This allows easily using preview URLs on platforms like Vercel. Analyze Query from Inspector: No more npx zero-analyze-query or ssh'ing into production. You can analyze any query right from the dev tools of your browser. On by default in every Zero app. Simplified Metrics Output in Inspector: No more .metrics[\"long-name-i-cant-remember\"].quantile(0.99). The most important metrics – hydration and update time – are right on the query object. Also, you don't have to (await __zero.inspect()).client.queries anymore. It's just __zero.inspector.client.queries(). New Type helpers: QueryResultType and QueryRowType are handy ways to get the type of a query result or one of its rows. Faster storage for React Native via op-sqlite: The op-sqlite bindings are faster than the expo built-in ones. We now provide this built-in to Zero. Brand New Cloudflare Sample: Turned the old hello-zero-do sample into a complete Cloudflare sample using workers for everything. Improved ZQL server-side APIs: More convenient setup, and added node-postgres and Drizzle support.",
     "kind": "section"
   },
   {
-    "id": "358-release-notes/0.24#fixes",
+    "id": "358-release-notes\\0.24#fixes",
     "title": "Zero 0.24",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.24",
+    "url": "/docs/release-notes\\0.24",
     "content": "Expose server errors from get-queries endpoint to client Correctly map primary keys to server names in some edge cases Reduce some OTEL error logging to warn Fix a case of deadlock related to CVR cleanup Fix hang on shutdown under Bun CLI (thanks David!) Fix \"View already exists\" error, Discord Fix rows sometimes missing from startAt queries Improve performance of CVR cleanup Disable statement-level timeouts that were preventing CVR cleanup Fix WAL growth when no connected clients Fix exception with local-only queries and enableLegacyQueries:false Fix inability to use --flags with zero-cache-dev (thanks Alizain!). Reduce ping timeouts during slow queries with better time-slicing Improve handling of ownership changes in the change-streamer",
     "kind": "section"
   },
   {
-    "id": "359-release-notes/0.24#breaking-changes",
+    "id": "359-release-notes\\0.24#breaking-changes",
     "title": "Zero 0.24",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.24",
+    "url": "/docs/release-notes\\0.24",
     "content": "If you are using the push.url param to the Zero constructor, rename it to mutateURL (more info). If you are using the ZERO_PUSH_URL config param, rename it to ZERO_MUTATE_URL (more info). If you are awaiting queries directly without calling run(), like await z.query.foo.where(...), or await tx.query.foo.where(...), add .run() to the end, like await z.query.foo.where(...).run() or await tx.query.foo.where(...).run().. This is most common in custom mutator implementations (more info) If you are building for React Native, change your import path from @rocicorp/zero/react-native to @rocicorp/zero/expo-sqlite (more info) Add a ZERO_ADMIN_PASSWORD env var to your production config. This is now required (more info)",
     "kind": "section"
   },
   {
-    "id": "360-release-notes/0.24#example-upgrades",
+    "id": "360-release-notes\\0.24#example-upgrades",
     "title": "Zero 0.24",
     "searchTitle": "Example Upgrades",
     "sectionTitle": "Example Upgrades",
     "sectionId": "example-upgrades",
-    "url": "/docs/release-notes/0.24",
+    "url": "/docs/release-notes\\0.24",
     "content": "ztunes zslack hello-zero-solid hello-zero – Note that we are keeping hello-zero on the legacy query and mutator APIs until they are deprecated, for testing reasons. So this PR doesn't include custom mutator, synced query, or auth-related changes.",
     "kind": "section"
   },
   {
-    "id": "42-release-notes/0.25",
+    "id": "42-release-notes\\0.25",
     "title": "Zero 0.25",
     "searchTitle": "Zero 0.25",
-    "url": "/docs/release-notes/0.25",
+    "url": "/docs/release-notes\\0.25",
     "content": "Installation npm install @rocicorp/zero@0.25 Overview This release massively overhauls and simplifies the entire Zero API. Conceptually, Zero is now just schemas, queries, and mutators. There are no longer first-class auth or permission systems. There are no longer \"custom mutators\" and \"crud mutators\", or \"synced queries\" and \"zql queries\". All the old APIs have been deprecated, and the docs have been rewritten and simpilfied. Additionally, this release introduces a raft of big new features. To ease the transition, and allow access to new features without a ton of work, you can still use the old APIs via the enableLegacyQueries and enableLegacyMutators flags. Note that support for these older APIs will be removed for the Zero beta early next year. Upgrading We have implemented both \"minimal\" and \"maximal\" sample upgrades. The minimal upgrades show how to update to 0.25 with very little work, by opting into deprecated APIs: ztunes minimal: Minimal React upgrade. hello-zero-solid minimal: Minimal SolidJS upgrade. The maximal upgrades show how to use all the new features. Refer to the commit log of each PR for step-by-step examples of how to upgrade: ztunes maximal: Maximal React upgrade. hello-zero-solid maximal: Maximal SolidJS upgrade. zslack: Maximal React Native upgrade. hello-zero-cf: Maximal Cloudflare upgrade. Additionally, the old hello-zero sample has been updated from the original CRUD mutators and queries all the way to the latest hotness. So if you were still using those APIs, you can use this as a guide to upgrade. Features Query Planning: Zero now automatically plans joins, similar to other databases. You no longer need to specify flip:true to optimize whereExists() calls. Reworked Query DX: Queries now receive a Context automatically – you don't have to pass it at the call site. Also, any Standard Schema conforming library can be used for validation and the API has been generally simplified and streamlined. Reworked Mutator DX: The mutator API has been overhauled to match queries. Mutators now also support validation. drizzle-zero and prisma-zero are now first-class: They have moved into the rocicorp org and are now officially supported. Default Schema Type: The Schema type can now be registered as a default with Zero. You can just say useZero() – useZero<Schema> is no longer needed. You can also delete your createUseZero() helper if you have one. This registration happens by default if you use the new drizzle-zero or prisma-zero packages. New Connection Status API: Brand new connection status API with overhauled error-handling and reconnection behavior. Mutator promises now return structured errors: The client and server promises now always resolve. In the case of an error, they now return a structured error object. New Install Guide: Rewritten guide to add Zero to an existing project. New zero-out tool: Removes all trace of Zero from Postgres. Support for Generated Columns: In Postgres 18+, generated stored columns are now synced. This is useful for denormalizing data from JSON columns to support filtering in Zero. Performance Queries should be 0.2x to 4x faster, depending on the query. Some highlights: Only cache for duration of fetch in exists: 60% improvement on sparse exists queries. Do not fetch on null constraint: 33% improvement on some queries. Remove join storage: ~25% improvement in queries with related calls. Fixes Cooperative concurrency for queries ZERO_REPLICA_FILE now defaults to zero.db serverURL renamed to cacheURL GET_QUERIES renamed to QUERY throughout Ping timeouts now configurable in constructor and at runtime Add configurable WebSocket compression tx.upsert should not overwrite w/ null on missing value sourceField in schema wasn't strongly typed Avoid unique violations during push caused by history compression Invalid SQL was being generated for arrays Handle connections to a view-syncer that has shut down properly Process pending messages on closed websocket Do not hydrate queries if no clients initialized Inspector.analyzeQuery() wasn't mapping names Add flow control to subscriber catchup Migrate TTL/inactivatedAt to DOUBLE PRECISION with clamping Continuous change-log cleanup for single-node Count SQLite row scans, not what is returned to us Make schema path optional for zero-cache-dev (thanks @mattkinnersley!) Export context types (thanks @awkweb!) Suppress deprecation warnings for unset options Fixed closing expo-sqlite DB before deleting Catch errors from async/pipelined db calls Expliclty set isolation level in CVR transactions Change when/where we check advance progress to catch slow change Fix desync caused by client/server inconsistency in keys used to identify rows Send name/args for named queries to enable auth context Re-transform queries on every reconnect Defer completing orderBy(s) until pipeline build and use client primary key Pipeline-driver was in invalid state after ResetPipelinesSignal error Fix pipeline storage db collision SolidJS connection state not updating (thanks @fezproof) Corrects the error semantics of the mutate callback Delay resolving ViewSyncer#initialized until cvr.clientSchema is ensured Use memo to ensure minimal updates in SolidJS Sort queries by hydrateServer desc Delay the replication-manager handoff for loadbalancer task registration Use zql_root as root table name instead of root (thanks @tjenkinson!) Breaking Changes Despite the large DX update, we tried to make the upgrade as smooth as possible. However, there are a few breaking changes we could not easily avoid. If you do not want to immediately opt-in to the new query and mutator APIs, set enableLegacyQueries and enableLegacyMutators to true in your schema.ts. If you are using the .client or .server promises with custom mutators, these no longer ever reject. They now always resolve with a result type that has success/error cases Mutators now reject while Zero is offline. You may want to use the new Connection Status API to detect this and display custom UI to users. The pattern for reauthentication has changed. The auth parameter is now always a string – the function form is no longer supported. Instead, call zero.connection.connect({auth: token}) to reconnect. This was done to simplify the API and support reauth via cookies consistently. The onError feature of Zero has been removed. It was undocumented and only half-working. Please use the new Connection Status API to detect errors and display custom UI to users.",
     "headings": [
       {
@@ -4557,80 +4557,80 @@
     "kind": "page"
   },
   {
-    "id": "361-release-notes/0.25#installation",
+    "id": "361-release-notes\\0.25#installation",
     "title": "Zero 0.25",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
     "sectionId": "installation",
-    "url": "/docs/release-notes/0.25",
+    "url": "/docs/release-notes\\0.25",
     "content": "npm install @rocicorp/zero@0.25",
     "kind": "section"
   },
   {
-    "id": "362-release-notes/0.25#overview",
+    "id": "362-release-notes\\0.25#overview",
     "title": "Zero 0.25",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
     "sectionId": "overview",
-    "url": "/docs/release-notes/0.25",
+    "url": "/docs/release-notes\\0.25",
     "content": "This release massively overhauls and simplifies the entire Zero API. Conceptually, Zero is now just schemas, queries, and mutators. There are no longer first-class auth or permission systems. There are no longer \"custom mutators\" and \"crud mutators\", or \"synced queries\" and \"zql queries\". All the old APIs have been deprecated, and the docs have been rewritten and simpilfied. Additionally, this release introduces a raft of big new features. To ease the transition, and allow access to new features without a ton of work, you can still use the old APIs via the enableLegacyQueries and enableLegacyMutators flags. Note that support for these older APIs will be removed for the Zero beta early next year.",
     "kind": "section"
   },
   {
-    "id": "363-release-notes/0.25#upgrading",
+    "id": "363-release-notes\\0.25#upgrading",
     "title": "Zero 0.25",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
     "sectionId": "upgrading",
-    "url": "/docs/release-notes/0.25",
+    "url": "/docs/release-notes\\0.25",
     "content": "We have implemented both \"minimal\" and \"maximal\" sample upgrades. The minimal upgrades show how to update to 0.25 with very little work, by opting into deprecated APIs: ztunes minimal: Minimal React upgrade. hello-zero-solid minimal: Minimal SolidJS upgrade. The maximal upgrades show how to use all the new features. Refer to the commit log of each PR for step-by-step examples of how to upgrade: ztunes maximal: Maximal React upgrade. hello-zero-solid maximal: Maximal SolidJS upgrade. zslack: Maximal React Native upgrade. hello-zero-cf: Maximal Cloudflare upgrade. Additionally, the old hello-zero sample has been updated from the original CRUD mutators and queries all the way to the latest hotness. So if you were still using those APIs, you can use this as a guide to upgrade.",
     "kind": "section"
   },
   {
-    "id": "364-release-notes/0.25#features",
+    "id": "364-release-notes\\0.25#features",
     "title": "Zero 0.25",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.25",
+    "url": "/docs/release-notes\\0.25",
     "content": "Query Planning: Zero now automatically plans joins, similar to other databases. You no longer need to specify flip:true to optimize whereExists() calls. Reworked Query DX: Queries now receive a Context automatically – you don't have to pass it at the call site. Also, any Standard Schema conforming library can be used for validation and the API has been generally simplified and streamlined. Reworked Mutator DX: The mutator API has been overhauled to match queries. Mutators now also support validation. drizzle-zero and prisma-zero are now first-class: They have moved into the rocicorp org and are now officially supported. Default Schema Type: The Schema type can now be registered as a default with Zero. You can just say useZero() – useZero<Schema> is no longer needed. You can also delete your createUseZero() helper if you have one. This registration happens by default if you use the new drizzle-zero or prisma-zero packages. New Connection Status API: Brand new connection status API with overhauled error-handling and reconnection behavior. Mutator promises now return structured errors: The client and server promises now always resolve. In the case of an error, they now return a structured error object. New Install Guide: Rewritten guide to add Zero to an existing project. New zero-out tool: Removes all trace of Zero from Postgres. Support for Generated Columns: In Postgres 18+, generated stored columns are now synced. This is useful for denormalizing data from JSON columns to support filtering in Zero.",
     "kind": "section"
   },
   {
-    "id": "365-release-notes/0.25#performance",
+    "id": "365-release-notes\\0.25#performance",
     "title": "Zero 0.25",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
     "sectionId": "performance",
-    "url": "/docs/release-notes/0.25",
+    "url": "/docs/release-notes\\0.25",
     "content": "Queries should be 0.2x to 4x faster, depending on the query. Some highlights: Only cache for duration of fetch in exists: 60% improvement on sparse exists queries. Do not fetch on null constraint: 33% improvement on some queries. Remove join storage: ~25% improvement in queries with related calls.",
     "kind": "section"
   },
   {
-    "id": "366-release-notes/0.25#fixes",
+    "id": "366-release-notes\\0.25#fixes",
     "title": "Zero 0.25",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.25",
+    "url": "/docs/release-notes\\0.25",
     "content": "Cooperative concurrency for queries ZERO_REPLICA_FILE now defaults to zero.db serverURL renamed to cacheURL GET_QUERIES renamed to QUERY throughout Ping timeouts now configurable in constructor and at runtime Add configurable WebSocket compression tx.upsert should not overwrite w/ null on missing value sourceField in schema wasn't strongly typed Avoid unique violations during push caused by history compression Invalid SQL was being generated for arrays Handle connections to a view-syncer that has shut down properly Process pending messages on closed websocket Do not hydrate queries if no clients initialized Inspector.analyzeQuery() wasn't mapping names Add flow control to subscriber catchup Migrate TTL/inactivatedAt to DOUBLE PRECISION with clamping Continuous change-log cleanup for single-node Count SQLite row scans, not what is returned to us Make schema path optional for zero-cache-dev (thanks @mattkinnersley!) Export context types (thanks @awkweb!) Suppress deprecation warnings for unset options Fixed closing expo-sqlite DB before deleting Catch errors from async/pipelined db calls Expliclty set isolation level in CVR transactions Change when/where we check advance progress to catch slow change Fix desync caused by client/server inconsistency in keys used to identify rows Send name/args for named queries to enable auth context Re-transform queries on every reconnect Defer completing orderBy(s) until pipeline build and use client primary key Pipeline-driver was in invalid state after ResetPipelinesSignal error Fix pipeline storage db collision SolidJS connection state not updating (thanks @fezproof) Corrects the error semantics of the mutate callback Delay resolving ViewSyncer#initialized until cvr.clientSchema is ensured Use memo to ensure minimal updates in SolidJS Sort queries by hydrateServer desc Delay the replication-manager handoff for loadbalancer task registration Use zql_root as root table name instead of root (thanks @tjenkinson!)",
     "kind": "section"
   },
   {
-    "id": "367-release-notes/0.25#breaking-changes",
+    "id": "367-release-notes\\0.25#breaking-changes",
     "title": "Zero 0.25",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.25",
+    "url": "/docs/release-notes\\0.25",
     "content": "Despite the large DX update, we tried to make the upgrade as smooth as possible. However, there are a few breaking changes we could not easily avoid. If you do not want to immediately opt-in to the new query and mutator APIs, set enableLegacyQueries and enableLegacyMutators to true in your schema.ts. If you are using the .client or .server promises with custom mutators, these no longer ever reject. They now always resolve with a result type that has success/error cases Mutators now reject while Zero is offline. You may want to use the new Connection Status API to detect this and display custom UI to users. The pattern for reauthentication has changed. The auth parameter is now always a string – the function form is no longer supported. Instead, call zero.connection.connect({auth: token}) to reconnect. This was done to simplify the API and support reauth via cookies consistently. The onError feature of Zero has been removed. It was undocumented and only half-working. Please use the new Connection Status API to detect errors and display custom UI to users.",
     "kind": "section"
   },
   {
-    "id": "43-release-notes/0.26",
+    "id": "43-release-notes\\0.26",
     "title": "Zero 0.26",
     "searchTitle": "Zero 0.26",
-    "url": "/docs/release-notes/0.26",
+    "url": "/docs/release-notes\\0.26",
     "content": "Installation npm install @rocicorp/zero@0.26 Features Schema Backfill: Zero now natively supports adding columns with non-constant defaults, or adding existing columns to a custom publication. There is no longer a need to touch every row in the database to backfill data manually. Scalar Subqueries: Added a new optional optimization for exists queries that filter by related data with a one-to-one relationship. This can improve query performance significantly for cases where the subquery result changes rarely. Virtual Scroll: Added zero-virtual library for efficient infinite scrolling in React. Support for time and timetz columns: Added support for time and timetz columns (thanks GRBurst). Comparing to undefined: Added a new convenience for comparing to undefined. This is useful for filtering by nullable fields. zero.delete(): Added a more convenient way to delete all data from the browser's IndexedDB database. Fixes Updating auth tokens no cycles connection Add configurable back-pressure limit for change streamer Surface replication LSN at /statz?replication Generalize all statz output to be machine-readable Fix unique constraint violations during sync Fix zero-sqlite3 install script to work with bun Warn when mutations are rejected due to offline/error/closed state Fix queries being dropped when other queries with same hash expire Fix incorrect query results when filtering by undefined values Fix connection.connect() being ignored when in error/auth state Extra table name validation Redact sensitive info from logs Do not log mutation args Allow validation of JWT issuer and audience claims Protect against admin password timing attacks Forward origin header to API server Escape publication names Prevent denial of service attacks Fix race condition in notification handling Fix custom kvStoreProvider being ignored in React Native (thanks @kvnkusch!) Allow hybrid permissions with new queries in zero-cache-dev Fix unnecessary reconnection attempts after auth errors Fix \"database connection is not open\" error during shutdown Fix view-syncer crash from stale WebSocket messages Forward fresh auth token with each push message (thanks @jbingen!) Prevent IDB collection from deleting active databases Fix statz double close and ensure sqlite db handles are closed Fix OOM crashes when replicating databases with large rows Fix parsing of json[] and jsonb[] types Fix slow queries on tables with nullable unique columns Fix replication crash from closed WebSocket (thanks @utkarsh-611!) Fix notifications not working in background browser tabs Log WebSocket close code 1006 as info, not error (thanks @jbingen!) Fix replication deadlock on Storer crash (thanks @utkarsh-611!) Downgrade IDBNotFoundError to info log level (thanks @jbingen!) Fix type safety for default context/schema types Fix watermark errors when restoring from litestream backups Fix replica metadata being deleted during non-disruptive resync Fix occasional server crash when Postgres goes down Set idle transaction timeout to prevent hung transactions Fix lock errors under high CDC load Retry on change-db connection errors Detect publication differences during initial sync Prevent concurrent schema migrations from racing Fix stale destroy timers on query resubscribe (thanks @alpkaravil!) Add missing @types/ws dependency (thanks @YevheniiKotyrlo!) Fix constraints not detected when definition changes but name stays same Fix duplicate mutations when retry transaction succeeds Fix analyze-query crash with scalar subqueries Detect tables moved out of published schema Breaking Changes Just two very minor breaking changes this time, that are unlikely to affect most users: If you send custom headers to query or mutate endpoints, you must now allowlist them via ZERO_MUTATE_ALLOWED_CLIENT_HEADERS or ZERO_QUERY_ALLOWED_CLIENT_HEADERS. By default, no client-provided headers are forwarded. If you have very large mutations, note that WebSocket messages are now limited to 10MB by default. Increase ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES if needed.",
     "headings": [
       {
@@ -4653,50 +4653,50 @@
     "kind": "page"
   },
   {
-    "id": "368-release-notes/0.26#installation",
+    "id": "368-release-notes\\0.26#installation",
     "title": "Zero 0.26",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
     "sectionId": "installation",
-    "url": "/docs/release-notes/0.26",
+    "url": "/docs/release-notes\\0.26",
     "content": "npm install @rocicorp/zero@0.26",
     "kind": "section"
   },
   {
-    "id": "369-release-notes/0.26#features",
+    "id": "369-release-notes\\0.26#features",
     "title": "Zero 0.26",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.26",
+    "url": "/docs/release-notes\\0.26",
     "content": "Schema Backfill: Zero now natively supports adding columns with non-constant defaults, or adding existing columns to a custom publication. There is no longer a need to touch every row in the database to backfill data manually. Scalar Subqueries: Added a new optional optimization for exists queries that filter by related data with a one-to-one relationship. This can improve query performance significantly for cases where the subquery result changes rarely. Virtual Scroll: Added zero-virtual library for efficient infinite scrolling in React. Support for time and timetz columns: Added support for time and timetz columns (thanks GRBurst). Comparing to undefined: Added a new convenience for comparing to undefined. This is useful for filtering by nullable fields. zero.delete(): Added a more convenient way to delete all data from the browser's IndexedDB database.",
     "kind": "section"
   },
   {
-    "id": "370-release-notes/0.26#fixes",
+    "id": "370-release-notes\\0.26#fixes",
     "title": "Zero 0.26",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.26",
+    "url": "/docs/release-notes\\0.26",
     "content": "Updating auth tokens no cycles connection Add configurable back-pressure limit for change streamer Surface replication LSN at /statz?replication Generalize all statz output to be machine-readable Fix unique constraint violations during sync Fix zero-sqlite3 install script to work with bun Warn when mutations are rejected due to offline/error/closed state Fix queries being dropped when other queries with same hash expire Fix incorrect query results when filtering by undefined values Fix connection.connect() being ignored when in error/auth state Extra table name validation Redact sensitive info from logs Do not log mutation args Allow validation of JWT issuer and audience claims Protect against admin password timing attacks Forward origin header to API server Escape publication names Prevent denial of service attacks Fix race condition in notification handling Fix custom kvStoreProvider being ignored in React Native (thanks @kvnkusch!) Allow hybrid permissions with new queries in zero-cache-dev Fix unnecessary reconnection attempts after auth errors Fix \"database connection is not open\" error during shutdown Fix view-syncer crash from stale WebSocket messages Forward fresh auth token with each push message (thanks @jbingen!) Prevent IDB collection from deleting active databases Fix statz double close and ensure sqlite db handles are closed Fix OOM crashes when replicating databases with large rows Fix parsing of json[] and jsonb[] types Fix slow queries on tables with nullable unique columns Fix replication crash from closed WebSocket (thanks @utkarsh-611!) Fix notifications not working in background browser tabs Log WebSocket close code 1006 as info, not error (thanks @jbingen!) Fix replication deadlock on Storer crash (thanks @utkarsh-611!) Downgrade IDBNotFoundError to info log level (thanks @jbingen!) Fix type safety for default context/schema types Fix watermark errors when restoring from litestream backups Fix replica metadata being deleted during non-disruptive resync Fix occasional server crash when Postgres goes down Set idle transaction timeout to prevent hung transactions Fix lock errors under high CDC load Retry on change-db connection errors Detect publication differences during initial sync Prevent concurrent schema migrations from racing Fix stale destroy timers on query resubscribe (thanks @alpkaravil!) Add missing @types/ws dependency (thanks @YevheniiKotyrlo!) Fix constraints not detected when definition changes but name stays same Fix duplicate mutations when retry transaction succeeds Fix analyze-query crash with scalar subqueries Detect tables moved out of published schema",
     "kind": "section"
   },
   {
-    "id": "371-release-notes/0.26#breaking-changes",
+    "id": "371-release-notes\\0.26#breaking-changes",
     "title": "Zero 0.26",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.26",
+    "url": "/docs/release-notes\\0.26",
     "content": "Just two very minor breaking changes this time, that are unlikely to affect most users: If you send custom headers to query or mutate endpoints, you must now allowlist them via ZERO_MUTATE_ALLOWED_CLIENT_HEADERS or ZERO_QUERY_ALLOWED_CLIENT_HEADERS. By default, no client-provided headers are forwarded. If you have very large mutations, note that WebSocket messages are now limited to 10MB by default. Increase ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES if needed.",
     "kind": "section"
   },
   {
-    "id": "44-release-notes/0.3",
+    "id": "44-release-notes\\0.3",
     "title": "Zero 0.3",
     "searchTitle": "Zero 0.3",
-    "url": "/docs/release-notes/0.3",
+    "url": "/docs/release-notes\\0.3",
     "content": "Install npm install @rocicorp/zero@0.3 Breaking changes zero.config file is now TypeScript, not JSON. See: https://github.com/rocicorp/hello-zero/blob/07c08b1f86b526a96e281ee65af672f52a59bcee/zero.config.ts. Features Schema Migrations: Zero now has first-class support for schema migration (documentation). Write Permissions: First-class write permissions based on ZQL (documentation). Date/Time related types: Zero now natively supports the TIMESTAMP and DATE Postgres types (sample app, documentation). SolidJS: We now have first-class support for SolidJS (documentation). Intellisense for Schema Definition: Introduce createSchema and createTableSchema helper functions to enable intellisense when defining shemas. See Sample App. escapeLike() : Add helper to properly escape strings for use in LIKE filters. See Sample App. New QuickStart App: Entirely rewrote the setup/sample flow to (a) make it much faster to get started playing with Zero, and (b) demonstrate more features. Fixes The @rocicorp/zero package now downloads a prebuilt sqlite instead of compiling it locally. This significantly speeds up install. Support rds.force_ssl=1 RDS configuration. Fixed bug where sibling subqueries could be lost on edit changes. Fixes to error handling to ensure zero-cache prints errors when crashing in multiprocess mode. If zero-cache hears from a client with an unknown CVR/cookie, zero-cache forces that client to reset itself and reload automatically. Useful during development when server-state is frequently getting cleared. Docs Started work to make real docs. Not quite done yet. zbugs https://bugs.rocicorp.dev/ (pw: zql) Improve startup perf: ~3s → ~1.5s Hawaii ↔ US East. More work to do here but good progress. Responsive design for mobile. “Short IDs”: Bugs now have a short numeric ID, not a random hash. See Demo Video. First-class label picker. Unread indicators. Finish j/k support for paging through issues. It’s now “search-aware”, it pages through issues in order of search you clicked through to detail page in. Text search (slash to activate — needs better discoverability) Emojis on issues and comments Sort controls on list view remove fps meter temporarily numerous other UI polish",
     "headings": [
       {
@@ -4727,70 +4727,70 @@
     "kind": "page"
   },
   {
-    "id": "372-release-notes/0.3#install",
+    "id": "372-release-notes\\0.3#install",
     "title": "Zero 0.3",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.3",
+    "url": "/docs/release-notes\\0.3",
     "content": "npm install @rocicorp/zero@0.3",
     "kind": "section"
   },
   {
-    "id": "373-release-notes/0.3#breaking-changes",
+    "id": "373-release-notes\\0.3#breaking-changes",
     "title": "Zero 0.3",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.3",
+    "url": "/docs/release-notes\\0.3",
     "content": "zero.config file is now TypeScript, not JSON. See: https://github.com/rocicorp/hello-zero/blob/07c08b1f86b526a96e281ee65af672f52a59bcee/zero.config.ts.",
     "kind": "section"
   },
   {
-    "id": "374-release-notes/0.3#features",
+    "id": "374-release-notes\\0.3#features",
     "title": "Zero 0.3",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.3",
+    "url": "/docs/release-notes\\0.3",
     "content": "Schema Migrations: Zero now has first-class support for schema migration (documentation). Write Permissions: First-class write permissions based on ZQL (documentation). Date/Time related types: Zero now natively supports the TIMESTAMP and DATE Postgres types (sample app, documentation). SolidJS: We now have first-class support for SolidJS (documentation). Intellisense for Schema Definition: Introduce createSchema and createTableSchema helper functions to enable intellisense when defining shemas. See Sample App. escapeLike() : Add helper to properly escape strings for use in LIKE filters. See Sample App. New QuickStart App: Entirely rewrote the setup/sample flow to (a) make it much faster to get started playing with Zero, and (b) demonstrate more features.",
     "kind": "section"
   },
   {
-    "id": "375-release-notes/0.3#fixes",
+    "id": "375-release-notes\\0.3#fixes",
     "title": "Zero 0.3",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.3",
+    "url": "/docs/release-notes\\0.3",
     "content": "The @rocicorp/zero package now downloads a prebuilt sqlite instead of compiling it locally. This significantly speeds up install. Support rds.force_ssl=1 RDS configuration. Fixed bug where sibling subqueries could be lost on edit changes. Fixes to error handling to ensure zero-cache prints errors when crashing in multiprocess mode. If zero-cache hears from a client with an unknown CVR/cookie, zero-cache forces that client to reset itself and reload automatically. Useful during development when server-state is frequently getting cleared.",
     "kind": "section"
   },
   {
-    "id": "376-release-notes/0.3#docs",
+    "id": "376-release-notes\\0.3#docs",
     "title": "Zero 0.3",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
     "sectionId": "docs",
-    "url": "/docs/release-notes/0.3",
+    "url": "/docs/release-notes\\0.3",
     "content": "Started work to make real docs. Not quite done yet.",
     "kind": "section"
   },
   {
-    "id": "377-release-notes/0.3#zbugs",
+    "id": "377-release-notes\\0.3#zbugs",
     "title": "Zero 0.3",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
     "sectionId": "zbugs",
-    "url": "/docs/release-notes/0.3",
+    "url": "/docs/release-notes\\0.3",
     "content": "https://bugs.rocicorp.dev/ (pw: zql) Improve startup perf: ~3s → ~1.5s Hawaii ↔ US East. More work to do here but good progress. Responsive design for mobile. “Short IDs”: Bugs now have a short numeric ID, not a random hash. See Demo Video. First-class label picker. Unread indicators. Finish j/k support for paging through issues. It’s now “search-aware”, it pages through issues in order of search you clicked through to detail page in. Text search (slash to activate — needs better discoverability) Emojis on issues and comments Sort controls on list view remove fps meter temporarily numerous other UI polish",
     "kind": "section"
   },
   {
-    "id": "45-release-notes/0.4",
+    "id": "45-release-notes\\0.4",
     "title": "Zero 0.4",
     "searchTitle": "Zero 0.4",
-    "url": "/docs/release-notes/0.4",
+    "url": "/docs/release-notes\\0.4",
     "content": "Install npm install @rocicorp/zero@0.4 Breaking changes The or changes modified the client/server protocol. You’ll need to restart zero-cache and clear browser data after updating. Added or , and , and not to ZQL (documentation). Added query.run() method (documentation). Fixes Use batch() method in zero-solid to improve performance when multiple updates happen in same frame. To take advantage of this you must use the createZero helper from @rocicorp/zero/solid, instead of instantiating Zero directly. See the solid sample app. Postgres tables that were reserved words in SQLite but not Postgres caused crash during replication. LIKE was not matching correctly in the case of multiline subjects. Upstream database and zero database can now be same Postgres db (don’t need separate ports). Docs nothing notable zbugs Use or to run text search over both titles and bodies prevent j/k in emoji preload emojis",
     "headings": [
       {
@@ -4821,70 +4821,70 @@
     "kind": "page"
   },
   {
-    "id": "378-release-notes/0.4#install",
+    "id": "378-release-notes\\0.4#install",
     "title": "Zero 0.4",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.4",
+    "url": "/docs/release-notes\\0.4",
     "content": "npm install @rocicorp/zero@0.4",
     "kind": "section"
   },
   {
-    "id": "379-release-notes/0.4#breaking-changes",
+    "id": "379-release-notes\\0.4#breaking-changes",
     "title": "Zero 0.4",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.4",
+    "url": "/docs/release-notes\\0.4",
     "content": "The or changes modified the client/server protocol. You’ll need to restart zero-cache and clear browser data after updating.",
     "kind": "section"
   },
   {
-    "id": "380-release-notes/0.4#added-or--and--and-not-to-zql-documentation",
+    "id": "380-release-notes\\0.4#added-or--and--and-not-to-zql-documentation",
     "title": "Zero 0.4",
     "searchTitle": "Added or , and , and not to ZQL (documentation).",
     "sectionTitle": "Added or , and , and not to ZQL (documentation).",
     "sectionId": "added-or--and--and-not-to-zql-documentation",
-    "url": "/docs/release-notes/0.4",
+    "url": "/docs/release-notes\\0.4",
     "content": "Added query.run() method (documentation).",
     "kind": "section"
   },
   {
-    "id": "381-release-notes/0.4#fixes",
+    "id": "381-release-notes\\0.4#fixes",
     "title": "Zero 0.4",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.4",
+    "url": "/docs/release-notes\\0.4",
     "content": "Use batch() method in zero-solid to improve performance when multiple updates happen in same frame. To take advantage of this you must use the createZero helper from @rocicorp/zero/solid, instead of instantiating Zero directly. See the solid sample app. Postgres tables that were reserved words in SQLite but not Postgres caused crash during replication. LIKE was not matching correctly in the case of multiline subjects. Upstream database and zero database can now be same Postgres db (don’t need separate ports).",
     "kind": "section"
   },
   {
-    "id": "382-release-notes/0.4#docs",
+    "id": "382-release-notes\\0.4#docs",
     "title": "Zero 0.4",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
     "sectionId": "docs",
-    "url": "/docs/release-notes/0.4",
+    "url": "/docs/release-notes\\0.4",
     "content": "nothing notable",
     "kind": "section"
   },
   {
-    "id": "383-release-notes/0.4#zbugs",
+    "id": "383-release-notes\\0.4#zbugs",
     "title": "Zero 0.4",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
     "sectionId": "zbugs",
-    "url": "/docs/release-notes/0.4",
+    "url": "/docs/release-notes\\0.4",
     "content": "Use or to run text search over both titles and bodies prevent j/k in emoji preload emojis",
     "kind": "section"
   },
   {
-    "id": "46-release-notes/0.5",
+    "id": "46-release-notes\\0.5",
     "title": "Zero 0.5",
     "searchTitle": "Zero 0.5",
-    "url": "/docs/release-notes/0.5",
+    "url": "/docs/release-notes\\0.5",
     "content": "Install npm install @rocicorp/zero@0.5 Breaking changes createTableSchema and createSchema moved to @rocicorp/zero/schema subpackage. This is in preparation to moving authorization into the schema file. SchemaToRow helper type was renamed TableSchemaToRow and moved into @rocicorp/zero/schema. Basically: - import { createSchema, createTableSchema, SchemaToRow } from \"@rocicorp/zero\"; + import { createSchema, createTableSchema, TableSchemaToRow } from \"@rocicorp/zero/schema\"; Features Added support for JSON columns in Postgres (documentation). Zero pacakage now includes zero-sqlite3, which can be used to explore our sqlite files (documentation). Fixes We were not correctly replicating the char(n) type, despite documenting that we were. Docs nothing notable zbugs nothing notable",
     "headings": [
       {
@@ -4915,70 +4915,70 @@
     "kind": "page"
   },
   {
-    "id": "384-release-notes/0.5#install",
+    "id": "384-release-notes\\0.5#install",
     "title": "Zero 0.5",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.5",
+    "url": "/docs/release-notes\\0.5",
     "content": "npm install @rocicorp/zero@0.5",
     "kind": "section"
   },
   {
-    "id": "385-release-notes/0.5#breaking-changes",
+    "id": "385-release-notes\\0.5#breaking-changes",
     "title": "Zero 0.5",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.5",
+    "url": "/docs/release-notes\\0.5",
     "content": "createTableSchema and createSchema moved to @rocicorp/zero/schema subpackage. This is in preparation to moving authorization into the schema file. SchemaToRow helper type was renamed TableSchemaToRow and moved into @rocicorp/zero/schema. Basically: - import { createSchema, createTableSchema, SchemaToRow } from \"@rocicorp/zero\"; + import { createSchema, createTableSchema, TableSchemaToRow } from \"@rocicorp/zero/schema\";",
     "kind": "section"
   },
   {
-    "id": "386-release-notes/0.5#features",
+    "id": "386-release-notes\\0.5#features",
     "title": "Zero 0.5",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.5",
+    "url": "/docs/release-notes\\0.5",
     "content": "Added support for JSON columns in Postgres (documentation). Zero pacakage now includes zero-sqlite3, which can be used to explore our sqlite files (documentation).",
     "kind": "section"
   },
   {
-    "id": "387-release-notes/0.5#fixes",
+    "id": "387-release-notes\\0.5#fixes",
     "title": "Zero 0.5",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.5",
+    "url": "/docs/release-notes\\0.5",
     "content": "We were not correctly replicating the char(n) type, despite documenting that we were.",
     "kind": "section"
   },
   {
-    "id": "388-release-notes/0.5#docs",
+    "id": "388-release-notes\\0.5#docs",
     "title": "Zero 0.5",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
     "sectionId": "docs",
-    "url": "/docs/release-notes/0.5",
+    "url": "/docs/release-notes\\0.5",
     "content": "nothing notable",
     "kind": "section"
   },
   {
-    "id": "389-release-notes/0.5#zbugs",
+    "id": "389-release-notes\\0.5#zbugs",
     "title": "Zero 0.5",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
     "sectionId": "zbugs",
-    "url": "/docs/release-notes/0.5",
+    "url": "/docs/release-notes\\0.5",
     "content": "nothing notable",
     "kind": "section"
   },
   {
-    "id": "47-release-notes/0.6",
+    "id": "47-release-notes\\0.6",
     "title": "Zero 0.6",
     "searchTitle": "Zero 0.6",
-    "url": "/docs/release-notes/0.6",
+    "url": "/docs/release-notes\\0.6",
     "content": "Install npm install @rocicorp/zero@0.6 Upgrade Guide This release is a bit harder to upgrade to than previous alphas. For a step-by-step guide, please refer to the commits that upgrade the React and Solid quickstart apps: Upgrading hello-zero from Zero 0.5 to 0.6 Upgrading hello-zero-solid from Zero 0.5 to 0.6 Breaking Changes Totally new configuration system. zero.config.ts is no more – config is now via env vars (documentation). Permissions rules moved into schema (documentation). Renamed CRUD mutators to be consistent with SQL naming (bug, documentation). z.mutate.<table>.create -> insert z.mutate.<table>.put -> upsert Removed select from ZQL. It wasn’t doing anything (documentation) Moved batch mutation to its own mutateBatch method. Before the mutate field also doubled as a method. This made intellisense hard to understand since z.mutate had all the tables as fields but also all the fields of a function. Features Relationship filters. Queries can now include whereExists (bug, documentation). Reworked syntax for compound where filters, including ergonomically building or expressions with dynamic number of clauses (bug, documentation). Support using Postgres databases without superuser access for smaller apps (documentation). Support for running Zero client under Cloudflare Durable Objects (documentation). Reworked support for null / undefined to properly support optional fields (bug, documentation). Added IS / IS NOT to ZQL to support checking for null (bug, documentation). Improved intellisense for mutators. Added --port flag and ZERO_PORT environment variable (bug, documentation). Default max connections of zero-cache more conservatively so that it should fit with even common small Postgres configurations. zero-cache now accepts requests with any base path, not just /api. The server parameter to the Zero client constructor can now be a host (https://myapp-myteam.zero.ms) or a host with a single path component (https://myapp-myteam.zero.ms/zero). These two changes together allow hosting zero-cache on same domain with an app that already uses the /api prefix (bug). Allow Postgres columns with default values, but don’t sync them (documentation). The npx zero-sqlite utility now accepts all the same flags and arguments that sqlite3 does (documentation). zbugs Added tooltip describing who submitted which emoji reactions Updated implementation of label, assignee, and owner filters to use relationship filters Updated text filter implementation to use or to search description and comments too Docs Added new ZQL reference Added new mutators reference Added new config reference",
     "headings": [
       {
@@ -5009,70 +5009,70 @@
     "kind": "page"
   },
   {
-    "id": "390-release-notes/0.6#install",
+    "id": "390-release-notes\\0.6#install",
     "title": "Zero 0.6",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.6",
+    "url": "/docs/release-notes\\0.6",
     "content": "npm install @rocicorp/zero@0.6",
     "kind": "section"
   },
   {
-    "id": "391-release-notes/0.6#upgrade-guide",
+    "id": "391-release-notes\\0.6#upgrade-guide",
     "title": "Zero 0.6",
     "searchTitle": "Upgrade Guide",
     "sectionTitle": "Upgrade Guide",
     "sectionId": "upgrade-guide",
-    "url": "/docs/release-notes/0.6",
+    "url": "/docs/release-notes\\0.6",
     "content": "This release is a bit harder to upgrade to than previous alphas. For a step-by-step guide, please refer to the commits that upgrade the React and Solid quickstart apps: Upgrading hello-zero from Zero 0.5 to 0.6 Upgrading hello-zero-solid from Zero 0.5 to 0.6",
     "kind": "section"
   },
   {
-    "id": "392-release-notes/0.6#breaking-changes",
+    "id": "392-release-notes\\0.6#breaking-changes",
     "title": "Zero 0.6",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.6",
+    "url": "/docs/release-notes\\0.6",
     "content": "Totally new configuration system. zero.config.ts is no more – config is now via env vars (documentation). Permissions rules moved into schema (documentation). Renamed CRUD mutators to be consistent with SQL naming (bug, documentation). z.mutate.<table>.create -> insert z.mutate.<table>.put -> upsert Removed select from ZQL. It wasn’t doing anything (documentation) Moved batch mutation to its own mutateBatch method. Before the mutate field also doubled as a method. This made intellisense hard to understand since z.mutate had all the tables as fields but also all the fields of a function.",
     "kind": "section"
   },
   {
-    "id": "393-release-notes/0.6#features",
+    "id": "393-release-notes\\0.6#features",
     "title": "Zero 0.6",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.6",
+    "url": "/docs/release-notes\\0.6",
     "content": "Relationship filters. Queries can now include whereExists (bug, documentation). Reworked syntax for compound where filters, including ergonomically building or expressions with dynamic number of clauses (bug, documentation). Support using Postgres databases without superuser access for smaller apps (documentation). Support for running Zero client under Cloudflare Durable Objects (documentation). Reworked support for null / undefined to properly support optional fields (bug, documentation). Added IS / IS NOT to ZQL to support checking for null (bug, documentation). Improved intellisense for mutators. Added --port flag and ZERO_PORT environment variable (bug, documentation). Default max connections of zero-cache more conservatively so that it should fit with even common small Postgres configurations. zero-cache now accepts requests with any base path, not just /api. The server parameter to the Zero client constructor can now be a host (https://myapp-myteam.zero.ms) or a host with a single path component (https://myapp-myteam.zero.ms/zero). These two changes together allow hosting zero-cache on same domain with an app that already uses the /api prefix (bug). Allow Postgres columns with default values, but don’t sync them (documentation). The npx zero-sqlite utility now accepts all the same flags and arguments that sqlite3 does (documentation).",
     "kind": "section"
   },
   {
-    "id": "394-release-notes/0.6#zbugs",
+    "id": "394-release-notes\\0.6#zbugs",
     "title": "Zero 0.6",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
     "sectionId": "zbugs",
-    "url": "/docs/release-notes/0.6",
+    "url": "/docs/release-notes\\0.6",
     "content": "Added tooltip describing who submitted which emoji reactions Updated implementation of label, assignee, and owner filters to use relationship filters Updated text filter implementation to use or to search description and comments too",
     "kind": "section"
   },
   {
-    "id": "395-release-notes/0.6#docs",
+    "id": "395-release-notes\\0.6#docs",
     "title": "Zero 0.6",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
     "sectionId": "docs",
-    "url": "/docs/release-notes/0.6",
+    "url": "/docs/release-notes\\0.6",
     "content": "Added new ZQL reference Added new mutators reference Added new config reference",
     "kind": "section"
   },
   {
-    "id": "48-release-notes/0.7",
+    "id": "48-release-notes\\0.7",
     "title": "Zero 0.7",
     "searchTitle": "Zero 0.7",
-    "url": "/docs/release-notes/0.7",
+    "url": "/docs/release-notes\\0.7",
     "content": "Install npm install @rocicorp/zero@0.7 Features Read permissions. You can now control read access to data using ZQL (docs). Deployment. We now have a single-node Docker container (docs). Future work will add multinode support. Compound FKs. Zero already supported compound primary keys, but now it also supports compound foreign keys (docs). Schema DX: Columns types can use bare strings now if optional is not needed (example). PK can be a single string in the common case where it’s non-compound (example). Breaking Changes Several changes to schema.ts. See update to hello-zero for overview. Details: defineAuthorization was renamed to definedPermissions to avoid confusion with authentication. The way that many:many relationships are defined has changed to be more general and easy to remember. See example. The signature of definePermissions and the related rule functions have changed: Now rules return an expression instead of full query. This was required to make read permissions work and we did it for write permissions for consitency (see example). The update policy now has two child policies: preMutation and postMutation. The rules we used to have were preMutation. They run before a change and can be used to validate a user has permission to change a row. The postMutation rules run after and can be used to limit the changes a user is allowed to make. The schema.ts file should export an object having two fields: schema and permissions. The way that schema.ts is consumed has also changed. Rather than zero-cache directly reading the typescript source, we compile it to JSON and read that. ZERO_SCHEMA_FILE should now point to a JSON file, not .ts. It defaults to ./zero-schema.json which we’ve found to be pretty useful so you’ll probably just remove this key from your .env entirely. Use npx zero-build-schema to generate the JSON. You must currently do this manually each time you change the schema, we will automate it soon. We compile the schema to JSON so that we can use it on the server without needing a TS toolchain there. Also so that we can run a SaaS in the future without needing to run user code. zbugs Comments now have permalinks. Implementing permalinks in a synced SPA is fun! Private issues. Zbugs now supports private (to team only) issues. I wonder what’s in them … 👀. Docs The docs have moved. Please don’t use Notion anymore, they won’t be updated.",
     "headings": [
       {
@@ -5099,60 +5099,60 @@
     "kind": "page"
   },
   {
-    "id": "396-release-notes/0.7#install",
+    "id": "396-release-notes\\0.7#install",
     "title": "Zero 0.7",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.7",
+    "url": "/docs/release-notes\\0.7",
     "content": "npm install @rocicorp/zero@0.7",
     "kind": "section"
   },
   {
-    "id": "397-release-notes/0.7#features",
+    "id": "397-release-notes\\0.7#features",
     "title": "Zero 0.7",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.7",
+    "url": "/docs/release-notes\\0.7",
     "content": "Read permissions. You can now control read access to data using ZQL (docs). Deployment. We now have a single-node Docker container (docs). Future work will add multinode support. Compound FKs. Zero already supported compound primary keys, but now it also supports compound foreign keys (docs). Schema DX: Columns types can use bare strings now if optional is not needed (example). PK can be a single string in the common case where it’s non-compound (example).",
     "kind": "section"
   },
   {
-    "id": "398-release-notes/0.7#breaking-changes",
+    "id": "398-release-notes\\0.7#breaking-changes",
     "title": "Zero 0.7",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.7",
+    "url": "/docs/release-notes\\0.7",
     "content": "Several changes to schema.ts. See update to hello-zero for overview. Details: defineAuthorization was renamed to definedPermissions to avoid confusion with authentication. The way that many:many relationships are defined has changed to be more general and easy to remember. See example. The signature of definePermissions and the related rule functions have changed: Now rules return an expression instead of full query. This was required to make read permissions work and we did it for write permissions for consitency (see example). The update policy now has two child policies: preMutation and postMutation. The rules we used to have were preMutation. They run before a change and can be used to validate a user has permission to change a row. The postMutation rules run after and can be used to limit the changes a user is allowed to make. The schema.ts file should export an object having two fields: schema and permissions. The way that schema.ts is consumed has also changed. Rather than zero-cache directly reading the typescript source, we compile it to JSON and read that. ZERO_SCHEMA_FILE should now point to a JSON file, not .ts. It defaults to ./zero-schema.json which we’ve found to be pretty useful so you’ll probably just remove this key from your .env entirely. Use npx zero-build-schema to generate the JSON. You must currently do this manually each time you change the schema, we will automate it soon. We compile the schema to JSON so that we can use it on the server without needing a TS toolchain there. Also so that we can run a SaaS in the future without needing to run user code.",
     "kind": "section"
   },
   {
-    "id": "399-release-notes/0.7#zbugs",
+    "id": "399-release-notes\\0.7#zbugs",
     "title": "Zero 0.7",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
     "sectionId": "zbugs",
-    "url": "/docs/release-notes/0.7",
+    "url": "/docs/release-notes\\0.7",
     "content": "Comments now have permalinks. Implementing permalinks in a synced SPA is fun! Private issues. Zbugs now supports private (to team only) issues. I wonder what’s in them … 👀.",
     "kind": "section"
   },
   {
-    "id": "400-release-notes/0.7#docs",
+    "id": "400-release-notes\\0.7#docs",
     "title": "Zero 0.7",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
     "sectionId": "docs",
-    "url": "/docs/release-notes/0.7",
+    "url": "/docs/release-notes\\0.7",
     "content": "The docs have moved. Please don’t use Notion anymore, they won’t be updated.",
     "kind": "section"
   },
   {
-    "id": "49-release-notes/0.8",
+    "id": "49-release-notes\\0.8",
     "title": "Zero 0.8",
     "searchTitle": "Zero 0.8",
-    "url": "/docs/release-notes/0.8",
+    "url": "/docs/release-notes\\0.8",
     "content": "Install npm install @rocicorp/zero@0.8 See the changes to hello-zero or hello-zero-solid for example updates. Features Schema Autobuild. There's now a zero-cache-dev script that automatically rebuilds the schema and restarts zero-cache on changes to schema.ts. (docs) Result Type. You can now tell whether a query is complete or partial. (docs) Enums. Enums are now supported in Postgres schemas and on client. (docs) Custom Types. You can define custom JSON types in your schema. (docs) OTEL Tracing. Initial tracing support. (docs) timestampz. Add support for timestampz Postgres column type. (docs) SSLMode. You can disable TLS when zero-cache connects to DB with sslmode=disable. (docs) Permission Helpers. ANYONE_CAN and NOBODY_CAN helpers were added to make these cases more readable. (docs) Multitenant Support. A single zero-cache can now front separate Postgres databases. This is useful for customers that have one \"dev\" database in production per-developer. (docs) Fixes Crash with JSON Columns. Fixed a crash when a JSON column was used in a Zero app with write permissions (bug) Better Connection Error Reporting. Some connection errors would cause zero-cache to exit silently. Now they are returned to client and logged. Breaking Changes useQuery in React now returns a 2-tuple of [rows, result] where result is an object with a type field. postProposedMutation in write permissions for update renamed to postMutation for consistency. TableScheamToRow renamed to Row to not be so silly long.",
     "headings": [
       {
@@ -5175,50 +5175,50 @@
     "kind": "page"
   },
   {
-    "id": "401-release-notes/0.8#install",
+    "id": "401-release-notes\\0.8#install",
     "title": "Zero 0.8",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.8",
+    "url": "/docs/release-notes\\0.8",
     "content": "npm install @rocicorp/zero@0.8 See the changes to hello-zero or hello-zero-solid for example updates.",
     "kind": "section"
   },
   {
-    "id": "402-release-notes/0.8#features",
+    "id": "402-release-notes\\0.8#features",
     "title": "Zero 0.8",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.8",
+    "url": "/docs/release-notes\\0.8",
     "content": "Schema Autobuild. There's now a zero-cache-dev script that automatically rebuilds the schema and restarts zero-cache on changes to schema.ts. (docs) Result Type. You can now tell whether a query is complete or partial. (docs) Enums. Enums are now supported in Postgres schemas and on client. (docs) Custom Types. You can define custom JSON types in your schema. (docs) OTEL Tracing. Initial tracing support. (docs) timestampz. Add support for timestampz Postgres column type. (docs) SSLMode. You can disable TLS when zero-cache connects to DB with sslmode=disable. (docs) Permission Helpers. ANYONE_CAN and NOBODY_CAN helpers were added to make these cases more readable. (docs) Multitenant Support. A single zero-cache can now front separate Postgres databases. This is useful for customers that have one \"dev\" database in production per-developer. (docs)",
     "kind": "section"
   },
   {
-    "id": "403-release-notes/0.8#fixes",
+    "id": "403-release-notes\\0.8#fixes",
     "title": "Zero 0.8",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.8",
+    "url": "/docs/release-notes\\0.8",
     "content": "Crash with JSON Columns. Fixed a crash when a JSON column was used in a Zero app with write permissions (bug) Better Connection Error Reporting. Some connection errors would cause zero-cache to exit silently. Now they are returned to client and logged.",
     "kind": "section"
   },
   {
-    "id": "404-release-notes/0.8#breaking-changes",
+    "id": "404-release-notes\\0.8#breaking-changes",
     "title": "Zero 0.8",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.8",
+    "url": "/docs/release-notes\\0.8",
     "content": "useQuery in React now returns a 2-tuple of [rows, result] where result is an object with a type field. postProposedMutation in write permissions for update renamed to postMutation for consistency. TableScheamToRow renamed to Row to not be so silly long.",
     "kind": "section"
   },
   {
-    "id": "50-release-notes/0.9",
+    "id": "50-release-notes\\0.9",
     "title": "Zero 0.9",
     "searchTitle": "Zero 0.9",
-    "url": "/docs/release-notes/0.9",
+    "url": "/docs/release-notes\\0.9",
     "content": "Install npm install @rocicorp/zero@0.9 See the changes to hello-zero or hello-zero-solid for example updates. Features JWK Support. For auth, you can now specify a JWK containing a public key, or a JWKS url to support autodiscovery of keys. (docs) UUID column. Zero now supports the uuid Postgres column type. (docs) Fixes Readonly Values. Type of values returned from Zero queries are marked readonly. The system always considered them readonly, but now the types reflect that. (docs) Breaking Changes The zero-cache config ZERO_JWT_SECRET has been renamed to ZERO_AUTH_SECRET for consistency with the new JWK-related keys. If you were using the old name, you'll need to update your .env file. All values returned by Zero are now readonly. You'll probably have to add this TS modifier various places. If you find yourself casting away readonly you probably should be cloing the value instead.",
     "headings": [
       {
@@ -5241,50 +5241,50 @@
     "kind": "page"
   },
   {
-    "id": "405-release-notes/0.9#install",
+    "id": "405-release-notes\\0.9#install",
     "title": "Zero 0.9",
     "searchTitle": "Install",
     "sectionTitle": "Install",
     "sectionId": "install",
-    "url": "/docs/release-notes/0.9",
+    "url": "/docs/release-notes\\0.9",
     "content": "npm install @rocicorp/zero@0.9 See the changes to hello-zero or hello-zero-solid for example updates.",
     "kind": "section"
   },
   {
-    "id": "406-release-notes/0.9#features",
+    "id": "406-release-notes\\0.9#features",
     "title": "Zero 0.9",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/0.9",
+    "url": "/docs/release-notes\\0.9",
     "content": "JWK Support. For auth, you can now specify a JWK containing a public key, or a JWKS url to support autodiscovery of keys. (docs) UUID column. Zero now supports the uuid Postgres column type. (docs)",
     "kind": "section"
   },
   {
-    "id": "407-release-notes/0.9#fixes",
+    "id": "407-release-notes\\0.9#fixes",
     "title": "Zero 0.9",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/0.9",
+    "url": "/docs/release-notes\\0.9",
     "content": "Readonly Values. Type of values returned from Zero queries are marked readonly. The system always considered them readonly, but now the types reflect that. (docs)",
     "kind": "section"
   },
   {
-    "id": "408-release-notes/0.9#breaking-changes",
+    "id": "408-release-notes\\0.9#breaking-changes",
     "title": "Zero 0.9",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/0.9",
+    "url": "/docs/release-notes\\0.9",
     "content": "The zero-cache config ZERO_JWT_SECRET has been renamed to ZERO_AUTH_SECRET for consistency with the new JWK-related keys. If you were using the old name, you'll need to update your .env file. All values returned by Zero are now readonly. You'll probably have to add this TS modifier various places. If you find yourself casting away readonly you probably should be cloing the value instead.",
     "kind": "section"
   },
   {
-    "id": "51-release-notes/1.0",
+    "id": "51-release-notes\\1.0",
     "title": "Zero 1.0",
     "searchTitle": "Zero 1.0",
-    "url": "/docs/release-notes/1.0",
+    "url": "/docs/release-notes\\1.0",
     "content": "Installation npm install @rocicorp/zero@1.0 Overview After nearly two years of development, 50+ releases, thousands of commits, and hundreds of bugfixes, we are declaring Zero stable. This means we fully support the Zero API and are committed to maintaining it. There may still be breaking changes in the future, but they will be rare and much smaller than they have been until now. Functionally, this release is a very minor update to 0.26.2. The major version bump is symbolic – there are no actual breaking changes. Features Schema Change Hooks: Added support for detecting publication changes on Supabase via COMMENT ON PUBLICATION statements, working around Supabase's lack of event trigger support for publications. Fixes Handle corrupted litestream restores Fix error handling when CDC is unhealthy Fix IPC_CHANNEL_CLOSED race condition during shutdown Fix orphaned subscriber scenarios Fix time/timetz SQL generation and type handling Breaking Changes None.",
     "headings": [
       {
@@ -5311,60 +5311,60 @@
     "kind": "page"
   },
   {
-    "id": "409-release-notes/1.0#installation",
+    "id": "409-release-notes\\1.0#installation",
     "title": "Zero 1.0",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
     "sectionId": "installation",
-    "url": "/docs/release-notes/1.0",
+    "url": "/docs/release-notes\\1.0",
     "content": "npm install @rocicorp/zero@1.0",
     "kind": "section"
   },
   {
-    "id": "410-release-notes/1.0#overview",
+    "id": "410-release-notes\\1.0#overview",
     "title": "Zero 1.0",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
     "sectionId": "overview",
-    "url": "/docs/release-notes/1.0",
+    "url": "/docs/release-notes\\1.0",
     "content": "After nearly two years of development, 50+ releases, thousands of commits, and hundreds of bugfixes, we are declaring Zero stable. This means we fully support the Zero API and are committed to maintaining it. There may still be breaking changes in the future, but they will be rare and much smaller than they have been until now. Functionally, this release is a very minor update to 0.26.2. The major version bump is symbolic – there are no actual breaking changes.",
     "kind": "section"
   },
   {
-    "id": "411-release-notes/1.0#features",
+    "id": "411-release-notes\\1.0#features",
     "title": "Zero 1.0",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/1.0",
+    "url": "/docs/release-notes\\1.0",
     "content": "Schema Change Hooks: Added support for detecting publication changes on Supabase via COMMENT ON PUBLICATION statements, working around Supabase's lack of event trigger support for publications.",
     "kind": "section"
   },
   {
-    "id": "412-release-notes/1.0#fixes",
+    "id": "412-release-notes\\1.0#fixes",
     "title": "Zero 1.0",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/1.0",
+    "url": "/docs/release-notes\\1.0",
     "content": "Handle corrupted litestream restores Fix error handling when CDC is unhealthy Fix IPC_CHANNEL_CLOSED race condition during shutdown Fix orphaned subscriber scenarios Fix time/timetz SQL generation and type handling",
     "kind": "section"
   },
   {
-    "id": "413-release-notes/1.0#breaking-changes",
+    "id": "413-release-notes\\1.0#breaking-changes",
     "title": "Zero 1.0",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/1.0",
+    "url": "/docs/release-notes\\1.0",
     "content": "None.",
     "kind": "section"
   },
   {
-    "id": "52-release-notes/1.1",
+    "id": "52-release-notes\\1.1",
     "title": "Zero 1.1",
     "searchTitle": "Zero 1.1",
-    "url": "/docs/release-notes/1.1",
+    "url": "/docs/release-notes\\1.1",
     "content": "Installation npm install @rocicorp/zero@1.1 Features Replication Lag Metrics: Added new OpenTelemetry metric zero.replication.total_lag to monitor replication lag. Fixes Fix reads disrupting replica initialization Breaking Changes None.",
     "headings": [
       {
@@ -5387,50 +5387,50 @@
     "kind": "page"
   },
   {
-    "id": "414-release-notes/1.1#installation",
+    "id": "414-release-notes\\1.1#installation",
     "title": "Zero 1.1",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
     "sectionId": "installation",
-    "url": "/docs/release-notes/1.1",
+    "url": "/docs/release-notes\\1.1",
     "content": "npm install @rocicorp/zero@1.1",
     "kind": "section"
   },
   {
-    "id": "415-release-notes/1.1#features",
+    "id": "415-release-notes\\1.1#features",
     "title": "Zero 1.1",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/1.1",
+    "url": "/docs/release-notes\\1.1",
     "content": "Replication Lag Metrics: Added new OpenTelemetry metric zero.replication.total_lag to monitor replication lag.",
     "kind": "section"
   },
   {
-    "id": "416-release-notes/1.1#fixes",
+    "id": "416-release-notes\\1.1#fixes",
     "title": "Zero 1.1",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/1.1",
+    "url": "/docs/release-notes\\1.1",
     "content": "Fix reads disrupting replica initialization",
     "kind": "section"
   },
   {
-    "id": "417-release-notes/1.1#breaking-changes",
+    "id": "417-release-notes\\1.1#breaking-changes",
     "title": "Zero 1.1",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/1.1",
+    "url": "/docs/release-notes\\1.1",
     "content": "None.",
     "kind": "section"
   },
   {
-    "id": "53-release-notes/1.2",
+    "id": "53-release-notes\\1.2",
     "title": "Zero 1.2",
     "searchTitle": "Zero 1.2",
-    "url": "/docs/release-notes/1.2",
+    "url": "/docs/release-notes\\1.2",
     "content": "Installation npm install @rocicorp/zero@1.2 Features Replica metrics: Added new replica metrics group to otel, with db_size, wal_size, and backup_lag metrics. Performance Optimizations which improve query performance 10–30% in benchmarks: Added fast-path to compare-utf8 for BMP-only strings (thanks @Karavil!) Replaced closure-based BTree iterators with class instances (thanks @Karavil!) Eliminated per-call object allocations in binary search Reuse comparators instead of allocating closures Fixes Fix timestamp handling for BC dates and years outside 0-9999 Fix crash with fractional timestamp values in queries Fix \"Constraint should match partition key\" error` Fix custom push URL not being used for _zero_cleanupResults Fix \"unknown table\" error when adding related() to existing query Downgrade TTL clock update failure to warning Bump litestream to v0.0.9 with S3 retry fixes Breaking Changes None.",
     "headings": [
       {
@@ -5457,60 +5457,60 @@
     "kind": "page"
   },
   {
-    "id": "418-release-notes/1.2#installation",
+    "id": "418-release-notes\\1.2#installation",
     "title": "Zero 1.2",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
     "sectionId": "installation",
-    "url": "/docs/release-notes/1.2",
+    "url": "/docs/release-notes\\1.2",
     "content": "npm install @rocicorp/zero@1.2",
     "kind": "section"
   },
   {
-    "id": "419-release-notes/1.2#features",
+    "id": "419-release-notes\\1.2#features",
     "title": "Zero 1.2",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/1.2",
+    "url": "/docs/release-notes\\1.2",
     "content": "Replica metrics: Added new replica metrics group to otel, with db_size, wal_size, and backup_lag metrics.",
     "kind": "section"
   },
   {
-    "id": "420-release-notes/1.2#performance",
+    "id": "420-release-notes\\1.2#performance",
     "title": "Zero 1.2",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
     "sectionId": "performance",
-    "url": "/docs/release-notes/1.2",
+    "url": "/docs/release-notes\\1.2",
     "content": "Optimizations which improve query performance 10–30% in benchmarks: Added fast-path to compare-utf8 for BMP-only strings (thanks @Karavil!) Replaced closure-based BTree iterators with class instances (thanks @Karavil!) Eliminated per-call object allocations in binary search Reuse comparators instead of allocating closures",
     "kind": "section"
   },
   {
-    "id": "421-release-notes/1.2#fixes",
+    "id": "421-release-notes\\1.2#fixes",
     "title": "Zero 1.2",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/1.2",
+    "url": "/docs/release-notes\\1.2",
     "content": "Fix timestamp handling for BC dates and years outside 0-9999 Fix crash with fractional timestamp values in queries Fix \"Constraint should match partition key\" error` Fix custom push URL not being used for _zero_cleanupResults Fix \"unknown table\" error when adding related() to existing query Downgrade TTL clock update failure to warning Bump litestream to v0.0.9 with S3 retry fixes",
     "kind": "section"
   },
   {
-    "id": "422-release-notes/1.2#breaking-changes",
+    "id": "422-release-notes\\1.2#breaking-changes",
     "title": "Zero 1.2",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/1.2",
+    "url": "/docs/release-notes\\1.2",
     "content": "None.",
     "kind": "section"
   },
   {
-    "id": "54-release-notes/1.3",
+    "id": "54-release-notes\\1.3",
     "title": "Zero 1.3",
     "searchTitle": "Zero 1.3",
-    "url": "/docs/release-notes/1.3",
+    "url": "/docs/release-notes\\1.3",
     "content": "Installation npm install @rocicorp/zero@1.3 Features Distributed Tracing: Clients can now pass OpenTelemetry trace context to zero-cache via a getTraceparent callback, enabling end-to-end trace correlation from your frontend through zero-cache to your API server. Sync Metrics: Added five new OTel metrics for sync worker visibility: zero.sync.active-client-groups, zero.sync.queries, zero.sync.rows, zero.sync.lock-wait-time, and zero.sync.pipeline-resets. Performance 2x faster initial sync by switching to binary COPY protocol 20-30% faster updates by optimizing compareValues and makeBoundComparator Fixes Auth token and cookie not sent for cleanup pushes Hang during initial sync when no upstream changes occurred after backfill Publication validation not detecting UPDATE privilege changes Spurious error logs from background Postgres connection warmup Breaking Changes None.",
     "headings": [
       {
@@ -5537,60 +5537,60 @@
     "kind": "page"
   },
   {
-    "id": "423-release-notes/1.3#installation",
+    "id": "423-release-notes\\1.3#installation",
     "title": "Zero 1.3",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
     "sectionId": "installation",
-    "url": "/docs/release-notes/1.3",
+    "url": "/docs/release-notes\\1.3",
     "content": "npm install @rocicorp/zero@1.3",
     "kind": "section"
   },
   {
-    "id": "424-release-notes/1.3#features",
+    "id": "424-release-notes\\1.3#features",
     "title": "Zero 1.3",
     "searchTitle": "Features",
     "sectionTitle": "Features",
     "sectionId": "features",
-    "url": "/docs/release-notes/1.3",
+    "url": "/docs/release-notes\\1.3",
     "content": "Distributed Tracing: Clients can now pass OpenTelemetry trace context to zero-cache via a getTraceparent callback, enabling end-to-end trace correlation from your frontend through zero-cache to your API server. Sync Metrics: Added five new OTel metrics for sync worker visibility: zero.sync.active-client-groups, zero.sync.queries, zero.sync.rows, zero.sync.lock-wait-time, and zero.sync.pipeline-resets.",
     "kind": "section"
   },
   {
-    "id": "425-release-notes/1.3#performance",
+    "id": "425-release-notes\\1.3#performance",
     "title": "Zero 1.3",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
     "sectionId": "performance",
-    "url": "/docs/release-notes/1.3",
+    "url": "/docs/release-notes\\1.3",
     "content": "2x faster initial sync by switching to binary COPY protocol 20-30% faster updates by optimizing compareValues and makeBoundComparator",
     "kind": "section"
   },
   {
-    "id": "426-release-notes/1.3#fixes",
+    "id": "426-release-notes\\1.3#fixes",
     "title": "Zero 1.3",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
-    "url": "/docs/release-notes/1.3",
+    "url": "/docs/release-notes\\1.3",
     "content": "Auth token and cookie not sent for cleanup pushes Hang during initial sync when no upstream changes occurred after backfill Publication validation not detecting UPDATE privilege changes Spurious error logs from background Postgres connection warmup",
     "kind": "section"
   },
   {
-    "id": "427-release-notes/1.3#breaking-changes",
+    "id": "427-release-notes\\1.3#breaking-changes",
     "title": "Zero 1.3",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
-    "url": "/docs/release-notes/1.3",
+    "url": "/docs/release-notes\\1.3",
     "content": "None.",
     "kind": "section"
   },
   {
-    "id": "55-release-notes",
+    "id": "55-release-notes\\index",
     "title": "Release Notes",
     "searchTitle": "Release Notes",
-    "url": "/docs/release-notes",
+    "url": "/docs/release-notes\\index",
     "content": "Zero 1.3: Faster Initial Sync and Other Perf Improvements Zero 1.2: IVM Performance and Bug Fixes Zero 1.1: Replication Monitoring Zero 1.0: First Stable Release Zero 0.26: Schema Backfill and Scalar Subqueries Zero 0.25: DX Overhaul, Query Planning Zero 0.24: Join Flipping, Cookie Auth, Inspector Updates Zero 0.23: Synced Queries and React Native Support Zero 0.22: Simplified TTLs Zero 0.21: PG arrays, TanStack starter, and more Zero 0.20: Full Supabase support, performance improvements Zero 0.19: Many, many bugfixes and cleanups Zero 0.18: Custom Mutators Zero 0.17: Background Queries Zero 0.16: Lambda-Based Permission Deployment Zero 0.15: Live Permission Updates Zero 0.14: Name Mapping and Multischema Zero 0.13: Multinode and SST Zero 0.12: Circular Relationships Zero 0.11: Windows Zero 0.10: Remove Top-Level Await Zero 0.9: JWK Support Zero 0.8: Schema Autobuild, Result Types, and Enums Zero 0.7: Read Perms and Docker Zero 0.6: Relationship Filters Zero 0.5: JSON Columns Zero 0.4: Compound Filters Zero 0.3: Schema Migrations and Write Perms Zero 0.2: Skip Mode and Computed PKs Zero 0.1: First Release",
     "headings": [],
     "kind": "page"
@@ -6446,7 +6446,7 @@
     "title": "When To Use Zero",
     "searchTitle": "When To Use Zero",
     "url": "/docs/when-to-use",
-    "content": "Every tool has tradeoffs. This page will help you understand if Zero is a good fit for what you're building. Zero Might be a Good Fit You want to sync only a small subset of data to client Zero's query-driven sync is a powerful solution for partial sync. You can define the data you want to sync with a set of Zero queries. By using partial sync, Zero apps can commonly load in < 1s, yet still maintain the interaction perf of sync. You need fine-grained read or write permissions Zero's mutators allow you to run arbitrary authorization, validation, or business logic on the write path. You can enforce that a write depends on what group a user is in, what has been shared with them, their role, etc. Read permissions are very expressive, allowing similar control over what data is synced to the client. You are building a traditional client-server web app Zero was designed from the ground up to be as close to a classic web app as a sync engine can be. If you have a traditional web app, you can try Zero side-by-side with your existing REST or GraphQL API, and incrementally migrate over time. You use PostgreSQL Some tools in our space require you to use a non-standard backend database or data model. Zero works with PostgreSQL, and uses your existing schema. Your app is broadly \"like Linear\" Zero is currently best suited for productivity apps with lots of interactivity. Interaction performance is very important to you Zero was built by people obsessed with interaction performance. If you share this goal you'll be going with the grain of Zero's design choices. Zero Might Not be a Good Fit You need the privacy or data ownership benefits of local-first Zero is not local-first. It's a client-server system with an authoritative server. You need to support offline writes or long periods offline Zero doesn't support offline writes. You are building a native mobile app Zero is written in TypeScript and only supports TypeScript clients. The total backend dataset is > ~100GB Zero stores a replica of your database (at least the subset you want to be syncable to clients) in a SQLite database owned by zero-cache. Zero's query engine is built assuming very fast local access to this replica (i.e., attached NVMe). But other setups are technically supported and work for smaller data. The ultimate size limit on the database that Zero can work with is the size limit of this SQLite database. So up to 45TB on EC2 at time of writing. However, most of our customers today use Zero with smaller datasets. We currently recommend Zero for use with datasets less than 100GB. If you to work with larger datasets, please reach out and we can talk it through with you. Zero Might Not be a Good Fit Yet Please see our roadmap for high-priority upcoming Zero features. Alternatives If Zero isn't right for you, here are some good alternatives to consider: Automerge: Local-first, CRDT-based solution. Pioneering branch-based offline support. Convex: Not a sync engine (reads and writes are server-first), but a very nice reactive database that is in GA. Ditto: CRDT-based, with high quality offline support. Electric: Postgres-based sync engine with a SaaS cloud. LiveStore: Interesting event sourced design from one of the founders of Prisma. Jazz: Batteries-included local-first. PowerSync: Sync engine that works with Postgres, MySQL, and MongoDB.",
+    "content": "Every tool has tradeoffs. This page will help you understand if Zero is a good fit for what you're building. Zero Might be a Good Fit You want to sync only a small subset of data to client Zero's query-driven sync is a powerful solution for partial sync. You can define the data you want to sync with a set of Zero queries. By using partial sync, Zero apps can commonly load in < 1s, yet still maintain the interaction perf of sync. You need fine-grained read or write permissions Zero's mutators allow you to run arbitrary authorization, validation, or business logic on the write path. You can enforce that a write depends on what group a user is in, what has been shared with them, their role, etc. Read permissions are very expressive, allowing similar control over what data is synced to the client. You are building a traditional client-server web app Zero was designed from the ground up to be as close to a classic web app as a sync engine can be. If you have a traditional web app, you can try Zero side-by-side with your existing REST or GraphQL API, and incrementally migrate over time. You use PostgreSQL Some tools in our space require you to use a non-standard backend database or data model. Zero works with PostgreSQL, and uses your existing schema. Your app is broadly \"like Linear\" Zero is currently best suited for productivity apps with lots of interactivity. Interaction performance is very important to you Zero was built by people obsessed with interaction performance. If you share this goal you'll be going with the grain of Zero's design choices. Zero Might Not be a Good Fit You need the privacy or data ownership benefits of local-first Zero is not local-first. It's a client-server system with an authoritative server. You need to support offline writes or long periods offline Zero doesn't support offline writes. You are building a native mobile app Zero is written in TypeScript and only supports TypeScript clients. The total backend dataset is > ~100GB Zero stores a replica of your database (at least the subset you want to be syncable to clients) in a SQLite database owned by zero-cache. Zero's query engine is built assuming very fast local access to this replica (i.e., attached NVMe). But other setups are technically supported and work for smaller data. The ultimate size limit on the database that Zero can work with is the size limit of this SQLite database. So up to 45TB on EC2 at time of writing. However, most of our customers today use Zero with smaller datasets. We currently recommend Zero for use with datasets less than 100GB. If you want to work with larger datasets, please reach out and we can talk it through with you. Zero Might Not be a Good Fit Yet Please see our roadmap for high-priority upcoming Zero features. Alternatives If Zero isn't right for you, here are some good alternatives to consider: Automerge: Local-first, CRDT-based solution. Pioneering branch-based offline support. Convex: Not a sync engine (reads and writes are server-first), but a very nice reactive database that is in GA. Ditto: CRDT-based, with high quality offline support. Electric: Postgres-based sync engine with a SaaS cloud. LiveStore: Interesting event sourced design from one of the founders of Prisma. Jazz: Batteries-included local-first. PowerSync: Sync engine that works with Postgres, MySQL, and MongoDB.",
     "headings": [
       {
         "text": "Zero Might be a Good Fit",
@@ -6584,7 +6584,7 @@
     "sectionTitle": "Zero Might Not be a Good Fit",
     "sectionId": "zero-might-not-be-a-good-fit",
     "url": "/docs/when-to-use",
-    "content": "You need the privacy or data ownership benefits of local-first Zero is not local-first. It's a client-server system with an authoritative server. You need to support offline writes or long periods offline Zero doesn't support offline writes. You are building a native mobile app Zero is written in TypeScript and only supports TypeScript clients. The total backend dataset is > ~100GB Zero stores a replica of your database (at least the subset you want to be syncable to clients) in a SQLite database owned by zero-cache. Zero's query engine is built assuming very fast local access to this replica (i.e., attached NVMe). But other setups are technically supported and work for smaller data. The ultimate size limit on the database that Zero can work with is the size limit of this SQLite database. So up to 45TB on EC2 at time of writing. However, most of our customers today use Zero with smaller datasets. We currently recommend Zero for use with datasets less than 100GB. If you to work with larger datasets, please reach out and we can talk it through with you.",
+    "content": "You need the privacy or data ownership benefits of local-first Zero is not local-first. It's a client-server system with an authoritative server. You need to support offline writes or long periods offline Zero doesn't support offline writes. You are building a native mobile app Zero is written in TypeScript and only supports TypeScript clients. The total backend dataset is > ~100GB Zero stores a replica of your database (at least the subset you want to be syncable to clients) in a SQLite database owned by zero-cache. Zero's query engine is built assuming very fast local access to this replica (i.e., attached NVMe). But other setups are technically supported and work for smaller data. The ultimate size limit on the database that Zero can work with is the size limit of this SQLite database. So up to 45TB on EC2 at time of writing. However, most of our customers today use Zero with smaller datasets. We currently recommend Zero for use with datasets less than 100GB. If you want to work with larger datasets, please reach out and we can talk it through with you.",
     "kind": "section"
   },
   {
@@ -6624,7 +6624,7 @@
     "sectionTitle": "The total backend dataset is > ~100GB",
     "sectionId": "the-total-backend-dataset-is--100gb",
     "url": "/docs/when-to-use",
-    "content": "Zero stores a replica of your database (at least the subset you want to be syncable to clients) in a SQLite database owned by zero-cache. Zero's query engine is built assuming very fast local access to this replica (i.e., attached NVMe). But other setups are technically supported and work for smaller data. The ultimate size limit on the database that Zero can work with is the size limit of this SQLite database. So up to 45TB on EC2 at time of writing. However, most of our customers today use Zero with smaller datasets. We currently recommend Zero for use with datasets less than 100GB. If you to work with larger datasets, please reach out and we can talk it through with you.",
+    "content": "Zero stores a replica of your database (at least the subset you want to be syncable to clients) in a SQLite database owned by zero-cache. Zero's query engine is built assuming very fast local access to this replica (i.e., attached NVMe). But other setups are technically supported and work for smaller data. The ultimate size limit on the database that Zero can work with is the size limit of this SQLite database. So up to 45TB on EC2 at time of writing. However, most of our customers today use Zero with smaller datasets. We currently recommend Zero for use with datasets less than 100GB. If you want to work with larger datasets, please reach out and we can talk it through with you.",
     "kind": "section"
   },
   {

--- a/contents/docs/when-to-use.mdx
+++ b/contents/docs/when-to-use.mdx
@@ -53,7 +53,7 @@ Zero's query engine is built assuming very fast local access to this replica (i.
 
 The ultimate size limit on the database that Zero can work with is the size limit of this SQLite database. So [up to 45TB on EC2](https://aws.amazon.com/ec2/instance-types/) at time of writing.
 
-However, most of our customers today use Zero with smaller datasets. We currently recommend Zero for use with datasets less than 100GB. If you to work with larger datasets, please [reach out](https://discord.rocicorp.dev) and we can talk it through with you.
+However, most of our customers today use Zero with smaller datasets. We currently recommend Zero for use with datasets less than 100GB. If you want to work with larger datasets, please [reach out](https://discord.rocicorp.dev) and we can talk it through with you.
 
 ## Zero Might Not be a Good Fit **Yet**
 


### PR DESCRIPTION
## Changes

- There was a typo on the [When-To-Use-Zero](https://zero.rocicorp.dev/docs/when-to-use) page.
- I added the word "want".

## Screenshots

<img width="645" height="83" alt="image" src="https://github.com/user-attachments/assets/998b97de-8099-4463-855d-445f8a225871" />
