### PR TITLE
fix: add better tutorial and rework

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -396,6 +396,17 @@ html.dark [data-theme~='roci-dark'] code span {
   overflow: auto;
 }
 
+.prose pre code > [data-highlighted-line] {
+  margin-inline: -14px;
+  padding-inline: 12px 14px;
+  border-left: 1px solid rgba(var(--primary-accent), 0.6);
+  background-color: rgba(var(--primary-accent), 0.04);
+}
+
+html.dark .prose pre code > [data-highlighted-line] {
+  background-color: rgba(var(--primary-accent), 0.07);
+}
+
 .code-group-content figure {
   margin: 0 !important;
 }

--- a/assets/search-index.json
+++ b/assets/search-index.json
@@ -1551,7 +1551,7 @@
     "title": "Install Zero",
     "searchTitle": "Install Zero",
     "url": "/docs/install",
-    "content": "This guide shows how to add Zero to an existing TypeScript-based web app. For a concrete end-to-end walkthrough, build the music app in the tutorial. Integrate Zero Set Up Your Database You'll need a Postgres database for development. If you don't have a preferred method, we recommend using Docker: # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical See Provider Support for developing locally with popular cloud Postgres providers. Install and Run Zero-Cache Add Zero to your project: npm install @rocicorp/zeropnpm add @rocicorp/zero # Note: pnpm disables postinstall scripts by default for security. # Either approve the build: pnpm approve-builds # Or add to package.json: # \"pnpm\": { # \"onlyBuiltDependencies\": [\"@rocicorp/zero-sqlite3\"] # }bun add @rocicorp/zero # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate schema.ts automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate// zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Set Up the Zero Client Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. // root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// root.tsx import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) console.log('clientID', zero.clientID) export {zero} Sync Data Define Query Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema.ts' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries.ts' import {schema} from '../zero/schema.ts' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const users = await zero.run(queries.allUsers()) More about Queries Filters, sorting, relationships, preloading, and more Server-driven authentication Mutate Data Define Mutators Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, schema, etc. mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import type {Database} from '../../kysely/database.ts' const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Now you can run zero-cache locally with ZERO_UPSTREAM_DB, ZERO_QUERY_URL, and ZERO_MUTATE_URL configured: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev Invoke Mutators You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients. More about Mutators CRUD, server-specific code, permissions, and more Server-driven auth and Context Learn how to deploy your app to production",
+    "content": "This guide shows how to add Zero to an existing TypeScript-based web app. For a concrete end-to-end walkthrough, build the music app in the tutorial. Integrate Zero Set Up Your Database You'll need a Postgres database with logical replication enabled for development. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Provider Support and make sure wal_level is logical. Create a .env file so your app server and zero-cache-dev use the same Postgres connection: # Update to your app's database connection URL ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install Zero Add Zero and the validator used in these examples: npm install @rocicorp/zero zodpnpm add @rocicorp/zero zod # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # } pnpm rebuild @rocicorp/zero-sqlite3bun add @rocicorp/zero zod # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero zod # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json, then rebuild the native packages: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } yarn rebuild @rocicorp/zero-sqlite3 These examples use Zod; any Standard Schema-compatible validator works. Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate the schema automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generate --output src/zero/schema.tspnpm add -D drizzle-zero pnpm exec drizzle-zero generate --output src/zero/schema.tsbun add -D drizzle-zero bunx drizzle-zero generate --output src/zero/schema.tsyarn add -D drizzle-zero yarn exec drizzle-zero generate --output src/zero/schema.tsnpm install -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } yarn prisma generate// src/zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Set Up the Zero Client Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. Choose the tab that most closely matches where your app creates its root layout or client instance. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero App</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero} Sync Data Define Query Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// src/api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries' import {schema} from '../zero/schema' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero' import {queries} from './zero/queries' const users = await zero.run(queries.allUsers()) More about Queries Filters, sorting, relationships, preloading, and more Server-driven authentication Mutate Data Define Mutators Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack. These examples assume the selected database client is already installed in your app. // src/zero/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from './schema' import * as drizzleSchema from '../drizzle/schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from './schema' import type {Database} from '../kysely/database' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const sql = postgres(connectionString) export const dbProvider = zeroPostgresJS(schema, sql) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// src/api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {dbProvider} from '../zero/db-provider' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Start your app server in another terminal, then run zero-cache locally with ZERO_QUERY_URL and ZERO_MUTATE_URL configured. If your app uses a different origin, update localhost:3000. ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev Invoke Mutators You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero' import {mutators} from './zero/mutators' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients. More about Mutators CRUD, server-specific code, permissions, and more Server-driven auth and Context Learn how to deploy your app to production",
     "headings": [
       {
         "text": "Integrate Zero",
@@ -1562,8 +1562,8 @@
         "id": "set-up-your-database"
       },
       {
-        "text": "Install and Run Zero-Cache",
-        "id": "install-and-run-zero-cache"
+        "text": "Install Zero",
+        "id": "install-zero"
       },
       {
         "text": "Set Up Your Zero Schema",
@@ -1623,7 +1623,7 @@
     "sectionTitle": "Integrate Zero",
     "sectionId": "integrate-zero",
     "url": "/docs/install",
-    "content": "Set Up Your Database You'll need a Postgres database for development. If you don't have a preferred method, we recommend using Docker: # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical See Provider Support for developing locally with popular cloud Postgres providers. Install and Run Zero-Cache Add Zero to your project: npm install @rocicorp/zeropnpm add @rocicorp/zero # Note: pnpm disables postinstall scripts by default for security. # Either approve the build: pnpm approve-builds # Or add to package.json: # \"pnpm\": { # \"onlyBuiltDependencies\": [\"@rocicorp/zero-sqlite3\"] # }bun add @rocicorp/zero # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate schema.ts automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate// zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Set Up the Zero Client Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. // root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// root.tsx import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) console.log('clientID', zero.clientID) export {zero}",
+    "content": "Set Up Your Database You'll need a Postgres database with logical replication enabled for development. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Provider Support and make sure wal_level is logical. Create a .env file so your app server and zero-cache-dev use the same Postgres connection: # Update to your app's database connection URL ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install Zero Add Zero and the validator used in these examples: npm install @rocicorp/zero zodpnpm add @rocicorp/zero zod # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # } pnpm rebuild @rocicorp/zero-sqlite3bun add @rocicorp/zero zod # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero zod # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json, then rebuild the native packages: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } yarn rebuild @rocicorp/zero-sqlite3 These examples use Zod; any Standard Schema-compatible validator works. Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate the schema automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generate --output src/zero/schema.tspnpm add -D drizzle-zero pnpm exec drizzle-zero generate --output src/zero/schema.tsbun add -D drizzle-zero bunx drizzle-zero generate --output src/zero/schema.tsyarn add -D drizzle-zero yarn exec drizzle-zero generate --output src/zero/schema.tsnpm install -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } yarn prisma generate// src/zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Set Up the Zero Client Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. Choose the tab that most closely matches where your app creates its root layout or client instance. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero App</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero}",
     "kind": "section"
   },
   {
@@ -1633,17 +1633,17 @@
     "sectionTitle": "Set Up Your Database",
     "sectionId": "set-up-your-database",
     "url": "/docs/install",
-    "content": "You'll need a Postgres database for development. If you don't have a preferred method, we recommend using Docker: # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical See Provider Support for developing locally with popular cloud Postgres providers.",
+    "content": "You'll need a Postgres database with logical replication enabled for development. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Provider Support and make sure wal_level is logical. Create a .env file so your app server and zero-cache-dev use the same Postgres connection: # Update to your app's database connection URL ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\"",
     "kind": "section"
   },
   {
-    "id": "174-install#install-and-run-zero-cache",
+    "id": "174-install#install-zero",
     "title": "Install Zero",
-    "searchTitle": "Install and Run Zero-Cache",
-    "sectionTitle": "Install and Run Zero-Cache",
-    "sectionId": "install-and-run-zero-cache",
+    "searchTitle": "Install Zero",
+    "sectionTitle": "Install Zero",
+    "sectionId": "install-zero",
     "url": "/docs/install",
-    "content": "Add Zero to your project: npm install @rocicorp/zeropnpm add @rocicorp/zero # Note: pnpm disables postinstall scripts by default for security. # Either approve the build: pnpm approve-builds # Or add to package.json: # \"pnpm\": { # \"onlyBuiltDependencies\": [\"@rocicorp/zero-sqlite3\"] # }bun add @rocicorp/zero # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # }",
+    "content": "Add Zero and the validator used in these examples: npm install @rocicorp/zero zodpnpm add @rocicorp/zero zod # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # } pnpm rebuild @rocicorp/zero-sqlite3bun add @rocicorp/zero zod # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero zod # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json, then rebuild the native packages: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } yarn rebuild @rocicorp/zero-sqlite3 These examples use Zod; any Standard Schema-compatible validator works.",
     "kind": "section"
   },
   {
@@ -1653,7 +1653,7 @@
     "sectionTitle": "Set Up Your Zero Schema",
     "sectionId": "set-up-your-zero-schema",
     "url": "/docs/install",
-    "content": "Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate schema.ts automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate// zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } }",
+    "content": "Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate the schema automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generate --output src/zero/schema.tspnpm add -D drizzle-zero pnpm exec drizzle-zero generate --output src/zero/schema.tsbun add -D drizzle-zero bunx drizzle-zero generate --output src/zero/schema.tsyarn add -D drizzle-zero yarn exec drizzle-zero generate --output src/zero/schema.tsnpm install -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } yarn prisma generate// src/zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } }",
     "kind": "section"
   },
   {
@@ -1663,7 +1663,7 @@
     "sectionTitle": "Set Up the Zero Client",
     "sectionId": "set-up-the-zero-client",
     "url": "/docs/install",
-    "content": "Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. // root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// root.tsx import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) console.log('clientID', zero.clientID) export {zero}",
+    "content": "Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. Choose the tab that most closely matches where your app creates its root layout or client instance. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero App</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero}",
     "kind": "section"
   },
   {
@@ -1673,7 +1673,7 @@
     "sectionTitle": "Sync Data",
     "sectionId": "sync-data",
     "url": "/docs/install",
-    "content": "Define Query Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema.ts' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries.ts' import {schema} from '../zero/schema.ts' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const users = await zero.run(queries.allUsers()) More about Queries Filters, sorting, relationships, preloading, and more Server-driven authentication",
+    "content": "Define Query Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// src/api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries' import {schema} from '../zero/schema' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero' import {queries} from './zero/queries' const users = await zero.run(queries.allUsers()) More about Queries Filters, sorting, relationships, preloading, and more Server-driven authentication",
     "kind": "section"
   },
   {
@@ -1683,7 +1683,7 @@
     "sectionTitle": "Define Query",
     "sectionId": "define-query",
     "url": "/docs/install",
-    "content": "Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema.ts' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions.",
+    "content": "Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions.",
     "kind": "section"
   },
   {
@@ -1693,7 +1693,7 @@
     "sectionTitle": "Add Query Endpoint",
     "sectionId": "add-query-endpoint",
     "url": "/docs/install",
-    "content": "Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries.ts' import {schema} from '../zero/schema.ts' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) })",
+    "content": "Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// src/api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries' import {schema} from '../zero/schema' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) })",
     "kind": "section"
   },
   {
@@ -1703,7 +1703,7 @@
     "sectionTitle": "Invoke Query",
     "sectionId": "invoke-query",
     "url": "/docs/install",
-    "content": "Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const users = await zero.run(queries.allUsers())",
+    "content": "Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero' import {queries} from './zero/queries' const users = await zero.run(queries.allUsers())",
     "kind": "section"
   },
   {
@@ -1723,7 +1723,7 @@
     "sectionTitle": "Mutate Data",
     "sectionId": "mutate-data",
     "url": "/docs/install",
-    "content": "Define Mutators Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, schema, etc. mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import type {Database} from '../../kysely/database.ts' const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Now you can run zero-cache locally with ZERO_UPSTREAM_DB, ZERO_QUERY_URL, and ZERO_MUTATE_URL configured: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev Invoke Mutators You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients. More about Mutators CRUD, server-specific code, permissions, and more Server-driven auth and Context Learn how to deploy your app to production",
+    "content": "Define Mutators Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack. These examples assume the selected database client is already installed in your app. // src/zero/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from './schema' import * as drizzleSchema from '../drizzle/schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from './schema' import type {Database} from '../kysely/database' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const sql = postgres(connectionString) export const dbProvider = zeroPostgresJS(schema, sql) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// src/api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {dbProvider} from '../zero/db-provider' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Start your app server in another terminal, then run zero-cache locally with ZERO_QUERY_URL and ZERO_MUTATE_URL configured. If your app uses a different origin, update localhost:3000. ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev Invoke Mutators You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero' import {mutators} from './zero/mutators' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients. More about Mutators CRUD, server-specific code, permissions, and more Server-driven auth and Context Learn how to deploy your app to production",
     "kind": "section"
   },
   {
@@ -1733,7 +1733,7 @@
     "sectionTitle": "Define Mutators",
     "sectionId": "define-mutators",
     "url": "/docs/install",
-    "content": "Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, schema, etc. mutators }",
+    "content": "Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }",
     "kind": "section"
   },
   {
@@ -1743,7 +1743,7 @@
     "sectionTitle": "Add Mutate Endpoint",
     "sectionId": "add-mutate-endpoint",
     "url": "/docs/install",
-    "content": "Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import type {Database} from '../../kysely/database.ts' const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Now you can run zero-cache locally with ZERO_UPSTREAM_DB, ZERO_QUERY_URL, and ZERO_MUTATE_URL configured: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev",
+    "content": "Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack. These examples assume the selected database client is already installed in your app. // src/zero/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from './schema' import * as drizzleSchema from '../drizzle/schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from './schema' import type {Database} from '../kysely/database' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const sql = postgres(connectionString) export const dbProvider = zeroPostgresJS(schema, sql) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// src/api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {dbProvider} from '../zero/db-provider' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Start your app server in another terminal, then run zero-cache locally with ZERO_QUERY_URL and ZERO_MUTATE_URL configured. If your app uses a different origin, update localhost:3000. ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev",
     "kind": "section"
   },
   {
@@ -1753,7 +1753,7 @@
     "sectionTitle": "Invoke Mutators",
     "sectionId": "invoke-mutators",
     "url": "/docs/install",
-    "content": "You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients.",
+    "content": "You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero' import {mutators} from './zero/mutators' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients.",
     "kind": "section"
   },
   {
@@ -1771,9 +1771,24 @@
     "title": "Welcome to Zero",
     "searchTitle": "Welcome to Zero",
     "url": "/docs/introduction",
-    "content": "",
-    "headings": [],
+    "content": "Zero makes web apps feel instant by syncing the data your UI needs into a local, normalized client datastore. Reads and writes hit that local store first, then sync continuously with your server in the background. You control what syncs by writing normal queries in your app code, instead of syncing whole tables or maintaining static sync rules. Zero reuses cached data when it can and automatically falls back to the server when it needs more. Ready to get started? Build a new app with the tutorial Install Zero into an existing project Clone a starter app Play with a full-featured sample",
+    "headings": [
+      {
+        "text": "Ready to get started?",
+        "id": "ready-to-get-started"
+      }
+    ],
     "kind": "page"
+  },
+  {
+    "id": "187-introduction#ready-to-get-started",
+    "title": "Welcome to Zero",
+    "searchTitle": "Ready to get started?",
+    "sectionTitle": "Ready to get started?",
+    "sectionId": "ready-to-get-started",
+    "url": "/docs/introduction",
+    "content": "Build a new app with the tutorial Install Zero into an existing project Clone a starter app Play with a full-featured sample",
+    "kind": "section"
   },
   {
     "id": "17-mutators",
@@ -1902,7 +1917,7 @@
     "kind": "page"
   },
   {
-    "id": "187-mutators#architecture",
+    "id": "188-mutators#architecture",
     "title": "Mutators",
     "searchTitle": "Architecture",
     "sectionTitle": "Architecture",
@@ -1912,7 +1927,7 @@
     "kind": "section"
   },
   {
-    "id": "188-mutators#life-of-a-mutation",
+    "id": "189-mutators#life-of-a-mutation",
     "title": "Mutators",
     "searchTitle": "Life of a Mutation",
     "sectionTitle": "Life of a Mutation",
@@ -1922,7 +1937,7 @@
     "kind": "section"
   },
   {
-    "id": "189-mutators#defining-mutators",
+    "id": "190-mutators#defining-mutators",
     "title": "Mutators",
     "searchTitle": "Defining Mutators",
     "sectionTitle": "Defining Mutators",
@@ -1932,7 +1947,7 @@
     "kind": "section"
   },
   {
-    "id": "190-mutators#basics",
+    "id": "191-mutators#basics",
     "title": "Mutators",
     "searchTitle": "Basics",
     "sectionTitle": "Basics",
@@ -1942,7 +1957,7 @@
     "kind": "section"
   },
   {
-    "id": "191-mutators#writing-data",
+    "id": "192-mutators#writing-data",
     "title": "Mutators",
     "searchTitle": "Writing Data",
     "sectionTitle": "Writing Data",
@@ -1952,7 +1967,7 @@
     "kind": "section"
   },
   {
-    "id": "192-mutators#insert",
+    "id": "193-mutators#insert",
     "title": "Mutators",
     "searchTitle": "Insert",
     "sectionTitle": "Insert",
@@ -1962,7 +1977,7 @@
     "kind": "section"
   },
   {
-    "id": "193-mutators#upsert",
+    "id": "194-mutators#upsert",
     "title": "Mutators",
     "searchTitle": "Upsert",
     "sectionTitle": "Upsert",
@@ -1972,7 +1987,7 @@
     "kind": "section"
   },
   {
-    "id": "194-mutators#update",
+    "id": "195-mutators#update",
     "title": "Mutators",
     "searchTitle": "Update",
     "sectionTitle": "Update",
@@ -1982,7 +1997,7 @@
     "kind": "section"
   },
   {
-    "id": "195-mutators#delete",
+    "id": "196-mutators#delete",
     "title": "Mutators",
     "searchTitle": "Delete",
     "sectionTitle": "Delete",
@@ -1992,7 +2007,7 @@
     "kind": "section"
   },
   {
-    "id": "196-mutators#arguments",
+    "id": "197-mutators#arguments",
     "title": "Mutators",
     "searchTitle": "Arguments",
     "sectionTitle": "Arguments",
@@ -2002,7 +2017,7 @@
     "kind": "section"
   },
   {
-    "id": "197-mutators#reading-data",
+    "id": "198-mutators#reading-data",
     "title": "Mutators",
     "searchTitle": "Reading Data",
     "sectionTitle": "Reading Data",
@@ -2012,7 +2027,7 @@
     "kind": "section"
   },
   {
-    "id": "198-mutators#context",
+    "id": "199-mutators#context",
     "title": "Mutators",
     "searchTitle": "Context",
     "sectionTitle": "Context",
@@ -2022,7 +2037,7 @@
     "kind": "section"
   },
   {
-    "id": "199-mutators#mutator-registries",
+    "id": "200-mutators#mutator-registries",
     "title": "Mutators",
     "searchTitle": "Mutator Registries",
     "sectionTitle": "Mutator Registries",
@@ -2032,7 +2047,7 @@
     "kind": "section"
   },
   {
-    "id": "200-mutators#mutator-names",
+    "id": "201-mutators#mutator-names",
     "title": "Mutators",
     "searchTitle": "Mutator Names",
     "sectionTitle": "Mutator Names",
@@ -2042,7 +2057,7 @@
     "kind": "section"
   },
   {
-    "id": "201-mutators#mutatorsts",
+    "id": "202-mutators#mutatorsts",
     "title": "Mutators",
     "searchTitle": "mutators.ts",
     "sectionTitle": "mutators.ts",
@@ -2052,7 +2067,7 @@
     "kind": "section"
   },
   {
-    "id": "202-mutators#registration",
+    "id": "203-mutators#registration",
     "title": "Mutators",
     "searchTitle": "Registration",
     "sectionTitle": "Registration",
@@ -2062,7 +2077,7 @@
     "kind": "section"
   },
   {
-    "id": "203-mutators#server-setup",
+    "id": "204-mutators#server-setup",
     "title": "Mutators",
     "searchTitle": "Server Setup",
     "sectionTitle": "Server Setup",
@@ -2072,7 +2087,7 @@
     "kind": "section"
   },
   {
-    "id": "204-mutators#registering-the-endpoint",
+    "id": "205-mutators#registering-the-endpoint",
     "title": "Mutators",
     "searchTitle": "Registering the Endpoint",
     "sectionTitle": "Registering the Endpoint",
@@ -2082,7 +2097,7 @@
     "kind": "section"
   },
   {
-    "id": "205-mutators#implementing-the-endpoint",
+    "id": "206-mutators#implementing-the-endpoint",
     "title": "Mutators",
     "searchTitle": "Implementing the Endpoint",
     "sectionTitle": "Implementing the Endpoint",
@@ -2092,7 +2107,7 @@
     "kind": "section"
   },
   {
-    "id": "206-mutators#handling-errors",
+    "id": "207-mutators#handling-errors",
     "title": "Mutators",
     "searchTitle": "Handling Errors",
     "sectionTitle": "Handling Errors",
@@ -2102,7 +2117,7 @@
     "kind": "section"
   },
   {
-    "id": "207-mutators#custom-mutate-url",
+    "id": "208-mutators#custom-mutate-url",
     "title": "Mutators",
     "searchTitle": "Custom Mutate URL",
     "sectionTitle": "Custom Mutate URL",
@@ -2112,7 +2127,7 @@
     "kind": "section"
   },
   {
-    "id": "208-mutators#url-patterns",
+    "id": "209-mutators#url-patterns",
     "title": "Mutators",
     "searchTitle": "URL Patterns",
     "sectionTitle": "URL Patterns",
@@ -2122,7 +2137,7 @@
     "kind": "section"
   },
   {
-    "id": "209-mutators#server-specific-code",
+    "id": "210-mutators#server-specific-code",
     "title": "Mutators",
     "searchTitle": "Server-Specific Code",
     "sectionTitle": "Server-Specific Code",
@@ -2132,7 +2147,7 @@
     "kind": "section"
   },
   {
-    "id": "210-mutators#running-mutators",
+    "id": "211-mutators#running-mutators",
     "title": "Mutators",
     "searchTitle": "Running Mutators",
     "sectionTitle": "Running Mutators",
@@ -2142,7 +2157,7 @@
     "kind": "section"
   },
   {
-    "id": "211-mutators#waiting-for-results",
+    "id": "212-mutators#waiting-for-results",
     "title": "Mutators",
     "searchTitle": "Waiting for Results",
     "sectionTitle": "Waiting for Results",
@@ -2152,7 +2167,7 @@
     "kind": "section"
   },
   {
-    "id": "212-mutators#permissions",
+    "id": "213-mutators#permissions",
     "title": "Mutators",
     "searchTitle": "Permissions",
     "sectionTitle": "Permissions",
@@ -2162,7 +2177,7 @@
     "kind": "section"
   },
   {
-    "id": "213-mutators#dropping-down-to-raw-sql",
+    "id": "214-mutators#dropping-down-to-raw-sql",
     "title": "Mutators",
     "searchTitle": "Dropping Down to Raw SQL",
     "sectionTitle": "Dropping Down to Raw SQL",
@@ -2172,7 +2187,7 @@
     "kind": "section"
   },
   {
-    "id": "214-mutators#notifications-and-async-work",
+    "id": "215-mutators#notifications-and-async-work",
     "title": "Mutators",
     "searchTitle": "Notifications and Async Work",
     "sectionTitle": "Notifications and Async Work",
@@ -2182,7 +2197,7 @@
     "kind": "section"
   },
   {
-    "id": "215-mutators#custom-mutate-implementation",
+    "id": "216-mutators#custom-mutate-implementation",
     "title": "Mutators",
     "searchTitle": "Custom Mutate Implementation",
     "sectionTitle": "Custom Mutate Implementation",
@@ -2206,7 +2221,7 @@
     "kind": "page"
   },
   {
-    "id": "216-open-source#business-model",
+    "id": "217-open-source#business-model",
     "title": "Zero is Open Source Software",
     "searchTitle": "Business Model",
     "sectionTitle": "Business Model",
@@ -2258,7 +2273,7 @@
     "kind": "page"
   },
   {
-    "id": "217-otel#grafana-cloud-walkthrough",
+    "id": "218-otel#grafana-cloud-walkthrough",
     "title": "OpenTelemetry",
     "searchTitle": "Grafana Cloud Walkthrough",
     "sectionTitle": "Grafana Cloud Walkthrough",
@@ -2268,7 +2283,7 @@
     "kind": "section"
   },
   {
-    "id": "218-otel#distributed-tracing",
+    "id": "219-otel#distributed-tracing",
     "title": "OpenTelemetry",
     "searchTitle": "Distributed Tracing",
     "sectionTitle": "Distributed Tracing",
@@ -2278,7 +2293,7 @@
     "kind": "section"
   },
   {
-    "id": "219-otel#metrics-reference",
+    "id": "220-otel#metrics-reference",
     "title": "OpenTelemetry",
     "searchTitle": "Metrics Reference",
     "sectionTitle": "Metrics Reference",
@@ -2288,7 +2303,7 @@
     "kind": "section"
   },
   {
-    "id": "220-otel#zeroserver",
+    "id": "221-otel#zeroserver",
     "title": "OpenTelemetry",
     "searchTitle": "zero.server",
     "sectionTitle": "zero.server",
@@ -2298,7 +2313,7 @@
     "kind": "section"
   },
   {
-    "id": "221-otel#zeroreplica",
+    "id": "222-otel#zeroreplica",
     "title": "OpenTelemetry",
     "searchTitle": "zero.replica",
     "sectionTitle": "zero.replica",
@@ -2308,7 +2323,7 @@
     "kind": "section"
   },
   {
-    "id": "222-otel#zeroreplication",
+    "id": "223-otel#zeroreplication",
     "title": "OpenTelemetry",
     "searchTitle": "zero.replication",
     "sectionTitle": "zero.replication",
@@ -2318,7 +2333,7 @@
     "kind": "section"
   },
   {
-    "id": "223-otel#zerosync",
+    "id": "224-otel#zerosync",
     "title": "OpenTelemetry",
     "searchTitle": "zero.sync",
     "sectionTitle": "zero.sync",
@@ -2328,7 +2343,7 @@
     "kind": "section"
   },
   {
-    "id": "224-otel#zeromutation",
+    "id": "225-otel#zeromutation",
     "title": "OpenTelemetry",
     "searchTitle": "zero.mutation",
     "sectionTitle": "zero.mutation",
@@ -2388,7 +2403,7 @@
     "kind": "page"
   },
   {
-    "id": "225-postgres-support#object-names",
+    "id": "226-postgres-support#object-names",
     "title": "Supported Postgres Features",
     "searchTitle": "Object Names",
     "sectionTitle": "Object Names",
@@ -2398,7 +2413,7 @@
     "kind": "section"
   },
   {
-    "id": "226-postgres-support#object-types",
+    "id": "227-postgres-support#object-types",
     "title": "Supported Postgres Features",
     "searchTitle": "Object Types",
     "sectionTitle": "Object Types",
@@ -2408,7 +2423,7 @@
     "kind": "section"
   },
   {
-    "id": "227-postgres-support#column-types",
+    "id": "228-postgres-support#column-types",
     "title": "Supported Postgres Features",
     "searchTitle": "Column Types",
     "sectionTitle": "Column Types",
@@ -2418,7 +2433,7 @@
     "kind": "section"
   },
   {
-    "id": "228-postgres-support#column-defaults",
+    "id": "229-postgres-support#column-defaults",
     "title": "Supported Postgres Features",
     "searchTitle": "Column Defaults",
     "sectionTitle": "Column Defaults",
@@ -2428,7 +2443,7 @@
     "kind": "section"
   },
   {
-    "id": "229-postgres-support#ids",
+    "id": "230-postgres-support#ids",
     "title": "Supported Postgres Features",
     "searchTitle": "IDs",
     "sectionTitle": "IDs",
@@ -2438,7 +2453,7 @@
     "kind": "section"
   },
   {
-    "id": "230-postgres-support#primary-keys",
+    "id": "231-postgres-support#primary-keys",
     "title": "Supported Postgres Features",
     "searchTitle": "Primary Keys",
     "sectionTitle": "Primary Keys",
@@ -2448,7 +2463,7 @@
     "kind": "section"
   },
   {
-    "id": "231-postgres-support#limiting-replication",
+    "id": "232-postgres-support#limiting-replication",
     "title": "Supported Postgres Features",
     "searchTitle": "Limiting Replication",
     "sectionTitle": "Limiting Replication",
@@ -2458,7 +2473,7 @@
     "kind": "section"
   },
   {
-    "id": "232-postgres-support#zero-cache-replication",
+    "id": "233-postgres-support#zero-cache-replication",
     "title": "Supported Postgres Features",
     "searchTitle": "zero-cache replication",
     "sectionTitle": "zero-cache replication",
@@ -2468,7 +2483,7 @@
     "kind": "section"
   },
   {
-    "id": "233-postgres-support#browser-client-replication",
+    "id": "234-postgres-support#browser-client-replication",
     "title": "Supported Postgres Features",
     "searchTitle": "Browser client replication",
     "sectionTitle": "Browser client replication",
@@ -2478,7 +2493,7 @@
     "kind": "section"
   },
   {
-    "id": "234-postgres-support#schema-changes",
+    "id": "235-postgres-support#schema-changes",
     "title": "Supported Postgres Features",
     "searchTitle": "Schema changes",
     "sectionTitle": "Schema changes",
@@ -2514,7 +2529,7 @@
     "kind": "page"
   },
   {
-    "id": "235-previews#overview",
+    "id": "236-previews#overview",
     "title": "Previews",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -2524,7 +2539,7 @@
     "kind": "section"
   },
   {
-    "id": "236-previews#configure-allowed-endpoint-patterns",
+    "id": "237-previews#configure-allowed-endpoint-patterns",
     "title": "Previews",
     "searchTitle": "Configure Allowed Endpoint Patterns",
     "sectionTitle": "Configure Allowed Endpoint Patterns",
@@ -2534,7 +2549,7 @@
     "kind": "section"
   },
   {
-    "id": "237-previews#choose-endpoint-urls-in-the-client",
+    "id": "238-previews#choose-endpoint-urls-in-the-client",
     "title": "Previews",
     "searchTitle": "Choose Endpoint URLs in the Client",
     "sectionTitle": "Choose Endpoint URLs in the Client",
@@ -2544,7 +2559,7 @@
     "kind": "section"
   },
   {
-    "id": "238-previews#schema-changes-in-previews",
+    "id": "239-previews#schema-changes-in-previews",
     "title": "Previews",
     "searchTitle": "Schema Changes in Previews",
     "sectionTitle": "Schema Changes in Previews",
@@ -2688,7 +2703,7 @@
     "kind": "page"
   },
   {
-    "id": "239-queries#architecture",
+    "id": "240-queries#architecture",
     "title": "Queries",
     "searchTitle": "Architecture",
     "sectionTitle": "Architecture",
@@ -2698,7 +2713,7 @@
     "kind": "section"
   },
   {
-    "id": "240-queries#life-of-a-query",
+    "id": "241-queries#life-of-a-query",
     "title": "Queries",
     "searchTitle": "Life of a Query",
     "sectionTitle": "Life of a Query",
@@ -2708,7 +2723,7 @@
     "kind": "section"
   },
   {
-    "id": "241-queries#defining-queries",
+    "id": "242-queries#defining-queries",
     "title": "Queries",
     "searchTitle": "Defining Queries",
     "sectionTitle": "Defining Queries",
@@ -2718,7 +2733,7 @@
     "kind": "section"
   },
   {
-    "id": "242-queries#basics",
+    "id": "243-queries#basics",
     "title": "Queries",
     "searchTitle": "Basics",
     "sectionTitle": "Basics",
@@ -2728,7 +2743,7 @@
     "kind": "section"
   },
   {
-    "id": "243-queries#arguments",
+    "id": "244-queries#arguments",
     "title": "Queries",
     "searchTitle": "Arguments",
     "sectionTitle": "Arguments",
@@ -2738,7 +2753,7 @@
     "kind": "section"
   },
   {
-    "id": "244-queries#query-registries",
+    "id": "245-queries#query-registries",
     "title": "Queries",
     "searchTitle": "Query Registries",
     "sectionTitle": "Query Registries",
@@ -2748,7 +2763,7 @@
     "kind": "section"
   },
   {
-    "id": "245-queries#query-names",
+    "id": "246-queries#query-names",
     "title": "Queries",
     "searchTitle": "Query Names",
     "sectionTitle": "Query Names",
@@ -2758,7 +2773,7 @@
     "kind": "section"
   },
   {
-    "id": "246-queries#context",
+    "id": "247-queries#context",
     "title": "Queries",
     "searchTitle": "Context",
     "sectionTitle": "Context",
@@ -2768,7 +2783,7 @@
     "kind": "section"
   },
   {
-    "id": "247-queries#queriests",
+    "id": "248-queries#queriests",
     "title": "Queries",
     "searchTitle": "queries.ts",
     "sectionTitle": "queries.ts",
@@ -2778,7 +2793,7 @@
     "kind": "section"
   },
   {
-    "id": "248-queries#server-setup",
+    "id": "249-queries#server-setup",
     "title": "Queries",
     "searchTitle": "Server Setup",
     "sectionTitle": "Server Setup",
@@ -2788,7 +2803,7 @@
     "kind": "section"
   },
   {
-    "id": "249-queries#registering-the-endpoint",
+    "id": "250-queries#registering-the-endpoint",
     "title": "Queries",
     "searchTitle": "Registering the Endpoint",
     "sectionTitle": "Registering the Endpoint",
@@ -2798,7 +2813,7 @@
     "kind": "section"
   },
   {
-    "id": "250-queries#implementing-the-endpoint",
+    "id": "251-queries#implementing-the-endpoint",
     "title": "Queries",
     "searchTitle": "Implementing the Endpoint",
     "sectionTitle": "Implementing the Endpoint",
@@ -2808,7 +2823,7 @@
     "kind": "section"
   },
   {
-    "id": "251-queries#custom-query-url",
+    "id": "252-queries#custom-query-url",
     "title": "Queries",
     "searchTitle": "Custom Query URL",
     "sectionTitle": "Custom Query URL",
@@ -2818,7 +2833,7 @@
     "kind": "section"
   },
   {
-    "id": "252-queries#url-patterns",
+    "id": "253-queries#url-patterns",
     "title": "Queries",
     "searchTitle": "URL Patterns",
     "sectionTitle": "URL Patterns",
@@ -2828,7 +2843,7 @@
     "kind": "section"
   },
   {
-    "id": "253-queries#running-queries",
+    "id": "254-queries#running-queries",
     "title": "Queries",
     "searchTitle": "Running Queries",
     "sectionTitle": "Running Queries",
@@ -2838,7 +2853,7 @@
     "kind": "section"
   },
   {
-    "id": "254-queries#reactively",
+    "id": "255-queries#reactively",
     "title": "Queries",
     "searchTitle": "Reactively",
     "sectionTitle": "Reactively",
@@ -2848,7 +2863,7 @@
     "kind": "section"
   },
   {
-    "id": "255-queries#conditionally",
+    "id": "256-queries#conditionally",
     "title": "Queries",
     "searchTitle": "Conditionally",
     "sectionTitle": "Conditionally",
@@ -2858,7 +2873,7 @@
     "kind": "section"
   },
   {
-    "id": "256-queries#once",
+    "id": "257-queries#once",
     "title": "Queries",
     "searchTitle": "Once",
     "sectionTitle": "Once",
@@ -2868,7 +2883,7 @@
     "kind": "section"
   },
   {
-    "id": "257-queries#for-preloading",
+    "id": "258-queries#for-preloading",
     "title": "Queries",
     "searchTitle": "For Preloading",
     "sectionTitle": "For Preloading",
@@ -2878,7 +2893,7 @@
     "kind": "section"
   },
   {
-    "id": "258-queries#missing-data",
+    "id": "259-queries#missing-data",
     "title": "Queries",
     "searchTitle": "Missing Data",
     "sectionTitle": "Missing Data",
@@ -2888,7 +2903,7 @@
     "kind": "section"
   },
   {
-    "id": "259-queries#partial-data",
+    "id": "260-queries#partial-data",
     "title": "Queries",
     "searchTitle": "Partial Data",
     "sectionTitle": "Partial Data",
@@ -2898,7 +2913,7 @@
     "kind": "section"
   },
   {
-    "id": "260-queries#handling-errors",
+    "id": "261-queries#handling-errors",
     "title": "Queries",
     "searchTitle": "Handling Errors",
     "sectionTitle": "Handling Errors",
@@ -2908,7 +2923,7 @@
     "kind": "section"
   },
   {
-    "id": "261-queries#granular-updates",
+    "id": "262-queries#granular-updates",
     "title": "Queries",
     "searchTitle": "Granular Updates",
     "sectionTitle": "Granular Updates",
@@ -2918,7 +2933,7 @@
     "kind": "section"
   },
   {
-    "id": "262-queries#query-caching",
+    "id": "263-queries#query-caching",
     "title": "Queries",
     "searchTitle": "Query Caching",
     "sectionTitle": "Query Caching",
@@ -2928,7 +2943,7 @@
     "kind": "section"
   },
   {
-    "id": "263-queries#ttls",
+    "id": "264-queries#ttls",
     "title": "Queries",
     "searchTitle": "TTLs",
     "sectionTitle": "TTLs",
@@ -2938,7 +2953,7 @@
     "kind": "section"
   },
   {
-    "id": "264-queries#ttl-defaults",
+    "id": "265-queries#ttl-defaults",
     "title": "Queries",
     "searchTitle": "TTL Defaults",
     "sectionTitle": "TTL Defaults",
@@ -2948,7 +2963,7 @@
     "kind": "section"
   },
   {
-    "id": "265-queries#setting-different-ttls",
+    "id": "266-queries#setting-different-ttls",
     "title": "Queries",
     "searchTitle": "Setting Different TTLs",
     "sectionTitle": "Setting Different TTLs",
@@ -2958,7 +2973,7 @@
     "kind": "section"
   },
   {
-    "id": "266-queries#why-zero-ttls-are-short",
+    "id": "267-queries#why-zero-ttls-are-short",
     "title": "Queries",
     "searchTitle": "Why Zero TTLs are Short",
     "sectionTitle": "Why Zero TTLs are Short",
@@ -2968,7 +2983,7 @@
     "kind": "section"
   },
   {
-    "id": "267-queries#local-only-queries",
+    "id": "268-queries#local-only-queries",
     "title": "Queries",
     "searchTitle": "Local-Only Queries",
     "sectionTitle": "Local-Only Queries",
@@ -2978,7 +2993,7 @@
     "kind": "section"
   },
   {
-    "id": "268-queries#custom-server-implementation",
+    "id": "269-queries#custom-server-implementation",
     "title": "Queries",
     "searchTitle": "Custom Server Implementation",
     "sectionTitle": "Custom Server Implementation",
@@ -2988,7 +3003,7 @@
     "kind": "section"
   },
   {
-    "id": "269-queries#consistency",
+    "id": "270-queries#consistency",
     "title": "Queries",
     "searchTitle": "Consistency",
     "sectionTitle": "Consistency",
@@ -3020,7 +3035,7 @@
     "kind": "page"
   },
   {
-    "id": "270-quickstart#hello-zero-solid",
+    "id": "271-quickstart#hello-zero-solid",
     "title": "Quickstart",
     "searchTitle": "hello-zero-solid",
     "sectionTitle": "hello-zero-solid",
@@ -3030,7 +3045,7 @@
     "kind": "section"
   },
   {
-    "id": "271-quickstart#hello-zero-cf",
+    "id": "272-quickstart#hello-zero-cf",
     "title": "Quickstart",
     "searchTitle": "hello-zero-cf",
     "sectionTitle": "hello-zero-cf",
@@ -3040,7 +3055,7 @@
     "kind": "section"
   },
   {
-    "id": "272-quickstart#hello-zero",
+    "id": "273-quickstart#hello-zero",
     "title": "Quickstart",
     "searchTitle": "hello-zero",
     "sectionTitle": "hello-zero",
@@ -3085,7 +3100,7 @@
     "kind": "page"
   },
   {
-    "id": "273-react#setup",
+    "id": "274-react#setup",
     "title": "React",
     "searchTitle": "Setup",
     "sectionTitle": "Setup",
@@ -3095,7 +3110,7 @@
     "kind": "section"
   },
   {
-    "id": "274-react#usage",
+    "id": "275-react#usage",
     "title": "React",
     "searchTitle": "Usage",
     "sectionTitle": "Usage",
@@ -3105,7 +3120,7 @@
     "kind": "section"
   },
   {
-    "id": "275-react#suspense",
+    "id": "276-react#suspense",
     "title": "React",
     "searchTitle": "Suspense",
     "sectionTitle": "Suspense",
@@ -3115,7 +3130,7 @@
     "kind": "section"
   },
   {
-    "id": "276-react#examples",
+    "id": "277-react#examples",
     "title": "React",
     "searchTitle": "Examples",
     "sectionTitle": "Examples",
@@ -3147,7 +3162,7 @@
     "kind": "page"
   },
   {
-    "id": "277-release-notes/0.1#breaking-changes",
+    "id": "278-release-notes/0.1#breaking-changes",
     "title": "Zero 0.1",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
@@ -3157,7 +3172,7 @@
     "kind": "section"
   },
   {
-    "id": "278-release-notes/0.1#features",
+    "id": "279-release-notes/0.1#features",
     "title": "Zero 0.1",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3167,7 +3182,7 @@
     "kind": "section"
   },
   {
-    "id": "279-release-notes/0.1#source-tree-fixes",
+    "id": "280-release-notes/0.1#source-tree-fixes",
     "title": "Zero 0.1",
     "searchTitle": "Source tree fixes",
     "sectionTitle": "Source tree fixes",
@@ -3203,7 +3218,7 @@
     "kind": "page"
   },
   {
-    "id": "280-release-notes/0.10#install",
+    "id": "281-release-notes/0.10#install",
     "title": "Zero 0.10",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3213,7 +3228,7 @@
     "kind": "section"
   },
   {
-    "id": "281-release-notes/0.10#features",
+    "id": "282-release-notes/0.10#features",
     "title": "Zero 0.10",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3223,7 +3238,7 @@
     "kind": "section"
   },
   {
-    "id": "282-release-notes/0.10#fixes",
+    "id": "283-release-notes/0.10#fixes",
     "title": "Zero 0.10",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3233,7 +3248,7 @@
     "kind": "section"
   },
   {
-    "id": "283-release-notes/0.10#breaking-changes",
+    "id": "284-release-notes/0.10#breaking-changes",
     "title": "Zero 0.10",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3269,7 +3284,7 @@
     "kind": "page"
   },
   {
-    "id": "284-release-notes/0.11#install",
+    "id": "285-release-notes/0.11#install",
     "title": "Zero 0.11",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3279,7 +3294,7 @@
     "kind": "section"
   },
   {
-    "id": "285-release-notes/0.11#features",
+    "id": "286-release-notes/0.11#features",
     "title": "Zero 0.11",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3289,7 +3304,7 @@
     "kind": "section"
   },
   {
-    "id": "286-release-notes/0.11#fixes",
+    "id": "287-release-notes/0.11#fixes",
     "title": "Zero 0.11",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3299,7 +3314,7 @@
     "kind": "section"
   },
   {
-    "id": "287-release-notes/0.11#breaking-changes",
+    "id": "288-release-notes/0.11#breaking-changes",
     "title": "Zero 0.11",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3335,7 +3350,7 @@
     "kind": "page"
   },
   {
-    "id": "288-release-notes/0.12#install",
+    "id": "289-release-notes/0.12#install",
     "title": "Zero 0.12",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3345,7 +3360,7 @@
     "kind": "section"
   },
   {
-    "id": "289-release-notes/0.12#features",
+    "id": "290-release-notes/0.12#features",
     "title": "Zero 0.12",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3355,7 +3370,7 @@
     "kind": "section"
   },
   {
-    "id": "290-release-notes/0.12#fixes",
+    "id": "291-release-notes/0.12#fixes",
     "title": "Zero 0.12",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3365,7 +3380,7 @@
     "kind": "section"
   },
   {
-    "id": "291-release-notes/0.12#breaking-changes",
+    "id": "292-release-notes/0.12#breaking-changes",
     "title": "Zero 0.12",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3401,7 +3416,7 @@
     "kind": "page"
   },
   {
-    "id": "292-release-notes/0.13#install",
+    "id": "293-release-notes/0.13#install",
     "title": "Zero 0.13",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3411,7 +3426,7 @@
     "kind": "section"
   },
   {
-    "id": "293-release-notes/0.13#features",
+    "id": "294-release-notes/0.13#features",
     "title": "Zero 0.13",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3421,7 +3436,7 @@
     "kind": "section"
   },
   {
-    "id": "294-release-notes/0.13#fixes",
+    "id": "295-release-notes/0.13#fixes",
     "title": "Zero 0.13",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3431,7 +3446,7 @@
     "kind": "section"
   },
   {
-    "id": "295-release-notes/0.13#breaking-changes",
+    "id": "296-release-notes/0.13#breaking-changes",
     "title": "Zero 0.13",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3467,7 +3482,7 @@
     "kind": "page"
   },
   {
-    "id": "296-release-notes/0.14#install",
+    "id": "297-release-notes/0.14#install",
     "title": "Zero 0.14",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3477,7 +3492,7 @@
     "kind": "section"
   },
   {
-    "id": "297-release-notes/0.14#features",
+    "id": "298-release-notes/0.14#features",
     "title": "Zero 0.14",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3487,7 +3502,7 @@
     "kind": "section"
   },
   {
-    "id": "298-release-notes/0.14#fixes",
+    "id": "299-release-notes/0.14#fixes",
     "title": "Zero 0.14",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3497,7 +3512,7 @@
     "kind": "section"
   },
   {
-    "id": "299-release-notes/0.14#breaking-changes",
+    "id": "300-release-notes/0.14#breaking-changes",
     "title": "Zero 0.14",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3537,7 +3552,7 @@
     "kind": "page"
   },
   {
-    "id": "300-release-notes/0.15#install",
+    "id": "301-release-notes/0.15#install",
     "title": "Zero 0.15",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3547,7 +3562,7 @@
     "kind": "section"
   },
   {
-    "id": "301-release-notes/0.15#upgrade-guide",
+    "id": "302-release-notes/0.15#upgrade-guide",
     "title": "Zero 0.15",
     "searchTitle": "Upgrade Guide",
     "sectionTitle": "Upgrade Guide",
@@ -3557,7 +3572,7 @@
     "kind": "section"
   },
   {
-    "id": "302-release-notes/0.15#features",
+    "id": "303-release-notes/0.15#features",
     "title": "Zero 0.15",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3567,7 +3582,7 @@
     "kind": "section"
   },
   {
-    "id": "303-release-notes/0.15#fixes",
+    "id": "304-release-notes/0.15#fixes",
     "title": "Zero 0.15",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3577,7 +3592,7 @@
     "kind": "section"
   },
   {
-    "id": "304-release-notes/0.15#breaking-changes",
+    "id": "305-release-notes/0.15#breaking-changes",
     "title": "Zero 0.15",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3617,7 +3632,7 @@
     "kind": "page"
   },
   {
-    "id": "305-release-notes/0.16#install",
+    "id": "306-release-notes/0.16#install",
     "title": "Zero 0.16",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3627,7 +3642,7 @@
     "kind": "section"
   },
   {
-    "id": "306-release-notes/0.16#upgrading",
+    "id": "307-release-notes/0.16#upgrading",
     "title": "Zero 0.16",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -3637,7 +3652,7 @@
     "kind": "section"
   },
   {
-    "id": "307-release-notes/0.16#features",
+    "id": "308-release-notes/0.16#features",
     "title": "Zero 0.16",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3647,7 +3662,7 @@
     "kind": "section"
   },
   {
-    "id": "308-release-notes/0.16#fixes",
+    "id": "309-release-notes/0.16#fixes",
     "title": "Zero 0.16",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3657,7 +3672,7 @@
     "kind": "section"
   },
   {
-    "id": "309-release-notes/0.16#breaking-changes",
+    "id": "310-release-notes/0.16#breaking-changes",
     "title": "Zero 0.16",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3697,7 +3712,7 @@
     "kind": "page"
   },
   {
-    "id": "310-release-notes/0.17#install",
+    "id": "311-release-notes/0.17#install",
     "title": "Zero 0.17",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3707,7 +3722,7 @@
     "kind": "section"
   },
   {
-    "id": "311-release-notes/0.17#upgrading",
+    "id": "312-release-notes/0.17#upgrading",
     "title": "Zero 0.17",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -3717,7 +3732,7 @@
     "kind": "section"
   },
   {
-    "id": "312-release-notes/0.17#features",
+    "id": "313-release-notes/0.17#features",
     "title": "Zero 0.17",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3727,7 +3742,7 @@
     "kind": "section"
   },
   {
-    "id": "313-release-notes/0.17#fixes",
+    "id": "314-release-notes/0.17#fixes",
     "title": "Zero 0.17",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3737,7 +3752,7 @@
     "kind": "section"
   },
   {
-    "id": "314-release-notes/0.17#breaking-changes",
+    "id": "315-release-notes/0.17#breaking-changes",
     "title": "Zero 0.17",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3777,7 +3792,7 @@
     "kind": "page"
   },
   {
-    "id": "315-release-notes/0.18#install",
+    "id": "316-release-notes/0.18#install",
     "title": "Zero 0.18",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3787,7 +3802,7 @@
     "kind": "section"
   },
   {
-    "id": "316-release-notes/0.18#upgrading",
+    "id": "317-release-notes/0.18#upgrading",
     "title": "Zero 0.18",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -3797,7 +3812,7 @@
     "kind": "section"
   },
   {
-    "id": "317-release-notes/0.18#features",
+    "id": "318-release-notes/0.18#features",
     "title": "Zero 0.18",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3807,7 +3822,7 @@
     "kind": "section"
   },
   {
-    "id": "318-release-notes/0.18#fixes",
+    "id": "319-release-notes/0.18#fixes",
     "title": "Zero 0.18",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3817,7 +3832,7 @@
     "kind": "section"
   },
   {
-    "id": "319-release-notes/0.18#breaking-changes",
+    "id": "320-release-notes/0.18#breaking-changes",
     "title": "Zero 0.18",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3857,7 +3872,7 @@
     "kind": "page"
   },
   {
-    "id": "320-release-notes/0.19#install",
+    "id": "321-release-notes/0.19#install",
     "title": "Zero 0.19",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3867,7 +3882,7 @@
     "kind": "section"
   },
   {
-    "id": "321-release-notes/0.19#upgrading",
+    "id": "322-release-notes/0.19#upgrading",
     "title": "Zero 0.19",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -3877,7 +3892,7 @@
     "kind": "section"
   },
   {
-    "id": "322-release-notes/0.19#features",
+    "id": "323-release-notes/0.19#features",
     "title": "Zero 0.19",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3887,7 +3902,7 @@
     "kind": "section"
   },
   {
-    "id": "323-release-notes/0.19#fixes",
+    "id": "324-release-notes/0.19#fixes",
     "title": "Zero 0.19",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3897,7 +3912,7 @@
     "kind": "section"
   },
   {
-    "id": "324-release-notes/0.19#breaking-changes",
+    "id": "325-release-notes/0.19#breaking-changes",
     "title": "Zero 0.19",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3941,7 +3956,7 @@
     "kind": "page"
   },
   {
-    "id": "325-release-notes/0.2#breaking-changes",
+    "id": "326-release-notes/0.2#breaking-changes",
     "title": "Zero 0.2",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
@@ -3951,7 +3966,7 @@
     "kind": "section"
   },
   {
-    "id": "326-release-notes/0.2#features",
+    "id": "327-release-notes/0.2#features",
     "title": "Zero 0.2",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3961,7 +3976,7 @@
     "kind": "section"
   },
   {
-    "id": "327-release-notes/0.2#fixes",
+    "id": "328-release-notes/0.2#fixes",
     "title": "Zero 0.2",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3971,7 +3986,7 @@
     "kind": "section"
   },
   {
-    "id": "328-release-notes/0.2#docs",
+    "id": "329-release-notes/0.2#docs",
     "title": "Zero 0.2",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -3981,7 +3996,7 @@
     "kind": "section"
   },
   {
-    "id": "329-release-notes/0.2#source-tree-fixes",
+    "id": "330-release-notes/0.2#source-tree-fixes",
     "title": "Zero 0.2",
     "searchTitle": "Source tree fixes",
     "sectionTitle": "Source tree fixes",
@@ -3991,7 +4006,7 @@
     "kind": "section"
   },
   {
-    "id": "330-release-notes/0.2#zbugs",
+    "id": "331-release-notes/0.2#zbugs",
     "title": "Zero 0.2",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -4031,7 +4046,7 @@
     "kind": "page"
   },
   {
-    "id": "331-release-notes/0.20#install",
+    "id": "332-release-notes/0.20#install",
     "title": "Zero 0.20",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4041,7 +4056,7 @@
     "kind": "section"
   },
   {
-    "id": "332-release-notes/0.20#upgrading",
+    "id": "333-release-notes/0.20#upgrading",
     "title": "Zero 0.20",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -4051,7 +4066,7 @@
     "kind": "section"
   },
   {
-    "id": "333-release-notes/0.20#features",
+    "id": "334-release-notes/0.20#features",
     "title": "Zero 0.20",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4061,7 +4076,7 @@
     "kind": "section"
   },
   {
-    "id": "334-release-notes/0.20#fixes",
+    "id": "335-release-notes/0.20#fixes",
     "title": "Zero 0.20",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4071,7 +4086,7 @@
     "kind": "section"
   },
   {
-    "id": "335-release-notes/0.20#breaking-changes",
+    "id": "336-release-notes/0.20#breaking-changes",
     "title": "Zero 0.20",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4111,7 +4126,7 @@
     "kind": "page"
   },
   {
-    "id": "336-release-notes/0.21#install",
+    "id": "337-release-notes/0.21#install",
     "title": "Zero 0.21",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4121,7 +4136,7 @@
     "kind": "section"
   },
   {
-    "id": "337-release-notes/0.21#upgrading",
+    "id": "338-release-notes/0.21#upgrading",
     "title": "Zero 0.21",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -4131,7 +4146,7 @@
     "kind": "section"
   },
   {
-    "id": "338-release-notes/0.21#features",
+    "id": "339-release-notes/0.21#features",
     "title": "Zero 0.21",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4141,7 +4156,7 @@
     "kind": "section"
   },
   {
-    "id": "339-release-notes/0.21#fixes",
+    "id": "340-release-notes/0.21#fixes",
     "title": "Zero 0.21",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4151,7 +4166,7 @@
     "kind": "section"
   },
   {
-    "id": "340-release-notes/0.21#breaking-changes",
+    "id": "341-release-notes/0.21#breaking-changes",
     "title": "Zero 0.21",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4203,7 +4218,7 @@
     "kind": "page"
   },
   {
-    "id": "341-release-notes/0.22#install",
+    "id": "342-release-notes/0.22#install",
     "title": "Zero 0.22",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4213,7 +4228,7 @@
     "kind": "section"
   },
   {
-    "id": "342-release-notes/0.22#upgrading",
+    "id": "343-release-notes/0.22#upgrading",
     "title": "Zero 0.22",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -4223,7 +4238,7 @@
     "kind": "section"
   },
   {
-    "id": "343-release-notes/0.22#how-ttls-used-to-work",
+    "id": "344-release-notes/0.22#how-ttls-used-to-work",
     "title": "Zero 0.22",
     "searchTitle": "How TTLs Used to Work",
     "sectionTitle": "How TTLs Used to Work",
@@ -4233,7 +4248,7 @@
     "kind": "section"
   },
   {
-    "id": "344-release-notes/0.22#how-ttls-work-now",
+    "id": "345-release-notes/0.22#how-ttls-work-now",
     "title": "Zero 0.22",
     "searchTitle": "How TTLs Work Now",
     "sectionTitle": "How TTLs Work Now",
@@ -4243,7 +4258,7 @@
     "kind": "section"
   },
   {
-    "id": "345-release-notes/0.22#using-new-ttls",
+    "id": "346-release-notes/0.22#using-new-ttls",
     "title": "Zero 0.22",
     "searchTitle": "Using New TTLs",
     "sectionTitle": "Using New TTLs",
@@ -4253,7 +4268,7 @@
     "kind": "section"
   },
   {
-    "id": "346-release-notes/0.22#features",
+    "id": "347-release-notes/0.22#features",
     "title": "Zero 0.22",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4263,7 +4278,7 @@
     "kind": "section"
   },
   {
-    "id": "347-release-notes/0.22#fixes",
+    "id": "348-release-notes/0.22#fixes",
     "title": "Zero 0.22",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4273,7 +4288,7 @@
     "kind": "section"
   },
   {
-    "id": "348-release-notes/0.22#breaking-changes",
+    "id": "349-release-notes/0.22#breaking-changes",
     "title": "Zero 0.22",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4317,7 +4332,7 @@
     "kind": "page"
   },
   {
-    "id": "349-release-notes/0.23#install",
+    "id": "350-release-notes/0.23#install",
     "title": "Zero 0.23",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4327,7 +4342,7 @@
     "kind": "section"
   },
   {
-    "id": "350-release-notes/0.23#upgrading",
+    "id": "351-release-notes/0.23#upgrading",
     "title": "Zero 0.23",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -4337,7 +4352,7 @@
     "kind": "section"
   },
   {
-    "id": "351-release-notes/0.23#features",
+    "id": "352-release-notes/0.23#features",
     "title": "Zero 0.23",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4347,7 +4362,7 @@
     "kind": "section"
   },
   {
-    "id": "352-release-notes/0.23#fixes",
+    "id": "353-release-notes/0.23#fixes",
     "title": "Zero 0.23",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4357,7 +4372,7 @@
     "kind": "section"
   },
   {
-    "id": "353-release-notes/0.23#zbugs",
+    "id": "354-release-notes/0.23#zbugs",
     "title": "Zero 0.23",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -4367,7 +4382,7 @@
     "kind": "section"
   },
   {
-    "id": "354-release-notes/0.23#breaking-changes",
+    "id": "355-release-notes/0.23#breaking-changes",
     "title": "Zero 0.23",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4407,7 +4422,7 @@
     "kind": "page"
   },
   {
-    "id": "355-release-notes/0.24#installation",
+    "id": "356-release-notes/0.24#installation",
     "title": "Zero 0.24",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -4417,7 +4432,7 @@
     "kind": "section"
   },
   {
-    "id": "356-release-notes/0.24#features",
+    "id": "357-release-notes/0.24#features",
     "title": "Zero 0.24",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4427,7 +4442,7 @@
     "kind": "section"
   },
   {
-    "id": "357-release-notes/0.24#fixes",
+    "id": "358-release-notes/0.24#fixes",
     "title": "Zero 0.24",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4437,7 +4452,7 @@
     "kind": "section"
   },
   {
-    "id": "358-release-notes/0.24#breaking-changes",
+    "id": "359-release-notes/0.24#breaking-changes",
     "title": "Zero 0.24",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4447,7 +4462,7 @@
     "kind": "section"
   },
   {
-    "id": "359-release-notes/0.24#example-upgrades",
+    "id": "360-release-notes/0.24#example-upgrades",
     "title": "Zero 0.24",
     "searchTitle": "Example Upgrades",
     "sectionTitle": "Example Upgrades",
@@ -4495,7 +4510,7 @@
     "kind": "page"
   },
   {
-    "id": "360-release-notes/0.25#installation",
+    "id": "361-release-notes/0.25#installation",
     "title": "Zero 0.25",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -4505,7 +4520,7 @@
     "kind": "section"
   },
   {
-    "id": "361-release-notes/0.25#overview",
+    "id": "362-release-notes/0.25#overview",
     "title": "Zero 0.25",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -4515,7 +4530,7 @@
     "kind": "section"
   },
   {
-    "id": "362-release-notes/0.25#upgrading",
+    "id": "363-release-notes/0.25#upgrading",
     "title": "Zero 0.25",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -4525,7 +4540,7 @@
     "kind": "section"
   },
   {
-    "id": "363-release-notes/0.25#features",
+    "id": "364-release-notes/0.25#features",
     "title": "Zero 0.25",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4535,7 +4550,7 @@
     "kind": "section"
   },
   {
-    "id": "364-release-notes/0.25#performance",
+    "id": "365-release-notes/0.25#performance",
     "title": "Zero 0.25",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
@@ -4545,7 +4560,7 @@
     "kind": "section"
   },
   {
-    "id": "365-release-notes/0.25#fixes",
+    "id": "366-release-notes/0.25#fixes",
     "title": "Zero 0.25",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4555,7 +4570,7 @@
     "kind": "section"
   },
   {
-    "id": "366-release-notes/0.25#breaking-changes",
+    "id": "367-release-notes/0.25#breaking-changes",
     "title": "Zero 0.25",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4591,7 +4606,7 @@
     "kind": "page"
   },
   {
-    "id": "367-release-notes/0.26#installation",
+    "id": "368-release-notes/0.26#installation",
     "title": "Zero 0.26",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -4601,7 +4616,7 @@
     "kind": "section"
   },
   {
-    "id": "368-release-notes/0.26#features",
+    "id": "369-release-notes/0.26#features",
     "title": "Zero 0.26",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4611,7 +4626,7 @@
     "kind": "section"
   },
   {
-    "id": "369-release-notes/0.26#fixes",
+    "id": "370-release-notes/0.26#fixes",
     "title": "Zero 0.26",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4621,7 +4636,7 @@
     "kind": "section"
   },
   {
-    "id": "370-release-notes/0.26#breaking-changes",
+    "id": "371-release-notes/0.26#breaking-changes",
     "title": "Zero 0.26",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4665,7 +4680,7 @@
     "kind": "page"
   },
   {
-    "id": "371-release-notes/0.3#install",
+    "id": "372-release-notes/0.3#install",
     "title": "Zero 0.3",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4675,7 +4690,7 @@
     "kind": "section"
   },
   {
-    "id": "372-release-notes/0.3#breaking-changes",
+    "id": "373-release-notes/0.3#breaking-changes",
     "title": "Zero 0.3",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
@@ -4685,7 +4700,7 @@
     "kind": "section"
   },
   {
-    "id": "373-release-notes/0.3#features",
+    "id": "374-release-notes/0.3#features",
     "title": "Zero 0.3",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4695,7 +4710,7 @@
     "kind": "section"
   },
   {
-    "id": "374-release-notes/0.3#fixes",
+    "id": "375-release-notes/0.3#fixes",
     "title": "Zero 0.3",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4705,7 +4720,7 @@
     "kind": "section"
   },
   {
-    "id": "375-release-notes/0.3#docs",
+    "id": "376-release-notes/0.3#docs",
     "title": "Zero 0.3",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -4715,7 +4730,7 @@
     "kind": "section"
   },
   {
-    "id": "376-release-notes/0.3#zbugs",
+    "id": "377-release-notes/0.3#zbugs",
     "title": "Zero 0.3",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -4759,7 +4774,7 @@
     "kind": "page"
   },
   {
-    "id": "377-release-notes/0.4#install",
+    "id": "378-release-notes/0.4#install",
     "title": "Zero 0.4",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4769,7 +4784,7 @@
     "kind": "section"
   },
   {
-    "id": "378-release-notes/0.4#breaking-changes",
+    "id": "379-release-notes/0.4#breaking-changes",
     "title": "Zero 0.4",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
@@ -4779,7 +4794,7 @@
     "kind": "section"
   },
   {
-    "id": "379-release-notes/0.4#added-or--and--and-not-to-zql-documentation",
+    "id": "380-release-notes/0.4#added-or--and--and-not-to-zql-documentation",
     "title": "Zero 0.4",
     "searchTitle": "Added or , and , and not to ZQL (documentation).",
     "sectionTitle": "Added or , and , and not to ZQL (documentation).",
@@ -4789,7 +4804,7 @@
     "kind": "section"
   },
   {
-    "id": "380-release-notes/0.4#fixes",
+    "id": "381-release-notes/0.4#fixes",
     "title": "Zero 0.4",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4799,7 +4814,7 @@
     "kind": "section"
   },
   {
-    "id": "381-release-notes/0.4#docs",
+    "id": "382-release-notes/0.4#docs",
     "title": "Zero 0.4",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -4809,7 +4824,7 @@
     "kind": "section"
   },
   {
-    "id": "382-release-notes/0.4#zbugs",
+    "id": "383-release-notes/0.4#zbugs",
     "title": "Zero 0.4",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -4853,7 +4868,7 @@
     "kind": "page"
   },
   {
-    "id": "383-release-notes/0.5#install",
+    "id": "384-release-notes/0.5#install",
     "title": "Zero 0.5",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4863,7 +4878,7 @@
     "kind": "section"
   },
   {
-    "id": "384-release-notes/0.5#breaking-changes",
+    "id": "385-release-notes/0.5#breaking-changes",
     "title": "Zero 0.5",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
@@ -4873,7 +4888,7 @@
     "kind": "section"
   },
   {
-    "id": "385-release-notes/0.5#features",
+    "id": "386-release-notes/0.5#features",
     "title": "Zero 0.5",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4883,7 +4898,7 @@
     "kind": "section"
   },
   {
-    "id": "386-release-notes/0.5#fixes",
+    "id": "387-release-notes/0.5#fixes",
     "title": "Zero 0.5",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4893,7 +4908,7 @@
     "kind": "section"
   },
   {
-    "id": "387-release-notes/0.5#docs",
+    "id": "388-release-notes/0.5#docs",
     "title": "Zero 0.5",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -4903,7 +4918,7 @@
     "kind": "section"
   },
   {
-    "id": "388-release-notes/0.5#zbugs",
+    "id": "389-release-notes/0.5#zbugs",
     "title": "Zero 0.5",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -4947,7 +4962,7 @@
     "kind": "page"
   },
   {
-    "id": "389-release-notes/0.6#install",
+    "id": "390-release-notes/0.6#install",
     "title": "Zero 0.6",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4957,7 +4972,7 @@
     "kind": "section"
   },
   {
-    "id": "390-release-notes/0.6#upgrade-guide",
+    "id": "391-release-notes/0.6#upgrade-guide",
     "title": "Zero 0.6",
     "searchTitle": "Upgrade Guide",
     "sectionTitle": "Upgrade Guide",
@@ -4967,7 +4982,7 @@
     "kind": "section"
   },
   {
-    "id": "391-release-notes/0.6#breaking-changes",
+    "id": "392-release-notes/0.6#breaking-changes",
     "title": "Zero 0.6",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4977,7 +4992,7 @@
     "kind": "section"
   },
   {
-    "id": "392-release-notes/0.6#features",
+    "id": "393-release-notes/0.6#features",
     "title": "Zero 0.6",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4987,7 +5002,7 @@
     "kind": "section"
   },
   {
-    "id": "393-release-notes/0.6#zbugs",
+    "id": "394-release-notes/0.6#zbugs",
     "title": "Zero 0.6",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -4997,7 +5012,7 @@
     "kind": "section"
   },
   {
-    "id": "394-release-notes/0.6#docs",
+    "id": "395-release-notes/0.6#docs",
     "title": "Zero 0.6",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -5037,7 +5052,7 @@
     "kind": "page"
   },
   {
-    "id": "395-release-notes/0.7#install",
+    "id": "396-release-notes/0.7#install",
     "title": "Zero 0.7",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -5047,7 +5062,7 @@
     "kind": "section"
   },
   {
-    "id": "396-release-notes/0.7#features",
+    "id": "397-release-notes/0.7#features",
     "title": "Zero 0.7",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5057,7 +5072,7 @@
     "kind": "section"
   },
   {
-    "id": "397-release-notes/0.7#breaking-changes",
+    "id": "398-release-notes/0.7#breaking-changes",
     "title": "Zero 0.7",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5067,7 +5082,7 @@
     "kind": "section"
   },
   {
-    "id": "398-release-notes/0.7#zbugs",
+    "id": "399-release-notes/0.7#zbugs",
     "title": "Zero 0.7",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -5077,7 +5092,7 @@
     "kind": "section"
   },
   {
-    "id": "399-release-notes/0.7#docs",
+    "id": "400-release-notes/0.7#docs",
     "title": "Zero 0.7",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -5113,7 +5128,7 @@
     "kind": "page"
   },
   {
-    "id": "400-release-notes/0.8#install",
+    "id": "401-release-notes/0.8#install",
     "title": "Zero 0.8",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -5123,7 +5138,7 @@
     "kind": "section"
   },
   {
-    "id": "401-release-notes/0.8#features",
+    "id": "402-release-notes/0.8#features",
     "title": "Zero 0.8",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5133,7 +5148,7 @@
     "kind": "section"
   },
   {
-    "id": "402-release-notes/0.8#fixes",
+    "id": "403-release-notes/0.8#fixes",
     "title": "Zero 0.8",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5143,7 +5158,7 @@
     "kind": "section"
   },
   {
-    "id": "403-release-notes/0.8#breaking-changes",
+    "id": "404-release-notes/0.8#breaking-changes",
     "title": "Zero 0.8",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5179,7 +5194,7 @@
     "kind": "page"
   },
   {
-    "id": "404-release-notes/0.9#install",
+    "id": "405-release-notes/0.9#install",
     "title": "Zero 0.9",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -5189,7 +5204,7 @@
     "kind": "section"
   },
   {
-    "id": "405-release-notes/0.9#features",
+    "id": "406-release-notes/0.9#features",
     "title": "Zero 0.9",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5199,7 +5214,7 @@
     "kind": "section"
   },
   {
-    "id": "406-release-notes/0.9#fixes",
+    "id": "407-release-notes/0.9#fixes",
     "title": "Zero 0.9",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5209,7 +5224,7 @@
     "kind": "section"
   },
   {
-    "id": "407-release-notes/0.9#breaking-changes",
+    "id": "408-release-notes/0.9#breaking-changes",
     "title": "Zero 0.9",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5249,7 +5264,7 @@
     "kind": "page"
   },
   {
-    "id": "408-release-notes/1.0#installation",
+    "id": "409-release-notes/1.0#installation",
     "title": "Zero 1.0",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -5259,7 +5274,7 @@
     "kind": "section"
   },
   {
-    "id": "409-release-notes/1.0#overview",
+    "id": "410-release-notes/1.0#overview",
     "title": "Zero 1.0",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -5269,7 +5284,7 @@
     "kind": "section"
   },
   {
-    "id": "410-release-notes/1.0#features",
+    "id": "411-release-notes/1.0#features",
     "title": "Zero 1.0",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5279,7 +5294,7 @@
     "kind": "section"
   },
   {
-    "id": "411-release-notes/1.0#fixes",
+    "id": "412-release-notes/1.0#fixes",
     "title": "Zero 1.0",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5289,7 +5304,7 @@
     "kind": "section"
   },
   {
-    "id": "412-release-notes/1.0#breaking-changes",
+    "id": "413-release-notes/1.0#breaking-changes",
     "title": "Zero 1.0",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5325,7 +5340,7 @@
     "kind": "page"
   },
   {
-    "id": "413-release-notes/1.1#installation",
+    "id": "414-release-notes/1.1#installation",
     "title": "Zero 1.1",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -5335,7 +5350,7 @@
     "kind": "section"
   },
   {
-    "id": "414-release-notes/1.1#features",
+    "id": "415-release-notes/1.1#features",
     "title": "Zero 1.1",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5345,7 +5360,7 @@
     "kind": "section"
   },
   {
-    "id": "415-release-notes/1.1#fixes",
+    "id": "416-release-notes/1.1#fixes",
     "title": "Zero 1.1",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5355,7 +5370,7 @@
     "kind": "section"
   },
   {
-    "id": "416-release-notes/1.1#breaking-changes",
+    "id": "417-release-notes/1.1#breaking-changes",
     "title": "Zero 1.1",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5395,7 +5410,7 @@
     "kind": "page"
   },
   {
-    "id": "417-release-notes/1.2#installation",
+    "id": "418-release-notes/1.2#installation",
     "title": "Zero 1.2",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -5405,7 +5420,7 @@
     "kind": "section"
   },
   {
-    "id": "418-release-notes/1.2#features",
+    "id": "419-release-notes/1.2#features",
     "title": "Zero 1.2",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5415,7 +5430,7 @@
     "kind": "section"
   },
   {
-    "id": "419-release-notes/1.2#performance",
+    "id": "420-release-notes/1.2#performance",
     "title": "Zero 1.2",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
@@ -5425,7 +5440,7 @@
     "kind": "section"
   },
   {
-    "id": "420-release-notes/1.2#fixes",
+    "id": "421-release-notes/1.2#fixes",
     "title": "Zero 1.2",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5435,7 +5450,7 @@
     "kind": "section"
   },
   {
-    "id": "421-release-notes/1.2#breaking-changes",
+    "id": "422-release-notes/1.2#breaking-changes",
     "title": "Zero 1.2",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5475,7 +5490,7 @@
     "kind": "page"
   },
   {
-    "id": "422-release-notes/1.3#installation",
+    "id": "423-release-notes/1.3#installation",
     "title": "Zero 1.3",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -5485,7 +5500,7 @@
     "kind": "section"
   },
   {
-    "id": "423-release-notes/1.3#features",
+    "id": "424-release-notes/1.3#features",
     "title": "Zero 1.3",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5495,7 +5510,7 @@
     "kind": "section"
   },
   {
-    "id": "424-release-notes/1.3#performance",
+    "id": "425-release-notes/1.3#performance",
     "title": "Zero 1.3",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
@@ -5505,7 +5520,7 @@
     "kind": "section"
   },
   {
-    "id": "425-release-notes/1.3#fixes",
+    "id": "426-release-notes/1.3#fixes",
     "title": "Zero 1.3",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5515,7 +5530,7 @@
     "kind": "section"
   },
   {
-    "id": "426-release-notes/1.3#breaking-changes",
+    "id": "427-release-notes/1.3#breaking-changes",
     "title": "Zero 1.3",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5555,7 +5570,7 @@
     "kind": "page"
   },
   {
-    "id": "427-release-notes/1.4#installation",
+    "id": "428-release-notes/1.4#installation",
     "title": "Zero 1.4",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -5565,7 +5580,7 @@
     "kind": "section"
   },
   {
-    "id": "428-release-notes/1.4#features",
+    "id": "429-release-notes/1.4#features",
     "title": "Zero 1.4",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5575,7 +5590,7 @@
     "kind": "section"
   },
   {
-    "id": "429-release-notes/1.4#performance",
+    "id": "430-release-notes/1.4#performance",
     "title": "Zero 1.4",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
@@ -5585,7 +5600,7 @@
     "kind": "section"
   },
   {
-    "id": "430-release-notes/1.4#fixes",
+    "id": "431-release-notes/1.4#fixes",
     "title": "Zero 1.4",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5595,7 +5610,7 @@
     "kind": "section"
   },
   {
-    "id": "431-release-notes/1.4#breaking-changes",
+    "id": "432-release-notes/1.4#breaking-changes",
     "title": "Zero 1.4",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5632,7 +5647,7 @@
     "kind": "page"
   },
   {
-    "id": "432-reporting-bugs#zbugs",
+    "id": "433-reporting-bugs#zbugs",
     "title": "Reporting Bugs",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -5642,7 +5657,7 @@
     "kind": "section"
   },
   {
-    "id": "433-reporting-bugs#discord",
+    "id": "434-reporting-bugs#discord",
     "title": "Reporting Bugs",
     "searchTitle": "Discord",
     "sectionTitle": "Discord",
@@ -5678,7 +5693,7 @@
     "kind": "page"
   },
   {
-    "id": "434-rest#pattern",
+    "id": "435-rest#pattern",
     "title": "REST",
     "searchTitle": "Pattern",
     "sectionTitle": "Pattern",
@@ -5688,7 +5703,7 @@
     "kind": "section"
   },
   {
-    "id": "435-rest#tanstack-start-example",
+    "id": "436-rest#tanstack-start-example",
     "title": "REST",
     "searchTitle": "TanStack Start Example",
     "sectionTitle": "TanStack Start Example",
@@ -5698,7 +5713,7 @@
     "kind": "section"
   },
   {
-    "id": "436-rest#openapi-generation",
+    "id": "437-rest#openapi-generation",
     "title": "REST",
     "searchTitle": "OpenAPI Generation",
     "sectionTitle": "OpenAPI Generation",
@@ -5708,7 +5723,7 @@
     "kind": "section"
   },
   {
-    "id": "437-rest#full-working-example",
+    "id": "438-rest#full-working-example",
     "title": "REST",
     "searchTitle": "Full Working Example",
     "sectionTitle": "Full Working Example",
@@ -5736,7 +5751,7 @@
     "kind": "page"
   },
   {
-    "id": "438-roadmap#q4-2025",
+    "id": "439-roadmap#q4-2025",
     "title": "Roadmap",
     "searchTitle": "Q4 2025",
     "sectionTitle": "Q4 2025",
@@ -5746,7 +5761,7 @@
     "kind": "section"
   },
   {
-    "id": "439-roadmap#beyond",
+    "id": "440-roadmap#beyond",
     "title": "Roadmap",
     "searchTitle": "Beyond",
     "sectionTitle": "Beyond",
@@ -5782,7 +5797,7 @@
     "kind": "page"
   },
   {
-    "id": "440-samples#gigabugs",
+    "id": "441-samples#gigabugs",
     "title": "Samples",
     "searchTitle": "Gigabugs",
     "sectionTitle": "Gigabugs",
@@ -5792,7 +5807,7 @@
     "kind": "section"
   },
   {
-    "id": "441-samples#ztunes",
+    "id": "442-samples#ztunes",
     "title": "Samples",
     "searchTitle": "ztunes",
     "sectionTitle": "ztunes",
@@ -5802,7 +5817,7 @@
     "kind": "section"
   },
   {
-    "id": "442-samples#zslack",
+    "id": "443-samples#zslack",
     "title": "Samples",
     "searchTitle": "zslack",
     "sectionTitle": "zslack",
@@ -5812,7 +5827,7 @@
     "kind": "section"
   },
   {
-    "id": "443-samples#onboarding",
+    "id": "444-samples#onboarding",
     "title": "Samples",
     "searchTitle": "onboarding",
     "sectionTitle": "onboarding",
@@ -5826,7 +5841,7 @@
     "title": "Zero Schema",
     "searchTitle": "Zero Schema",
     "url": "/docs/schema",
-    "content": "Zero applications have both a database schema (the normal backend schema all web apps have) and a Zero schema. The Zero schema is conventionally located in schema.ts in your app's source code. The Zero schema serves two purposes: Provide typesafety for ZQL queries Define first-class relationships between tables The Zero schema is usually generated from your backend schema, but can be defined by hand for more control. Generating from Database If you use Drizzle or Prisma ORM, you can generate schema.ts with drizzle-zero or prisma-zero: npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate We'd love more! See the source for drizzle-zero and prisma-zero as a guide, or reach out on Discord with questions. Writing by Hand You can also write Zero schemas by hand for full control. Table Schemas Use the table function to define each table in your Zero schema: import {table, string, boolean} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), partner: boolean() }) .primaryKey('id') Column types are defined with the boolean(), number(), string(), json(), and enumeration() helpers. See Column Types for how database types are mapped to these types. Name Mapping Use from() to map a TypeScript table or column name to a different database name: const userPref = table('userPref') // Map TS \"userPref\" to DB name \"user_pref\" .from('user_pref') .columns({ id: string(), // Map TS \"orgID\" to DB name \"org_id\" orgID: string().from('org_id') }) Multiple Schemas You can also use from() to access other Postgres schemas: // Sync the \"event\" table from the \"analytics\" schema. const event = table('event').from('analytics.event') Optional Columns Columns can be marked optional. This corresponds to the SQL concept nullable. const user = table('user') .columns({ id: string(), name: string(), nickName: string().optional() }) .primaryKey('id') An optional column can store a value of the specified type or null to mean no value. Note that null and undefined mean different things when working with Zero rows. When reading, if a column is optional, Zero can return null for that field. undefined is not used at all when Reading from Zero. When writing, you can specify null for an optional field to explicitly write null to the datastore, unsetting any previous value. For create and upsert you can set optional fields to undefined (or leave the field off completely) to take the default value as specified by backend schema for that column. For update you can set any non-PK field to undefined to leave the previous value unmodified. Enumerations Use the enumeration helper to define a column that can only take on a specific set of values. This is most often used alongside an enum Postgres column type. import {table, string, enumeration} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), mood: enumeration<'happy' | 'sad' | 'taco'>() }) .primaryKey('id') Custom JSON Types Use the json helper to define a column that stores a JSON-compatible value: import {table, string, json} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), settings: json<{theme: 'light' | 'dark'}>() }) .primaryKey('id') Compound Primary Keys Pass multiple columns to primaryKey to define a compound primary key: const user = table('user') .columns({ orgID: string(), userID: string(), name: string() }) .primaryKey('orgID', 'userID') Relationships Use the relationships function to define relationships between tables. Use the one and many helpers to define singular and plural relationships, respectively: const messageRelationships = relationships( message, ({one, many}) => ({ sender: one({ sourceField: ['senderID'], destField: ['id'], destSchema: user }), replies: many({ sourceField: ['id'], destSchema: message, destField: ['parentMessageID'] }) }) ) This creates \"sender\" and \"replies\" relationships that can later be queried with the related ZQL clause: const messagesWithSenderAndReplies = z.query.messages .related('sender') .related('replies') This will return an object for each message row. Each message will have a sender field that is a single User object or null, and a replies field that is an array of Message objects. Many-to-Many Relationships You can create many-to-many relationships by chaining the relationship definitions. Assuming issue and label tables, along with an issueLabel junction table, you can define a labels relationship like this: const issueRelationships = relationships( issue, ({many}) => ({ labels: many( { sourceField: ['id'], destSchema: issueLabel, destField: ['issueID'] }, { sourceField: ['labelID'], destSchema: label, destField: ['id'] } ) }) ) See https://bugs.rocicorp.dev/issue/3454. Compound Keys Relationships Relationships can traverse compound keys. Imagine a user table with a compound primary key of orgID and userID, and a message table with a related senderOrgID and senderUserID. This can be represented in your schema with: const messageRelationships = relationships( message, ({one}) => ({ sender: one({ sourceField: ['senderOrgID', 'senderUserID'], destSchema: user, destField: ['orgID', 'userID'] }) }) ) Circular Relationships Circular relationships are fully supported: const commentRelationships = relationships( comment, ({one}) => ({ parent: one({ sourceField: ['parentID'], destSchema: comment, destField: ['id'] }) }) ) Database Schemas Use createSchema to define the entire Zero schema: import {createSchema} from '@rocicorp/zero' export const schema = createSchema({ tables: [user, medium, message], relationships: [ userRelationships, mediumRelationships, messageRelationships ] }) Register Schema Type Use DefaultTypes to register the your Schema type with Zero: declare module '@rocicorp/zero' { interface DefaultTypes { schema: Schema } } This prevents having to pass Schema manually to every Zero API. Schema Changes Zero applications have three components that interact with the database schema: Postgres, the API server (query/mutate endpoints), and the client. Development During development, you can make changes to all three components in any order: Change the Postgres schema Update the API server to use the new schema Update client code to use the new schema If the Zero client ever detects that its schema is incompatible with the server, it disconnects and fires the onUpdateNeeded event. If the API server ever detects that it has an incompatible schema, it will fail with an error. Simply reloading the app fixes both issues. Production Zero also supports downtime-free schema changes for use in production. To achieve this, the order you deploy in matters: Expand (adding things): Deploy providers before consumers. DB → API → Client. Contract (removing things): Deploy consumers before providers. Client → API → DB. For production apps, we strongly recommend testing schema changes on a staging environment that has a production-like dataset before deploying to production. Expand Changes When you're adding a column, table, or new mutator/query: Deploy the database change and wait for it to replicate through zero-cache. In Cloud Zero, you can see replication status in the dashboard. In self-hosted zero-cache, check the logs. If there's backfill, wait for that to complete. Deploy the API server. Deploy the client. If you use a custom publication with Supabase, you need to manually notify zero-cache of changes to your publication. For full-stack frameworks where the API and client deploy together, steps 2 and 3 are combined. If your change doesn't affect the Postgres schema (for example, just adding a mutator that uses existing columns), skip step 1. If your change doesn't affect the API server, skip step 2. If you deploy the API server before the schema change has replicated, mutators and/or queries will fail because they will refer to non-existent columns. If you deploy the client before the API change, the client will call mutators/queries that don't exist yet. Both these issues will cause Zero to go into an error state. The user can manually reload to recover from this as soon as the depended-upon component has been deployed. Contract Changes When you're removing a column, table, or mutator/query: Deploy the client (stop using the thing being removed). Deploy the API server (stop providing the thing being removed). Deploy the database change. When a client connects to zero-cache, it sends the schema it was built against. If that schema is incompatible with what zero-cache has (for example if server has just contracted), the client receives an error and calls onUpdateNeeded: new Zero({ // Optional. By default calls location.reload() onUpdateNeeded: reason => { if (reason.type === 'SchemaVersionNotSupported') { // Show a banner prompting the user to update } } }) By default onUpdateNeeded calls location.reload() if available. On the web, this will reload the page and the user will get the new code. For native apps or web apps that want a smoother experience, provide a custom onUpdateNeeded callback. Compound Changes Some changes are both expand and contract—like renaming a column or changing a mutator's interface. For these, you run both patterns in sequence: Expand: Add the new column/mutator. Optionally backfill data and add a trigger to keep the old column in sync. Contract: Remove the old column/mutator. Examples Adding a Column Add a bio column to the users table: Add column to database ALTER TABLE users ADD COLUMN bio TEXT; Wait for replication. Deploy API server Add bio to schema.ts Add any new queries that read bio Add any new mutators that write to bio Deploy Deploy client Update app code to display/edit bio Deploy For full-stack frameworks, steps 2 and 3 are a single deploy. Even when the API server and client are separate, they can be deployed in sequence by CI using a single PR. The client just can't be deployed until the API server is complete. Removing a Column Remove the bio column from the users table: Deploy client Remove bio from app code Deploy Deploy API server Remove mutators that write to bio Remove queries that read bio Remove bio from schema.ts Deploy Remove column from database ALTER TABLE users DROP COLUMN bio; Renaming a Column Rename nickname to displayName: Add new column with trigger ALTER TABLE users ADD COLUMN display_name TEXT; UPDATE users SET display_name = nickname; CREATE FUNCTION sync_display_name() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN -- On insert, sync whichever column was provided IF NEW.display_name IS NULL AND NEW.nickname IS NOT NULL THEN NEW.display_name := NEW.nickname; ELSIF NEW.nickname IS NULL AND NEW.display_name IS NOT NULL THEN NEW.nickname := NEW.display_name; END IF; ELSE -- UPDATE -- Sync whichever column changed IF NEW.display_name IS DISTINCT FROM OLD.display_name AND NEW.nickname IS NOT DISTINCT FROM OLD.nickname THEN NEW.nickname := NEW.display_name; ELSIF NEW.nickname IS DISTINCT FROM OLD.nickname AND NEW.display_name IS NOT DISTINCT FROM OLD.display_name THEN NEW.display_name := NEW.nickname; END IF; END IF; RETURN NEW; END; $$ LANGUAGE plpgsql; CREATE TRIGGER sync_display_name_trigger BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE FUNCTION sync_display_name(); Wait for replication. Deploy app using new column Add displayName to schema.ts Update app code to read/write displayName Update queries to read/write displayName Update mutators to use displayName Deploy API → Client Remove old column Remove nickname from schema.ts Deploy Client → API Drop trigger and old column: DROP TRIGGER sync_display_name_trigger ON users; DROP FUNCTION sync_display_name(); ALTER TABLE users DROP COLUMN nickname; Making a Column Optional Change nickname from required to optional: The safest approach is to treat this like a rename—create a new nullable column: Add new nullable column with trigger ALTER TABLE users ADD COLUMN nickname_v2 TEXT; -- nullable UPDATE users SET nickname_v2 = nickname; CREATE FUNCTION sync_nickname() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN -- On insert, sync whichever column was provided IF NEW.nickname_v2 IS NULL AND NEW.nickname IS NOT NULL THEN NEW.nickname_v2 := NEW.nickname; ELSIF NEW.nickname IS NULL AND NEW.nickname_v2 IS NOT NULL THEN NEW.nickname := COALESCE(NEW.nickname_v2, ''); -- default for old clients END IF; ELSE -- UPDATE -- Sync whichever column changed IF NEW.nickname_v2 IS DISTINCT FROM OLD.nickname_v2 AND NEW.nickname IS NOT DISTINCT FROM OLD.nickname THEN NEW.nickname := COALESCE(NEW.nickname_v2, ''); -- default for old clients ELSIF NEW.nickname IS DISTINCT FROM OLD.nickname AND NEW.nickname_v2 IS NOT DISTINCT FROM OLD.nickname_v2 THEN NEW.nickname_v2 := NEW.nickname; END IF; END IF; RETURN NEW; END; $$ LANGUAGE plpgsql; CREATE TRIGGER sync_nickname_trigger BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE FUNCTION sync_nickname(); Wait for replication. Deploy app using new column Add nicknameV2 to schema.ts as optional() Update app code to handle nulls Deploy API → Client Remove old column Remove nickname from schema.ts Rename nickname_v2 to nickname if desired (another rename cycle), or keep the new name Deploy Client → API Drop trigger and old column Quick Reference Backfill When you add a new column or table to your schema, initial data (from e.g., GENERATED, DEFAULT, CURRENT_TIMESTAMP, etc.) needs to be replicated to zero-cache and synced to clients. Similarly, when adding an existing column to a custom publication, that column's existing data needs to be replicated. Zero handles both these cases through a process called backfilling. Zero backfills existing data to the replica in the background after detecting a new column. The new column is not exposed to the client until all data has been backfilled, which may take some time depending on the amount of data. Monitoring Backfill Progress To track backfill progress, check your zero-cache logs for messages about backfilling status. If you're using Cloud Zero, backfill progress is displayed directly in the dashboard.",
+    "content": "Zero applications have both a database schema (the normal backend schema all web apps have) and a Zero schema. The Zero schema is conventionally located in schema.ts in your app's source code. The Zero schema serves two purposes: Provide typesafety for ZQL queries Define first-class relationships between tables The Zero schema is usually generated from your backend schema, but can be defined by hand for more control. Generating from Database If you use Drizzle or Prisma ORM, you can generate schema.ts with drizzle-zero or prisma-zero: npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm exec drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn exec drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate We'd love more! See the source for drizzle-zero and prisma-zero as a guide, or reach out on Discord with questions. Writing by Hand You can also write Zero schemas by hand for full control. Table Schemas Use the table function to define each table in your Zero schema: import {table, string, boolean} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), partner: boolean() }) .primaryKey('id') Column types are defined with the boolean(), number(), string(), json(), and enumeration() helpers. See Column Types for how database types are mapped to these types. Name Mapping Use from() to map a TypeScript table or column name to a different database name: const userPref = table('userPref') // Map TS \"userPref\" to DB name \"user_pref\" .from('user_pref') .columns({ id: string(), // Map TS \"orgID\" to DB name \"org_id\" orgID: string().from('org_id') }) Multiple Schemas You can also use from() to access other Postgres schemas: // Sync the \"event\" table from the \"analytics\" schema. const event = table('event').from('analytics.event') Optional Columns Columns can be marked optional. This corresponds to the SQL concept nullable. const user = table('user') .columns({ id: string(), name: string(), nickName: string().optional() }) .primaryKey('id') An optional column can store a value of the specified type or null to mean no value. Note that null and undefined mean different things when working with Zero rows. When reading, if a column is optional, Zero can return null for that field. undefined is not used at all when Reading from Zero. When writing, you can specify null for an optional field to explicitly write null to the datastore, unsetting any previous value. For create and upsert you can set optional fields to undefined (or leave the field off completely) to take the default value as specified by backend schema for that column. For update you can set any non-PK field to undefined to leave the previous value unmodified. Enumerations Use the enumeration helper to define a column that can only take on a specific set of values. This is most often used alongside an enum Postgres column type. import {table, string, enumeration} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), mood: enumeration<'happy' | 'sad' | 'taco'>() }) .primaryKey('id') Custom JSON Types Use the json helper to define a column that stores a JSON-compatible value: import {table, string, json} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), settings: json<{theme: 'light' | 'dark'}>() }) .primaryKey('id') Compound Primary Keys Pass multiple columns to primaryKey to define a compound primary key: const user = table('user') .columns({ orgID: string(), userID: string(), name: string() }) .primaryKey('orgID', 'userID') Relationships Use the relationships function to define relationships between tables. Use the one and many helpers to define singular and plural relationships, respectively: const messageRelationships = relationships( message, ({one, many}) => ({ sender: one({ sourceField: ['senderID'], destField: ['id'], destSchema: user }), replies: many({ sourceField: ['id'], destSchema: message, destField: ['parentMessageID'] }) }) ) This creates \"sender\" and \"replies\" relationships that can later be queried with the related ZQL clause: const messagesWithSenderAndReplies = z.query.messages .related('sender') .related('replies') This will return an object for each message row. Each message will have a sender field that is a single User object or null, and a replies field that is an array of Message objects. Many-to-Many Relationships You can create many-to-many relationships by chaining the relationship definitions. Assuming issue and label tables, along with an issueLabel junction table, you can define a labels relationship like this: const issueRelationships = relationships( issue, ({many}) => ({ labels: many( { sourceField: ['id'], destSchema: issueLabel, destField: ['issueID'] }, { sourceField: ['labelID'], destSchema: label, destField: ['id'] } ) }) ) See https://bugs.rocicorp.dev/issue/3454. Compound Keys Relationships Relationships can traverse compound keys. Imagine a user table with a compound primary key of orgID and userID, and a message table with a related senderOrgID and senderUserID. This can be represented in your schema with: const messageRelationships = relationships( message, ({one}) => ({ sender: one({ sourceField: ['senderOrgID', 'senderUserID'], destSchema: user, destField: ['orgID', 'userID'] }) }) ) Circular Relationships Circular relationships are fully supported: const commentRelationships = relationships( comment, ({one}) => ({ parent: one({ sourceField: ['parentID'], destSchema: comment, destField: ['id'] }) }) ) Database Schemas Use createSchema to define the entire Zero schema: import {createSchema} from '@rocicorp/zero' export const schema = createSchema({ tables: [user, medium, message], relationships: [ userRelationships, mediumRelationships, messageRelationships ] }) Register Schema Type Use DefaultTypes to register the your Schema type with Zero: declare module '@rocicorp/zero' { interface DefaultTypes { schema: Schema } } This prevents having to pass Schema manually to every Zero API. Schema Changes Zero applications have three components that interact with the database schema: Postgres, the API server (query/mutate endpoints), and the client. Development During development, you can make changes to all three components in any order: Change the Postgres schema Update the API server to use the new schema Update client code to use the new schema If the Zero client ever detects that its schema is incompatible with the server, it disconnects and fires the onUpdateNeeded event. If the API server ever detects that it has an incompatible schema, it will fail with an error. Simply reloading the app fixes both issues. Production Zero also supports downtime-free schema changes for use in production. To achieve this, the order you deploy in matters: Expand (adding things): Deploy providers before consumers. DB → API → Client. Contract (removing things): Deploy consumers before providers. Client → API → DB. For production apps, we strongly recommend testing schema changes on a staging environment that has a production-like dataset before deploying to production. Expand Changes When you're adding a column, table, or new mutator/query: Deploy the database change and wait for it to replicate through zero-cache. In Cloud Zero, you can see replication status in the dashboard. In self-hosted zero-cache, check the logs. If there's backfill, wait for that to complete. Deploy the API server. Deploy the client. If you use a custom publication with Supabase, you need to manually notify zero-cache of changes to your publication. For full-stack frameworks where the API and client deploy together, steps 2 and 3 are combined. If your change doesn't affect the Postgres schema (for example, just adding a mutator that uses existing columns), skip step 1. If your change doesn't affect the API server, skip step 2. If you deploy the API server before the schema change has replicated, mutators and/or queries will fail because they will refer to non-existent columns. If you deploy the client before the API change, the client will call mutators/queries that don't exist yet. Both these issues will cause Zero to go into an error state. The user can manually reload to recover from this as soon as the depended-upon component has been deployed. Contract Changes When you're removing a column, table, or mutator/query: Deploy the client (stop using the thing being removed). Deploy the API server (stop providing the thing being removed). Deploy the database change. When a client connects to zero-cache, it sends the schema it was built against. If that schema is incompatible with what zero-cache has (for example if server has just contracted), the client receives an error and calls onUpdateNeeded: new Zero({ // Optional. By default calls location.reload() onUpdateNeeded: reason => { if (reason.type === 'SchemaVersionNotSupported') { // Show a banner prompting the user to update } } }) By default onUpdateNeeded calls location.reload() if available. On the web, this will reload the page and the user will get the new code. For native apps or web apps that want a smoother experience, provide a custom onUpdateNeeded callback. Compound Changes Some changes are both expand and contract—like renaming a column or changing a mutator's interface. For these, you run both patterns in sequence: Expand: Add the new column/mutator. Optionally backfill data and add a trigger to keep the old column in sync. Contract: Remove the old column/mutator. Examples Adding a Column Add a bio column to the users table: Add column to database ALTER TABLE users ADD COLUMN bio TEXT; Wait for replication. Deploy API server Add bio to schema.ts Add any new queries that read bio Add any new mutators that write to bio Deploy Deploy client Update app code to display/edit bio Deploy For full-stack frameworks, steps 2 and 3 are a single deploy. Even when the API server and client are separate, they can be deployed in sequence by CI using a single PR. The client just can't be deployed until the API server is complete. Removing a Column Remove the bio column from the users table: Deploy client Remove bio from app code Deploy Deploy API server Remove mutators that write to bio Remove queries that read bio Remove bio from schema.ts Deploy Remove column from database ALTER TABLE users DROP COLUMN bio; Renaming a Column Rename nickname to displayName: Add new column with trigger ALTER TABLE users ADD COLUMN display_name TEXT; UPDATE users SET display_name = nickname; CREATE FUNCTION sync_display_name() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN -- On insert, sync whichever column was provided IF NEW.display_name IS NULL AND NEW.nickname IS NOT NULL THEN NEW.display_name := NEW.nickname; ELSIF NEW.nickname IS NULL AND NEW.display_name IS NOT NULL THEN NEW.nickname := NEW.display_name; END IF; ELSE -- UPDATE -- Sync whichever column changed IF NEW.display_name IS DISTINCT FROM OLD.display_name AND NEW.nickname IS NOT DISTINCT FROM OLD.nickname THEN NEW.nickname := NEW.display_name; ELSIF NEW.nickname IS DISTINCT FROM OLD.nickname AND NEW.display_name IS NOT DISTINCT FROM OLD.display_name THEN NEW.display_name := NEW.nickname; END IF; END IF; RETURN NEW; END; $$ LANGUAGE plpgsql; CREATE TRIGGER sync_display_name_trigger BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE FUNCTION sync_display_name(); Wait for replication. Deploy app using new column Add displayName to schema.ts Update app code to read/write displayName Update queries to read/write displayName Update mutators to use displayName Deploy API → Client Remove old column Remove nickname from schema.ts Deploy Client → API Drop trigger and old column: DROP TRIGGER sync_display_name_trigger ON users; DROP FUNCTION sync_display_name(); ALTER TABLE users DROP COLUMN nickname; Making a Column Optional Change nickname from required to optional: The safest approach is to treat this like a rename—create a new nullable column: Add new nullable column with trigger ALTER TABLE users ADD COLUMN nickname_v2 TEXT; -- nullable UPDATE users SET nickname_v2 = nickname; CREATE FUNCTION sync_nickname() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN -- On insert, sync whichever column was provided IF NEW.nickname_v2 IS NULL AND NEW.nickname IS NOT NULL THEN NEW.nickname_v2 := NEW.nickname; ELSIF NEW.nickname IS NULL AND NEW.nickname_v2 IS NOT NULL THEN NEW.nickname := COALESCE(NEW.nickname_v2, ''); -- default for old clients END IF; ELSE -- UPDATE -- Sync whichever column changed IF NEW.nickname_v2 IS DISTINCT FROM OLD.nickname_v2 AND NEW.nickname IS NOT DISTINCT FROM OLD.nickname THEN NEW.nickname := COALESCE(NEW.nickname_v2, ''); -- default for old clients ELSIF NEW.nickname IS DISTINCT FROM OLD.nickname AND NEW.nickname_v2 IS NOT DISTINCT FROM OLD.nickname_v2 THEN NEW.nickname_v2 := NEW.nickname; END IF; END IF; RETURN NEW; END; $$ LANGUAGE plpgsql; CREATE TRIGGER sync_nickname_trigger BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE FUNCTION sync_nickname(); Wait for replication. Deploy app using new column Add nicknameV2 to schema.ts as optional() Update app code to handle nulls Deploy API → Client Remove old column Remove nickname from schema.ts Rename nickname_v2 to nickname if desired (another rename cycle), or keep the new name Deploy Client → API Drop trigger and old column Quick Reference Backfill When you add a new column or table to your schema, initial data (from e.g., GENERATED, DEFAULT, CURRENT_TIMESTAMP, etc.) needs to be replicated to zero-cache and synced to clients. Similarly, when adding an existing column to a custom publication, that column's existing data needs to be replicated. Zero handles both these cases through a process called backfilling. Zero backfills existing data to the replica in the background after detecting a new column. The new column is not exposed to the client until all data has been backfilled, which may take some time depending on the amount of data. Monitoring Backfill Progress To track backfill progress, check your zero-cache logs for messages about backfilling status. If you're using Cloud Zero, backfill progress is displayed directly in the dashboard.",
     "headings": [
       {
         "text": "Generating from Database",
@@ -5948,17 +5963,17 @@
     "kind": "page"
   },
   {
-    "id": "444-schema#generating-from-database",
+    "id": "445-schema#generating-from-database",
     "title": "Zero Schema",
     "searchTitle": "Generating from Database",
     "sectionTitle": "Generating from Database",
     "sectionId": "generating-from-database",
     "url": "/docs/schema",
-    "content": "If you use Drizzle or Prisma ORM, you can generate schema.ts with drizzle-zero or prisma-zero: npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate We'd love more! See the source for drizzle-zero and prisma-zero as a guide, or reach out on Discord with questions.",
+    "content": "If you use Drizzle or Prisma ORM, you can generate schema.ts with drizzle-zero or prisma-zero: npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm exec drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn exec drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate We'd love more! See the source for drizzle-zero and prisma-zero as a guide, or reach out on Discord with questions.",
     "kind": "section"
   },
   {
-    "id": "445-schema#writing-by-hand",
+    "id": "446-schema#writing-by-hand",
     "title": "Zero Schema",
     "searchTitle": "Writing by Hand",
     "sectionTitle": "Writing by Hand",
@@ -5968,7 +5983,7 @@
     "kind": "section"
   },
   {
-    "id": "446-schema#table-schemas",
+    "id": "447-schema#table-schemas",
     "title": "Zero Schema",
     "searchTitle": "Table Schemas",
     "sectionTitle": "Table Schemas",
@@ -5978,7 +5993,7 @@
     "kind": "section"
   },
   {
-    "id": "447-schema#name-mapping",
+    "id": "448-schema#name-mapping",
     "title": "Zero Schema",
     "searchTitle": "Name Mapping",
     "sectionTitle": "Name Mapping",
@@ -5988,7 +6003,7 @@
     "kind": "section"
   },
   {
-    "id": "448-schema#multiple-schemas",
+    "id": "449-schema#multiple-schemas",
     "title": "Zero Schema",
     "searchTitle": "Multiple Schemas",
     "sectionTitle": "Multiple Schemas",
@@ -5998,7 +6013,7 @@
     "kind": "section"
   },
   {
-    "id": "449-schema#optional-columns",
+    "id": "450-schema#optional-columns",
     "title": "Zero Schema",
     "searchTitle": "Optional Columns",
     "sectionTitle": "Optional Columns",
@@ -6008,7 +6023,7 @@
     "kind": "section"
   },
   {
-    "id": "450-schema#enumerations",
+    "id": "451-schema#enumerations",
     "title": "Zero Schema",
     "searchTitle": "Enumerations",
     "sectionTitle": "Enumerations",
@@ -6018,7 +6033,7 @@
     "kind": "section"
   },
   {
-    "id": "451-schema#custom-json-types",
+    "id": "452-schema#custom-json-types",
     "title": "Zero Schema",
     "searchTitle": "Custom JSON Types",
     "sectionTitle": "Custom JSON Types",
@@ -6028,7 +6043,7 @@
     "kind": "section"
   },
   {
-    "id": "452-schema#compound-primary-keys",
+    "id": "453-schema#compound-primary-keys",
     "title": "Zero Schema",
     "searchTitle": "Compound Primary Keys",
     "sectionTitle": "Compound Primary Keys",
@@ -6038,7 +6053,7 @@
     "kind": "section"
   },
   {
-    "id": "453-schema#relationships",
+    "id": "454-schema#relationships",
     "title": "Zero Schema",
     "searchTitle": "Relationships",
     "sectionTitle": "Relationships",
@@ -6048,7 +6063,7 @@
     "kind": "section"
   },
   {
-    "id": "454-schema#many-to-many-relationships",
+    "id": "455-schema#many-to-many-relationships",
     "title": "Zero Schema",
     "searchTitle": "Many-to-Many Relationships",
     "sectionTitle": "Many-to-Many Relationships",
@@ -6058,7 +6073,7 @@
     "kind": "section"
   },
   {
-    "id": "455-schema#compound-keys-relationships",
+    "id": "456-schema#compound-keys-relationships",
     "title": "Zero Schema",
     "searchTitle": "Compound Keys Relationships",
     "sectionTitle": "Compound Keys Relationships",
@@ -6068,7 +6083,7 @@
     "kind": "section"
   },
   {
-    "id": "456-schema#circular-relationships",
+    "id": "457-schema#circular-relationships",
     "title": "Zero Schema",
     "searchTitle": "Circular Relationships",
     "sectionTitle": "Circular Relationships",
@@ -6078,7 +6093,7 @@
     "kind": "section"
   },
   {
-    "id": "457-schema#database-schemas",
+    "id": "458-schema#database-schemas",
     "title": "Zero Schema",
     "searchTitle": "Database Schemas",
     "sectionTitle": "Database Schemas",
@@ -6088,7 +6103,7 @@
     "kind": "section"
   },
   {
-    "id": "458-schema#register-schema-type",
+    "id": "459-schema#register-schema-type",
     "title": "Zero Schema",
     "searchTitle": "Register Schema Type",
     "sectionTitle": "Register Schema Type",
@@ -6098,7 +6113,7 @@
     "kind": "section"
   },
   {
-    "id": "459-schema#schema-changes",
+    "id": "460-schema#schema-changes",
     "title": "Zero Schema",
     "searchTitle": "Schema Changes",
     "sectionTitle": "Schema Changes",
@@ -6108,7 +6123,7 @@
     "kind": "section"
   },
   {
-    "id": "460-schema#development",
+    "id": "461-schema#development",
     "title": "Zero Schema",
     "searchTitle": "Development",
     "sectionTitle": "Development",
@@ -6118,7 +6133,7 @@
     "kind": "section"
   },
   {
-    "id": "461-schema#production",
+    "id": "462-schema#production",
     "title": "Zero Schema",
     "searchTitle": "Production",
     "sectionTitle": "Production",
@@ -6128,7 +6143,7 @@
     "kind": "section"
   },
   {
-    "id": "462-schema#expand-changes",
+    "id": "463-schema#expand-changes",
     "title": "Zero Schema",
     "searchTitle": "Expand Changes",
     "sectionTitle": "Expand Changes",
@@ -6138,7 +6153,7 @@
     "kind": "section"
   },
   {
-    "id": "463-schema#contract-changes",
+    "id": "464-schema#contract-changes",
     "title": "Zero Schema",
     "searchTitle": "Contract Changes",
     "sectionTitle": "Contract Changes",
@@ -6148,7 +6163,7 @@
     "kind": "section"
   },
   {
-    "id": "464-schema#compound-changes",
+    "id": "465-schema#compound-changes",
     "title": "Zero Schema",
     "searchTitle": "Compound Changes",
     "sectionTitle": "Compound Changes",
@@ -6158,7 +6173,7 @@
     "kind": "section"
   },
   {
-    "id": "465-schema#examples",
+    "id": "466-schema#examples",
     "title": "Zero Schema",
     "searchTitle": "Examples",
     "sectionTitle": "Examples",
@@ -6168,7 +6183,7 @@
     "kind": "section"
   },
   {
-    "id": "466-schema#adding-a-column",
+    "id": "467-schema#adding-a-column",
     "title": "Zero Schema",
     "searchTitle": "Adding a Column",
     "sectionTitle": "Adding a Column",
@@ -6178,7 +6193,7 @@
     "kind": "section"
   },
   {
-    "id": "467-schema#removing-a-column",
+    "id": "468-schema#removing-a-column",
     "title": "Zero Schema",
     "searchTitle": "Removing a Column",
     "sectionTitle": "Removing a Column",
@@ -6188,7 +6203,7 @@
     "kind": "section"
   },
   {
-    "id": "468-schema#renaming-a-column",
+    "id": "469-schema#renaming-a-column",
     "title": "Zero Schema",
     "searchTitle": "Renaming a Column",
     "sectionTitle": "Renaming a Column",
@@ -6198,7 +6213,7 @@
     "kind": "section"
   },
   {
-    "id": "469-schema#making-a-column-optional",
+    "id": "470-schema#making-a-column-optional",
     "title": "Zero Schema",
     "searchTitle": "Making a Column Optional",
     "sectionTitle": "Making a Column Optional",
@@ -6208,7 +6223,7 @@
     "kind": "section"
   },
   {
-    "id": "470-schema#quick-reference",
+    "id": "471-schema#quick-reference",
     "title": "Zero Schema",
     "searchTitle": "Quick Reference",
     "sectionTitle": "Quick Reference",
@@ -6218,7 +6233,7 @@
     "kind": "section"
   },
   {
-    "id": "471-schema#backfill",
+    "id": "472-schema#backfill",
     "title": "Zero Schema",
     "searchTitle": "Backfill",
     "sectionTitle": "Backfill",
@@ -6228,7 +6243,7 @@
     "kind": "section"
   },
   {
-    "id": "472-schema#monitoring-backfill-progress",
+    "id": "473-schema#monitoring-backfill-progress",
     "title": "Zero Schema",
     "searchTitle": "Monitoring Backfill Progress",
     "sectionTitle": "Monitoring Backfill Progress",
@@ -6296,7 +6311,7 @@
     "kind": "page"
   },
   {
-    "id": "473-self-host#minimum-viable-strategy",
+    "id": "474-self-host#minimum-viable-strategy",
     "title": "Self-Hosting Zero",
     "searchTitle": "Minimum Viable Strategy",
     "sectionTitle": "Minimum Viable Strategy",
@@ -6306,7 +6321,7 @@
     "kind": "section"
   },
   {
-    "id": "474-self-host#maximal-strategy",
+    "id": "475-self-host#maximal-strategy",
     "title": "Self-Hosting Zero",
     "searchTitle": "Maximal Strategy",
     "sectionTitle": "Maximal Strategy",
@@ -6316,7 +6331,7 @@
     "kind": "section"
   },
   {
-    "id": "475-self-host#replica-lifecycle",
+    "id": "476-self-host#replica-lifecycle",
     "title": "Self-Hosting Zero",
     "searchTitle": "Replica Lifecycle",
     "sectionTitle": "Replica Lifecycle",
@@ -6326,7 +6341,7 @@
     "kind": "section"
   },
   {
-    "id": "476-self-host#performance",
+    "id": "477-self-host#performance",
     "title": "Self-Hosting Zero",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
@@ -6336,7 +6351,7 @@
     "kind": "section"
   },
   {
-    "id": "477-self-host#hydration",
+    "id": "478-self-host#hydration",
     "title": "Self-Hosting Zero",
     "searchTitle": "Hydration",
     "sectionTitle": "Hydration",
@@ -6346,7 +6361,7 @@
     "kind": "section"
   },
   {
-    "id": "478-self-host#ivm-advancement",
+    "id": "479-self-host#ivm-advancement",
     "title": "Self-Hosting Zero",
     "searchTitle": "IVM advancement",
     "sectionTitle": "IVM advancement",
@@ -6356,7 +6371,7 @@
     "kind": "section"
   },
   {
-    "id": "479-self-host#system-level",
+    "id": "480-self-host#system-level",
     "title": "Self-Hosting Zero",
     "searchTitle": "System-level",
     "sectionTitle": "System-level",
@@ -6366,7 +6381,7 @@
     "kind": "section"
   },
   {
-    "id": "480-self-host#networking",
+    "id": "481-self-host#networking",
     "title": "Self-Hosting Zero",
     "searchTitle": "Networking",
     "sectionTitle": "Networking",
@@ -6376,7 +6391,7 @@
     "kind": "section"
   },
   {
-    "id": "481-self-host#sticky-sessions",
+    "id": "482-self-host#sticky-sessions",
     "title": "Self-Hosting Zero",
     "searchTitle": "Sticky Sessions",
     "sectionTitle": "Sticky Sessions",
@@ -6386,7 +6401,7 @@
     "kind": "section"
   },
   {
-    "id": "482-self-host#rolling-updates",
+    "id": "483-self-host#rolling-updates",
     "title": "Self-Hosting Zero",
     "searchTitle": "Rolling Updates",
     "sectionTitle": "Rolling Updates",
@@ -6396,7 +6411,7 @@
     "kind": "section"
   },
   {
-    "id": "483-self-host#clientserver-version-compatibility",
+    "id": "484-self-host#clientserver-version-compatibility",
     "title": "Self-Hosting Zero",
     "searchTitle": "Client/Server Version Compatibility",
     "sectionTitle": "Client/Server Version Compatibility",
@@ -6406,7 +6421,7 @@
     "kind": "section"
   },
   {
-    "id": "484-self-host#configuration",
+    "id": "485-self-host#configuration",
     "title": "Self-Hosting Zero",
     "searchTitle": "Configuration",
     "sectionTitle": "Configuration",
@@ -6442,7 +6457,7 @@
     "kind": "page"
   },
   {
-    "id": "485-server-zql#creating-a-database",
+    "id": "486-server-zql#creating-a-database",
     "title": "ZQL on the Server",
     "searchTitle": "Creating a Database",
     "sectionTitle": "Creating a Database",
@@ -6452,7 +6467,7 @@
     "kind": "section"
   },
   {
-    "id": "486-server-zql#custom-database",
+    "id": "487-server-zql#custom-database",
     "title": "ZQL on the Server",
     "searchTitle": "Custom Database",
     "sectionTitle": "Custom Database",
@@ -6462,7 +6477,7 @@
     "kind": "section"
   },
   {
-    "id": "487-server-zql#running-zql",
+    "id": "488-server-zql#running-zql",
     "title": "ZQL on the Server",
     "searchTitle": "Running ZQL",
     "sectionTitle": "Running ZQL",
@@ -6472,7 +6487,7 @@
     "kind": "section"
   },
   {
-    "id": "488-server-zql#ssr",
+    "id": "489-server-zql#ssr",
     "title": "ZQL on the Server",
     "searchTitle": "SSR",
     "sectionTitle": "SSR",
@@ -6504,7 +6519,7 @@
     "kind": "page"
   },
   {
-    "id": "489-solidjs#setup",
+    "id": "490-solidjs#setup",
     "title": "SolidJS",
     "searchTitle": "Setup",
     "sectionTitle": "Setup",
@@ -6514,7 +6529,7 @@
     "kind": "section"
   },
   {
-    "id": "490-solidjs#usage",
+    "id": "491-solidjs#usage",
     "title": "SolidJS",
     "searchTitle": "Usage",
     "sectionTitle": "Usage",
@@ -6524,7 +6539,7 @@
     "kind": "section"
   },
   {
-    "id": "491-solidjs#examples",
+    "id": "492-solidjs#examples",
     "title": "SolidJS",
     "searchTitle": "Examples",
     "sectionTitle": "Examples",
@@ -6560,7 +6575,7 @@
     "kind": "page"
   },
   {
-    "id": "492-status#breaking-changes",
+    "id": "493-status#breaking-changes",
     "title": "Project Status",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -6570,7 +6585,7 @@
     "kind": "section"
   },
   {
-    "id": "493-status#roadmap",
+    "id": "494-status#roadmap",
     "title": "Project Status",
     "searchTitle": "Roadmap",
     "sectionTitle": "Roadmap",
@@ -6580,7 +6595,7 @@
     "kind": "section"
   },
   {
-    "id": "494-status#2026",
+    "id": "495-status#2026",
     "title": "Project Status",
     "searchTitle": "2026",
     "sectionTitle": "2026",
@@ -6590,7 +6605,7 @@
     "kind": "section"
   },
   {
-    "id": "495-status#soon",
+    "id": "496-status#soon",
     "title": "Project Status",
     "searchTitle": "Soon",
     "sectionTitle": "Soon",
@@ -6622,7 +6637,7 @@
     "kind": "page"
   },
   {
-    "id": "496-sync#problem",
+    "id": "497-sync#problem",
     "title": "What is Sync?",
     "searchTitle": "Problem",
     "sectionTitle": "Problem",
@@ -6632,7 +6647,7 @@
     "kind": "section"
   },
   {
-    "id": "497-sync#solution",
+    "id": "498-sync#solution",
     "title": "What is Sync?",
     "searchTitle": "Solution",
     "sectionTitle": "Solution",
@@ -6642,7 +6657,7 @@
     "kind": "section"
   },
   {
-    "id": "498-sync#history-of-sync",
+    "id": "499-sync#history-of-sync",
     "title": "What is Sync?",
     "searchTitle": "History of Sync",
     "sectionTitle": "History of Sync",
@@ -6656,11 +6671,11 @@
     "title": "Tutorial",
     "searchTitle": "Tutorial",
     "url": "/docs/tutorial",
-    "content": "This guide builds a small music app with Zero from scratch. It's a nice way to get a feel for how Zero works and takes about 15 minutes to complete. You will seed a Postgres database with artists and albums, run zero-cache, add a query and a mutator, and watch data sync across clients in realtime. If you want to wire Zero into your own app, see Installation. Integrate Zero Create a Project Start with a TypeScript frontend framework: npx @tanstack/cli@latest create zero-music \\ --package-manager npm --yes --no-intent cd zero-musicpnpm dlx @tanstack/cli@latest create zero-music \\ --package-manager pnpm --yes --no-intent cd zero-musicbunx @tanstack/cli@latest create zero-music \\ --package-manager bun --yes --no-intent cd zero-musicnpx create-next-app@latest zero-music --yes --use-npm cd zero-musicpnpm create next-app zero-music --yes --use-pnpm cd zero-musicnpx create-next-app@latest zero-music --yes --use-bun cd zero-musicnpm init solid -- zero-music basic --solidstart --ts --v2 cd zero-music npm installpnpm create solid zero-music basic --solidstart --ts --v2 cd zero-music pnpm installbun create solid zero-music basic --solidstart --ts --v2 cd zero-music bun install Set Up Your Database You'll need a Postgres database with logical replication enabled. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Connecting to Postgres and make sure wal_level is logical. Then, create some music-themed tables and seed them with data (this step uses psql if you don't already have it). # Creates new albums, artists, fans, # and favorites tables with sample music data curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \\ | psql postgres://postgres:pass@localhost:5432/zero Create a .env file so your app server and zero-cache-dev use the same Postgres connection: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install and Run Zero-Cache Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\" Set Up Your Zero Schema Zero uses a schema.ts file to provide a type-safe query API on the client. Download the music-app schema: mkdir -p src/zero curl https://raw.githubusercontent.com/rocicorp/zero-music/1-install/packages/zero/src/schema.ts \\ -o src/zero/schema.ts This quickstart uses a premade schema.ts so you can stay focused on how Zero works. In a real app, you would usually generate schema.ts from your own Drizzle or Prisma schema, or manually add it alongside your application schema. See Installation and Zero Schema. Set Up the Zero Client Zero has first-class support for React and SolidJS. There is also a low-level API you can use in any TypeScript-based project. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero Music</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero} Sync Data Define Query Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev Invoke Query Use the seeded data to fetch albums for The Beatles under artist_1. // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export default function Page() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery} from '@rocicorp/zero/solid' import {queries} from '../zero/queries' export default function Home() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {queries} from './zero/queries' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) This query will run against the zero-cache replica and return Abbey Road and Revolver. The client will update its local datastore with these new albums, and future queries will run optimistically against the local data. Also, Zero queries are reactive, so if you edit data in Postgres directly, you will see it replicate to the Zero replica and the UI: Mutate Data Define Mutators Now let's add a write path that inserts a new album: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. Mutations are written directly to Postgres and replicated to the client. Your other code that writes to the same tables will also sync instantly to the client. First, create a dbProvider with node-postgres: // src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Add the mutate endpoint itself: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) } Restart zero-cache with ZERO_MUTATE_URL configured: ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-dev Invoke Mutators Now add a button to create an album: // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Page() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery, useZero} from '@rocicorp/zero/solid' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Home() { const zero = useZero() const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero().mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {mutators} from './zero/mutators' import {queries} from './zero/queries' const client = await zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log( 'albums', albums.map(album => album.title) ) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Please Please Me will appear in the album list immediately. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients: That's it! You now have a simple, Zero-powered music app. Try opening multiple browser windows to see the realtime sync in action!",
+    "content": "Let's build a small music app with Zero from scratch. It's a nice way to get a feel for how Zero works and takes about 15 minutes to complete. You will seed a Postgres database with artists and albums, run zero-cache, add a query and a mutator, and watch data sync across clients in realtime. If you want to wire Zero into your own app, see Installation. Setup Create a Project Start with a TypeScript frontend framework: npx @tanstack/cli@latest create zero-music \\ --package-manager npm --yes --no-intent cd zero-musicpnpm dlx @tanstack/cli@latest create zero-music \\ --package-manager pnpm --yes --no-intent cd zero-musicbunx @tanstack/cli@latest create zero-music \\ --package-manager bun --yes --no-intent cd zero-musicnpx create-next-app@latest zero-music --yes --use-npm cd zero-musicpnpm create next-app zero-music --yes --use-pnpm cd zero-musicnpx create-next-app@latest zero-music --yes --use-bun cd zero-musicnpm init solid -- zero-music basic --solidstart --ts --v2 cd zero-music npm installpnpm create solid zero-music basic --solidstart --ts --v2 cd zero-music pnpm installbun create solid zero-music basic --solidstart --ts --v2 cd zero-music bun install Set Up Your Database You'll need a Postgres database with logical replication enabled. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Connecting to Postgres and make sure wal_level is logical. Then, create some music-themed tables and seed them with data (this step uses psql if you don't already have it). # Creates new albums, artists, fans, # and favorites tables with sample music data curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \\ | psql postgres://postgres:pass@localhost:5432/zero Create a .env file so your app server and zero-cache-dev use the same Postgres connection: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install and Run Zero-Cache Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] These examples use Zod; any Standard Schema-compatible validator works. Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\" Integrate Zero Set Up Your Zero Schema Zero uses a schema.ts file to provide a type-safe query API on the client. Download the music-app schema: mkdir -p src/zero curl https://raw.githubusercontent.com/rocicorp/zero-music/1-install/packages/zero/src/schema.ts \\ -o src/zero/schema.ts This quickstart uses a premade schema.ts so you can stay focused on how Zero works. In a real app, you would usually generate schema.ts from your own Drizzle or Prisma schema, or manually add it alongside your application schema. See Installation and Zero Schema. Set Up the Zero Client Zero has first-class support for React and SolidJS. There is also a low-level API you can use in any TypeScript-based project. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero Music</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero} Sync Data Define Query Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev Invoke Query Use the seeded data to fetch albums for The Beatles under artist_1. // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export default function Page() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery} from '@rocicorp/zero/solid' import {queries} from '../zero/queries' export default function Home() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {queries} from './zero/queries' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) This query will run against the zero-cache replica and return Abbey Road and Revolver. The client will update its local datastore with these new albums, and future queries will run optimistically against the local data. Also, Zero queries are reactive, so if you edit data in Postgres directly, you will see it replicate to the Zero replica and the UI: Mutate Data Define Mutators Now let's add a write path that inserts a new album: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. Mutations are written directly to Postgres and replicated to the client. Your other code that writes to the same tables will also sync instantly to the client. First, create a dbProvider with node-postgres: // src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Add the mutate endpoint itself: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) } Restart zero-cache with ZERO_MUTATE_URL configured: ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-dev Invoke Mutators Now add a button to create an album: // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Page() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery, useZero} from '@rocicorp/zero/solid' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Home() { const zero = useZero() const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero().mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {mutators} from './zero/mutators' import {queries} from './zero/queries' const client = await zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log( 'albums', albums.map(album => album.title) ) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Please Please Me will appear in the album list immediately. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients: That's it! You now have a simple, Zero-powered music app. Try opening multiple browser windows to see the realtime sync in action! Next Steps Learn how to add auth Try adding Zero to your existing app Play with fully-fleshed out samples",
     "headings": [
       {
-        "text": "Integrate Zero",
-        "id": "integrate-zero"
+        "text": "Setup",
+        "id": "setup"
       },
       {
         "text": "Create a Project",
@@ -6673,6 +6688,10 @@
       {
         "text": "Install and Run Zero-Cache",
         "id": "install-and-run-zero-cache"
+      },
+      {
+        "text": "Integrate Zero",
+        "id": "integrate-zero"
       },
       {
         "text": "Set Up Your Zero Schema",
@@ -6713,22 +6732,26 @@
       {
         "text": "Invoke Mutators",
         "id": "invoke-mutators"
+      },
+      {
+        "text": "Next Steps",
+        "id": "next-steps"
       }
     ],
     "kind": "page"
   },
   {
-    "id": "499-tutorial#integrate-zero",
+    "id": "500-tutorial#setup",
     "title": "Tutorial",
-    "searchTitle": "Integrate Zero",
-    "sectionTitle": "Integrate Zero",
-    "sectionId": "integrate-zero",
+    "searchTitle": "Setup",
+    "sectionTitle": "Setup",
+    "sectionId": "setup",
     "url": "/docs/tutorial",
-    "content": "Create a Project Start with a TypeScript frontend framework: npx @tanstack/cli@latest create zero-music \\ --package-manager npm --yes --no-intent cd zero-musicpnpm dlx @tanstack/cli@latest create zero-music \\ --package-manager pnpm --yes --no-intent cd zero-musicbunx @tanstack/cli@latest create zero-music \\ --package-manager bun --yes --no-intent cd zero-musicnpx create-next-app@latest zero-music --yes --use-npm cd zero-musicpnpm create next-app zero-music --yes --use-pnpm cd zero-musicnpx create-next-app@latest zero-music --yes --use-bun cd zero-musicnpm init solid -- zero-music basic --solidstart --ts --v2 cd zero-music npm installpnpm create solid zero-music basic --solidstart --ts --v2 cd zero-music pnpm installbun create solid zero-music basic --solidstart --ts --v2 cd zero-music bun install Set Up Your Database You'll need a Postgres database with logical replication enabled. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Connecting to Postgres and make sure wal_level is logical. Then, create some music-themed tables and seed them with data (this step uses psql if you don't already have it). # Creates new albums, artists, fans, # and favorites tables with sample music data curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \\ | psql postgres://postgres:pass@localhost:5432/zero Create a .env file so your app server and zero-cache-dev use the same Postgres connection: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install and Run Zero-Cache Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\" Set Up Your Zero Schema Zero uses a schema.ts file to provide a type-safe query API on the client. Download the music-app schema: mkdir -p src/zero curl https://raw.githubusercontent.com/rocicorp/zero-music/1-install/packages/zero/src/schema.ts \\ -o src/zero/schema.ts This quickstart uses a premade schema.ts so you can stay focused on how Zero works. In a real app, you would usually generate schema.ts from your own Drizzle or Prisma schema, or manually add it alongside your application schema. See Installation and Zero Schema. Set Up the Zero Client Zero has first-class support for React and SolidJS. There is also a low-level API you can use in any TypeScript-based project. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero Music</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero}",
+    "content": "Create a Project Start with a TypeScript frontend framework: npx @tanstack/cli@latest create zero-music \\ --package-manager npm --yes --no-intent cd zero-musicpnpm dlx @tanstack/cli@latest create zero-music \\ --package-manager pnpm --yes --no-intent cd zero-musicbunx @tanstack/cli@latest create zero-music \\ --package-manager bun --yes --no-intent cd zero-musicnpx create-next-app@latest zero-music --yes --use-npm cd zero-musicpnpm create next-app zero-music --yes --use-pnpm cd zero-musicnpx create-next-app@latest zero-music --yes --use-bun cd zero-musicnpm init solid -- zero-music basic --solidstart --ts --v2 cd zero-music npm installpnpm create solid zero-music basic --solidstart --ts --v2 cd zero-music pnpm installbun create solid zero-music basic --solidstart --ts --v2 cd zero-music bun install Set Up Your Database You'll need a Postgres database with logical replication enabled. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Connecting to Postgres and make sure wal_level is logical. Then, create some music-themed tables and seed them with data (this step uses psql if you don't already have it). # Creates new albums, artists, fans, # and favorites tables with sample music data curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \\ | psql postgres://postgres:pass@localhost:5432/zero Create a .env file so your app server and zero-cache-dev use the same Postgres connection: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install and Run Zero-Cache Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] These examples use Zod; any Standard Schema-compatible validator works. Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\"",
     "kind": "section"
   },
   {
-    "id": "500-tutorial#create-a-project",
+    "id": "501-tutorial#create-a-project",
     "title": "Tutorial",
     "searchTitle": "Create a Project",
     "sectionTitle": "Create a Project",
@@ -6738,7 +6761,7 @@
     "kind": "section"
   },
   {
-    "id": "501-tutorial#set-up-your-database",
+    "id": "502-tutorial#set-up-your-database",
     "title": "Tutorial",
     "searchTitle": "Set Up Your Database",
     "sectionTitle": "Set Up Your Database",
@@ -6748,17 +6771,27 @@
     "kind": "section"
   },
   {
-    "id": "502-tutorial#install-and-run-zero-cache",
+    "id": "503-tutorial#install-and-run-zero-cache",
     "title": "Tutorial",
     "searchTitle": "Install and Run Zero-Cache",
     "sectionTitle": "Install and Run Zero-Cache",
     "sectionId": "install-and-run-zero-cache",
     "url": "/docs/tutorial",
-    "content": "Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\"",
+    "content": "Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] These examples use Zod; any Standard Schema-compatible validator works. Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\"",
     "kind": "section"
   },
   {
-    "id": "503-tutorial#set-up-your-zero-schema",
+    "id": "504-tutorial#integrate-zero",
+    "title": "Tutorial",
+    "searchTitle": "Integrate Zero",
+    "sectionTitle": "Integrate Zero",
+    "sectionId": "integrate-zero",
+    "url": "/docs/tutorial",
+    "content": "Set Up Your Zero Schema Zero uses a schema.ts file to provide a type-safe query API on the client. Download the music-app schema: mkdir -p src/zero curl https://raw.githubusercontent.com/rocicorp/zero-music/1-install/packages/zero/src/schema.ts \\ -o src/zero/schema.ts This quickstart uses a premade schema.ts so you can stay focused on how Zero works. In a real app, you would usually generate schema.ts from your own Drizzle or Prisma schema, or manually add it alongside your application schema. See Installation and Zero Schema. Set Up the Zero Client Zero has first-class support for React and SolidJS. There is also a low-level API you can use in any TypeScript-based project. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero Music</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero}",
+    "kind": "section"
+  },
+  {
+    "id": "505-tutorial#set-up-your-zero-schema",
     "title": "Tutorial",
     "searchTitle": "Set Up Your Zero Schema",
     "sectionTitle": "Set Up Your Zero Schema",
@@ -6768,7 +6801,7 @@
     "kind": "section"
   },
   {
-    "id": "504-tutorial#set-up-the-zero-client",
+    "id": "506-tutorial#set-up-the-zero-client",
     "title": "Tutorial",
     "searchTitle": "Set Up the Zero Client",
     "sectionTitle": "Set Up the Zero Client",
@@ -6778,27 +6811,27 @@
     "kind": "section"
   },
   {
-    "id": "505-tutorial#sync-data",
+    "id": "507-tutorial#sync-data",
     "title": "Tutorial",
     "searchTitle": "Sync Data",
     "sectionTitle": "Sync Data",
     "sectionId": "sync-data",
     "url": "/docs/tutorial",
-    "content": "Define Query Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev Invoke Query Use the seeded data to fetch albums for The Beatles under artist_1. // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export default function Page() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery} from '@rocicorp/zero/solid' import {queries} from '../zero/queries' export default function Home() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {queries} from './zero/queries' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) This query will run against the zero-cache replica and return Abbey Road and Revolver. The client will update its local datastore with these new albums, and future queries will run optimistically against the local data. Also, Zero queries are reactive, so if you edit data in Postgres directly, you will see it replicate to the Zero replica and the UI:",
+    "content": "Define Query Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev Invoke Query Use the seeded data to fetch albums for The Beatles under artist_1. // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export default function Page() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery} from '@rocicorp/zero/solid' import {queries} from '../zero/queries' export default function Home() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {queries} from './zero/queries' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) This query will run against the zero-cache replica and return Abbey Road and Revolver. The client will update its local datastore with these new albums, and future queries will run optimistically against the local data. Also, Zero queries are reactive, so if you edit data in Postgres directly, you will see it replicate to the Zero replica and the UI:",
     "kind": "section"
   },
   {
-    "id": "506-tutorial#define-query",
+    "id": "508-tutorial#define-query",
     "title": "Tutorial",
     "searchTitle": "Define Query",
     "sectionTitle": "Define Query",
     "sectionId": "define-query",
     "url": "/docs/tutorial",
-    "content": "Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more:",
+    "content": "Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: See Reading Data for more on filters, sorting, relationships, and permissions.",
     "kind": "section"
   },
   {
-    "id": "507-tutorial#add-query-endpoint",
+    "id": "509-tutorial#add-query-endpoint",
     "title": "Tutorial",
     "searchTitle": "Add Query Endpoint",
     "sectionTitle": "Add Query Endpoint",
@@ -6808,7 +6841,7 @@
     "kind": "section"
   },
   {
-    "id": "508-tutorial#invoke-query",
+    "id": "510-tutorial#invoke-query",
     "title": "Tutorial",
     "searchTitle": "Invoke Query",
     "sectionTitle": "Invoke Query",
@@ -6818,7 +6851,7 @@
     "kind": "section"
   },
   {
-    "id": "509-tutorial#mutate-data",
+    "id": "511-tutorial#mutate-data",
     "title": "Tutorial",
     "searchTitle": "Mutate Data",
     "sectionTitle": "Mutate Data",
@@ -6828,7 +6861,7 @@
     "kind": "section"
   },
   {
-    "id": "510-tutorial#define-mutators",
+    "id": "512-tutorial#define-mutators",
     "title": "Tutorial",
     "searchTitle": "Define Mutators",
     "sectionTitle": "Define Mutators",
@@ -6838,7 +6871,7 @@
     "kind": "section"
   },
   {
-    "id": "511-tutorial#add-mutate-endpoint",
+    "id": "513-tutorial#add-mutate-endpoint",
     "title": "Tutorial",
     "searchTitle": "Add Mutate Endpoint",
     "sectionTitle": "Add Mutate Endpoint",
@@ -6848,13 +6881,23 @@
     "kind": "section"
   },
   {
-    "id": "512-tutorial#invoke-mutators",
+    "id": "514-tutorial#invoke-mutators",
     "title": "Tutorial",
     "searchTitle": "Invoke Mutators",
     "sectionTitle": "Invoke Mutators",
     "sectionId": "invoke-mutators",
     "url": "/docs/tutorial",
     "content": "Now add a button to create an album: // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Page() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery, useZero} from '@rocicorp/zero/solid' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Home() { const zero = useZero() const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero().mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {mutators} from './zero/mutators' import {queries} from './zero/queries' const client = await zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log( 'albums', albums.map(album => album.title) ) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Please Please Me will appear in the album list immediately. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients: That's it! You now have a simple, Zero-powered music app. Try opening multiple browser windows to see the realtime sync in action!",
+    "kind": "section"
+  },
+  {
+    "id": "515-tutorial#next-steps",
+    "title": "Tutorial",
+    "searchTitle": "Next Steps",
+    "sectionTitle": "Next Steps",
+    "sectionId": "next-steps",
+    "url": "/docs/tutorial",
+    "content": "Learn how to add auth Try adding Zero to your existing app Play with fully-fleshed out samples",
     "kind": "section"
   },
   {
@@ -6924,7 +6967,7 @@
     "kind": "page"
   },
   {
-    "id": "513-when-to-use#zero-might-be-a-good-fit",
+    "id": "516-when-to-use#zero-might-be-a-good-fit",
     "title": "When To Use Zero",
     "searchTitle": "Zero Might be a Good Fit",
     "sectionTitle": "Zero Might be a Good Fit",
@@ -6934,7 +6977,7 @@
     "kind": "section"
   },
   {
-    "id": "514-when-to-use#you-want-to-sync-only-a-small-subset-of-data-to-client",
+    "id": "517-when-to-use#you-want-to-sync-only-a-small-subset-of-data-to-client",
     "title": "When To Use Zero",
     "searchTitle": "You want to sync only a small subset of data to client",
     "sectionTitle": "You want to sync only a small subset of data to client",
@@ -6944,7 +6987,7 @@
     "kind": "section"
   },
   {
-    "id": "515-when-to-use#you-need-fine-grained-read-or-write-permissions",
+    "id": "518-when-to-use#you-need-fine-grained-read-or-write-permissions",
     "title": "When To Use Zero",
     "searchTitle": "You need fine-grained read or write permissions",
     "sectionTitle": "You need fine-grained read or write permissions",
@@ -6954,7 +6997,7 @@
     "kind": "section"
   },
   {
-    "id": "516-when-to-use#you-are-building-a-traditional-client-server-web-app",
+    "id": "519-when-to-use#you-are-building-a-traditional-client-server-web-app",
     "title": "When To Use Zero",
     "searchTitle": "You are building a traditional client-server web app",
     "sectionTitle": "You are building a traditional client-server web app",
@@ -6964,7 +7007,7 @@
     "kind": "section"
   },
   {
-    "id": "517-when-to-use#you-use-postgresql",
+    "id": "520-when-to-use#you-use-postgresql",
     "title": "When To Use Zero",
     "searchTitle": "You use PostgreSQL",
     "sectionTitle": "You use PostgreSQL",
@@ -6974,7 +7017,7 @@
     "kind": "section"
   },
   {
-    "id": "518-when-to-use#your-app-is-broadly-like-linear",
+    "id": "521-when-to-use#your-app-is-broadly-like-linear",
     "title": "When To Use Zero",
     "searchTitle": "Your app is broadly \"like Linear\"",
     "sectionTitle": "Your app is broadly \"like Linear\"",
@@ -6984,7 +7027,7 @@
     "kind": "section"
   },
   {
-    "id": "519-when-to-use#interaction-performance-is-very-important-to-you",
+    "id": "522-when-to-use#interaction-performance-is-very-important-to-you",
     "title": "When To Use Zero",
     "searchTitle": "Interaction performance is very important to you",
     "sectionTitle": "Interaction performance is very important to you",
@@ -6994,7 +7037,7 @@
     "kind": "section"
   },
   {
-    "id": "520-when-to-use#zero-might-not-be-a-good-fit",
+    "id": "523-when-to-use#zero-might-not-be-a-good-fit",
     "title": "When To Use Zero",
     "searchTitle": "Zero Might Not be a Good Fit",
     "sectionTitle": "Zero Might Not be a Good Fit",
@@ -7004,7 +7047,7 @@
     "kind": "section"
   },
   {
-    "id": "521-when-to-use#you-need-the-privacy-or-data-ownership-benefits-of-local-first",
+    "id": "524-when-to-use#you-need-the-privacy-or-data-ownership-benefits-of-local-first",
     "title": "When To Use Zero",
     "searchTitle": "You need the privacy or data ownership benefits of local-first",
     "sectionTitle": "You need the privacy or data ownership benefits of local-first",
@@ -7014,7 +7057,7 @@
     "kind": "section"
   },
   {
-    "id": "522-when-to-use#you-need-to-support-offline-writes-or-long-periods-offline",
+    "id": "525-when-to-use#you-need-to-support-offline-writes-or-long-periods-offline",
     "title": "When To Use Zero",
     "searchTitle": "You need to support offline writes or long periods offline",
     "sectionTitle": "You need to support offline writes or long periods offline",
@@ -7024,7 +7067,7 @@
     "kind": "section"
   },
   {
-    "id": "523-when-to-use#you-are-building-a-native-mobile-app",
+    "id": "526-when-to-use#you-are-building-a-native-mobile-app",
     "title": "When To Use Zero",
     "searchTitle": "You are building a native mobile app",
     "sectionTitle": "You are building a native mobile app",
@@ -7034,7 +7077,7 @@
     "kind": "section"
   },
   {
-    "id": "524-when-to-use#the-total-backend-dataset-is--100gb",
+    "id": "527-when-to-use#the-total-backend-dataset-is--100gb",
     "title": "When To Use Zero",
     "searchTitle": "The total backend dataset is > ~100GB",
     "sectionTitle": "The total backend dataset is > ~100GB",
@@ -7044,7 +7087,7 @@
     "kind": "section"
   },
   {
-    "id": "525-when-to-use#zero-might-not-be-a-good-fit-yet",
+    "id": "528-when-to-use#zero-might-not-be-a-good-fit-yet",
     "title": "When To Use Zero",
     "searchTitle": "Zero Might Not be a Good Fit Yet",
     "sectionTitle": "Zero Might Not be a Good Fit Yet",
@@ -7054,7 +7097,7 @@
     "kind": "section"
   },
   {
-    "id": "526-when-to-use#alternatives",
+    "id": "529-when-to-use#alternatives",
     "title": "When To Use Zero",
     "searchTitle": "Alternatives",
     "sectionTitle": "Alternatives",
@@ -7390,7 +7433,7 @@
     "kind": "page"
   },
   {
-    "id": "527-zero-cache-config#required-flags",
+    "id": "530-zero-cache-config#required-flags",
     "title": "zero-cache Config",
     "searchTitle": "Required Flags",
     "sectionTitle": "Required Flags",
@@ -7400,7 +7443,7 @@
     "kind": "section"
   },
   {
-    "id": "528-zero-cache-config#upstream-db",
+    "id": "531-zero-cache-config#upstream-db",
     "title": "zero-cache Config",
     "searchTitle": "Upstream DB",
     "sectionTitle": "Upstream DB",
@@ -7410,7 +7453,7 @@
     "kind": "section"
   },
   {
-    "id": "529-zero-cache-config#admin-password",
+    "id": "532-zero-cache-config#admin-password",
     "title": "zero-cache Config",
     "searchTitle": "Admin Password",
     "sectionTitle": "Admin Password",
@@ -7420,7 +7463,7 @@
     "kind": "section"
   },
   {
-    "id": "530-zero-cache-config#optional-flags",
+    "id": "533-zero-cache-config#optional-flags",
     "title": "zero-cache Config",
     "searchTitle": "Optional Flags",
     "sectionTitle": "Optional Flags",
@@ -7430,7 +7473,7 @@
     "kind": "section"
   },
   {
-    "id": "531-zero-cache-config#app-id",
+    "id": "534-zero-cache-config#app-id",
     "title": "zero-cache Config",
     "searchTitle": "App ID",
     "sectionTitle": "App ID",
@@ -7440,7 +7483,7 @@
     "kind": "section"
   },
   {
-    "id": "532-zero-cache-config#app-publications",
+    "id": "535-zero-cache-config#app-publications",
     "title": "zero-cache Config",
     "searchTitle": "App Publications",
     "sectionTitle": "App Publications",
@@ -7450,7 +7493,7 @@
     "kind": "section"
   },
   {
-    "id": "533-zero-cache-config#auth-revalidate-interval-seconds",
+    "id": "536-zero-cache-config#auth-revalidate-interval-seconds",
     "title": "zero-cache Config",
     "searchTitle": "Auth Revalidate Interval Seconds",
     "sectionTitle": "Auth Revalidate Interval Seconds",
@@ -7460,7 +7503,7 @@
     "kind": "section"
   },
   {
-    "id": "534-zero-cache-config#auth-retransform-interval-seconds",
+    "id": "537-zero-cache-config#auth-retransform-interval-seconds",
     "title": "zero-cache Config",
     "searchTitle": "Auth Retransform Interval Seconds",
     "sectionTitle": "Auth Retransform Interval Seconds",
@@ -7470,7 +7513,7 @@
     "kind": "section"
   },
   {
-    "id": "535-zero-cache-config#auto-reset",
+    "id": "538-zero-cache-config#auto-reset",
     "title": "zero-cache Config",
     "searchTitle": "Auto Reset",
     "sectionTitle": "Auto Reset",
@@ -7480,7 +7523,7 @@
     "kind": "section"
   },
   {
-    "id": "536-zero-cache-config#change-db",
+    "id": "539-zero-cache-config#change-db",
     "title": "zero-cache Config",
     "searchTitle": "Change DB",
     "sectionTitle": "Change DB",
@@ -7490,7 +7533,7 @@
     "kind": "section"
   },
   {
-    "id": "537-zero-cache-config#change-max-connections",
+    "id": "540-zero-cache-config#change-max-connections",
     "title": "zero-cache Config",
     "searchTitle": "Change Max Connections",
     "sectionTitle": "Change Max Connections",
@@ -7500,7 +7543,7 @@
     "kind": "section"
   },
   {
-    "id": "538-zero-cache-config#change-streamer-back-pressure-limit-heap-proportion",
+    "id": "541-zero-cache-config#change-streamer-back-pressure-limit-heap-proportion",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Back Pressure Limit Heap Proportion",
     "sectionTitle": "Change Streamer Back Pressure Limit Heap Proportion",
@@ -7510,7 +7553,7 @@
     "kind": "section"
   },
   {
-    "id": "539-zero-cache-config#change-streamer-flow-control-consensus-padding-seconds",
+    "id": "542-zero-cache-config#change-streamer-flow-control-consensus-padding-seconds",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Flow Control Consensus Padding Seconds",
     "sectionTitle": "Change Streamer Flow Control Consensus Padding Seconds",
@@ -7520,7 +7563,7 @@
     "kind": "section"
   },
   {
-    "id": "540-zero-cache-config#change-streamer-mode",
+    "id": "543-zero-cache-config#change-streamer-mode",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Mode",
     "sectionTitle": "Change Streamer Mode",
@@ -7530,7 +7573,7 @@
     "kind": "section"
   },
   {
-    "id": "541-zero-cache-config#change-streamer-port",
+    "id": "544-zero-cache-config#change-streamer-port",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Port",
     "sectionTitle": "Change Streamer Port",
@@ -7540,7 +7583,7 @@
     "kind": "section"
   },
   {
-    "id": "542-zero-cache-config#change-streamer-startup-delay-ms",
+    "id": "545-zero-cache-config#change-streamer-startup-delay-ms",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Startup Delay (ms)",
     "sectionTitle": "Change Streamer Startup Delay (ms)",
@@ -7550,7 +7593,7 @@
     "kind": "section"
   },
   {
-    "id": "543-zero-cache-config#change-streamer-uri",
+    "id": "546-zero-cache-config#change-streamer-uri",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer URI",
     "sectionTitle": "Change Streamer URI",
@@ -7560,7 +7603,7 @@
     "kind": "section"
   },
   {
-    "id": "544-zero-cache-config#cvr-db",
+    "id": "547-zero-cache-config#cvr-db",
     "title": "zero-cache Config",
     "searchTitle": "CVR DB",
     "sectionTitle": "CVR DB",
@@ -7570,7 +7613,7 @@
     "kind": "section"
   },
   {
-    "id": "545-zero-cache-config#cvr-garbage-collection-inactivity-threshold-hours",
+    "id": "548-zero-cache-config#cvr-garbage-collection-inactivity-threshold-hours",
     "title": "zero-cache Config",
     "searchTitle": "CVR Garbage Collection Inactivity Threshold Hours",
     "sectionTitle": "CVR Garbage Collection Inactivity Threshold Hours",
@@ -7580,7 +7623,7 @@
     "kind": "section"
   },
   {
-    "id": "546-zero-cache-config#cvr-garbage-collection-initial-batch-size",
+    "id": "549-zero-cache-config#cvr-garbage-collection-initial-batch-size",
     "title": "zero-cache Config",
     "searchTitle": "CVR Garbage Collection Initial Batch Size",
     "sectionTitle": "CVR Garbage Collection Initial Batch Size",
@@ -7590,7 +7633,7 @@
     "kind": "section"
   },
   {
-    "id": "547-zero-cache-config#cvr-garbage-collection-initial-interval-seconds",
+    "id": "550-zero-cache-config#cvr-garbage-collection-initial-interval-seconds",
     "title": "zero-cache Config",
     "searchTitle": "CVR Garbage Collection Initial Interval Seconds",
     "sectionTitle": "CVR Garbage Collection Initial Interval Seconds",
@@ -7600,7 +7643,7 @@
     "kind": "section"
   },
   {
-    "id": "548-zero-cache-config#cvr-max-connections",
+    "id": "551-zero-cache-config#cvr-max-connections",
     "title": "zero-cache Config",
     "searchTitle": "CVR Max Connections",
     "sectionTitle": "CVR Max Connections",
@@ -7610,7 +7653,7 @@
     "kind": "section"
   },
   {
-    "id": "549-zero-cache-config#enable-query-planner",
+    "id": "552-zero-cache-config#enable-query-planner",
     "title": "zero-cache Config",
     "searchTitle": "Enable Query Planner",
     "sectionTitle": "Enable Query Planner",
@@ -7620,7 +7663,7 @@
     "kind": "section"
   },
   {
-    "id": "550-zero-cache-config#enable-crud-mutations",
+    "id": "553-zero-cache-config#enable-crud-mutations",
     "title": "zero-cache Config",
     "searchTitle": "Enable CRUD Mutations",
     "sectionTitle": "Enable CRUD Mutations",
@@ -7630,7 +7673,7 @@
     "kind": "section"
   },
   {
-    "id": "551-zero-cache-config#enable-telemetry",
+    "id": "554-zero-cache-config#enable-telemetry",
     "title": "zero-cache Config",
     "searchTitle": "Enable Telemetry",
     "sectionTitle": "Enable Telemetry",
@@ -7640,7 +7683,7 @@
     "kind": "section"
   },
   {
-    "id": "552-zero-cache-config#initial-sync-table-copy-workers",
+    "id": "555-zero-cache-config#initial-sync-table-copy-workers",
     "title": "zero-cache Config",
     "searchTitle": "Initial Sync Table Copy Workers",
     "sectionTitle": "Initial Sync Table Copy Workers",
@@ -7650,7 +7693,7 @@
     "kind": "section"
   },
   {
-    "id": "553-zero-cache-config#lazy-startup",
+    "id": "556-zero-cache-config#lazy-startup",
     "title": "zero-cache Config",
     "searchTitle": "Lazy Startup",
     "sectionTitle": "Lazy Startup",
@@ -7660,7 +7703,7 @@
     "kind": "section"
   },
   {
-    "id": "554-zero-cache-config#litestream-backup-url",
+    "id": "557-zero-cache-config#litestream-backup-url",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Backup URL",
     "sectionTitle": "Litestream Backup URL",
@@ -7670,7 +7713,7 @@
     "kind": "section"
   },
   {
-    "id": "555-zero-cache-config#litestream-endpoint",
+    "id": "558-zero-cache-config#litestream-endpoint",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Endpoint",
     "sectionTitle": "Litestream Endpoint",
@@ -7680,7 +7723,7 @@
     "kind": "section"
   },
   {
-    "id": "556-zero-cache-config#litestream-checkpoint-threshold-mb",
+    "id": "559-zero-cache-config#litestream-checkpoint-threshold-mb",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Checkpoint Threshold MB",
     "sectionTitle": "Litestream Checkpoint Threshold MB",
@@ -7690,7 +7733,7 @@
     "kind": "section"
   },
   {
-    "id": "557-zero-cache-config#litestream-config-path",
+    "id": "560-zero-cache-config#litestream-config-path",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Config Path",
     "sectionTitle": "Litestream Config Path",
@@ -7700,7 +7743,7 @@
     "kind": "section"
   },
   {
-    "id": "558-zero-cache-config#litestream-executable",
+    "id": "561-zero-cache-config#litestream-executable",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Executable",
     "sectionTitle": "Litestream Executable",
@@ -7710,7 +7753,7 @@
     "kind": "section"
   },
   {
-    "id": "559-zero-cache-config#litestream-incremental-backup-interval-minutes",
+    "id": "562-zero-cache-config#litestream-incremental-backup-interval-minutes",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Incremental Backup Interval Minutes",
     "sectionTitle": "Litestream Incremental Backup Interval Minutes",
@@ -7720,7 +7763,7 @@
     "kind": "section"
   },
   {
-    "id": "560-zero-cache-config#litestream-maximum-checkpoint-page-count",
+    "id": "563-zero-cache-config#litestream-maximum-checkpoint-page-count",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Maximum Checkpoint Page Count",
     "sectionTitle": "Litestream Maximum Checkpoint Page Count",
@@ -7730,7 +7773,7 @@
     "kind": "section"
   },
   {
-    "id": "561-zero-cache-config#litestream-minimum-checkpoint-page-count",
+    "id": "564-zero-cache-config#litestream-minimum-checkpoint-page-count",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Minimum Checkpoint Page Count",
     "sectionTitle": "Litestream Minimum Checkpoint Page Count",
@@ -7740,7 +7783,7 @@
     "kind": "section"
   },
   {
-    "id": "562-zero-cache-config#litestream-multipart-concurrency",
+    "id": "565-zero-cache-config#litestream-multipart-concurrency",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Multipart Concurrency",
     "sectionTitle": "Litestream Multipart Concurrency",
@@ -7750,7 +7793,7 @@
     "kind": "section"
   },
   {
-    "id": "563-zero-cache-config#litestream-multipart-size",
+    "id": "566-zero-cache-config#litestream-multipart-size",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Multipart Size",
     "sectionTitle": "Litestream Multipart Size",
@@ -7760,7 +7803,7 @@
     "kind": "section"
   },
   {
-    "id": "564-zero-cache-config#litestream-log-level",
+    "id": "567-zero-cache-config#litestream-log-level",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Log Level",
     "sectionTitle": "Litestream Log Level",
@@ -7770,7 +7813,7 @@
     "kind": "section"
   },
   {
-    "id": "565-zero-cache-config#litestream-port",
+    "id": "568-zero-cache-config#litestream-port",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Port",
     "sectionTitle": "Litestream Port",
@@ -7780,7 +7823,7 @@
     "kind": "section"
   },
   {
-    "id": "566-zero-cache-config#litestream-restore-parallelism",
+    "id": "569-zero-cache-config#litestream-restore-parallelism",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Restore Parallelism",
     "sectionTitle": "Litestream Restore Parallelism",
@@ -7790,7 +7833,7 @@
     "kind": "section"
   },
   {
-    "id": "567-zero-cache-config#litestream-snapshot-backup-interval-hours",
+    "id": "570-zero-cache-config#litestream-snapshot-backup-interval-hours",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Snapshot Backup Interval Hours",
     "sectionTitle": "Litestream Snapshot Backup Interval Hours",
@@ -7800,7 +7843,7 @@
     "kind": "section"
   },
   {
-    "id": "568-zero-cache-config#log-format",
+    "id": "571-zero-cache-config#log-format",
     "title": "zero-cache Config",
     "searchTitle": "Log Format",
     "sectionTitle": "Log Format",
@@ -7810,7 +7853,7 @@
     "kind": "section"
   },
   {
-    "id": "569-zero-cache-config#log-ivm-sampling",
+    "id": "572-zero-cache-config#log-ivm-sampling",
     "title": "zero-cache Config",
     "searchTitle": "Log IVM Sampling",
     "sectionTitle": "Log IVM Sampling",
@@ -7820,7 +7863,7 @@
     "kind": "section"
   },
   {
-    "id": "570-zero-cache-config#log-level",
+    "id": "573-zero-cache-config#log-level",
     "title": "zero-cache Config",
     "searchTitle": "Log Level",
     "sectionTitle": "Log Level",
@@ -7830,7 +7873,7 @@
     "kind": "section"
   },
   {
-    "id": "571-zero-cache-config#log-slow-hydrate-threshold",
+    "id": "574-zero-cache-config#log-slow-hydrate-threshold",
     "title": "zero-cache Config",
     "searchTitle": "Log Slow Hydrate Threshold",
     "sectionTitle": "Log Slow Hydrate Threshold",
@@ -7840,7 +7883,7 @@
     "kind": "section"
   },
   {
-    "id": "572-zero-cache-config#log-slow-row-threshold",
+    "id": "575-zero-cache-config#log-slow-row-threshold",
     "title": "zero-cache Config",
     "searchTitle": "Log Slow Row Threshold",
     "sectionTitle": "Log Slow Row Threshold",
@@ -7850,7 +7893,7 @@
     "kind": "section"
   },
   {
-    "id": "573-zero-cache-config#mutate-api-key",
+    "id": "576-zero-cache-config#mutate-api-key",
     "title": "zero-cache Config",
     "searchTitle": "Mutate API Key",
     "sectionTitle": "Mutate API Key",
@@ -7860,7 +7903,7 @@
     "kind": "section"
   },
   {
-    "id": "574-zero-cache-config#mutate-allowed-client-headers",
+    "id": "577-zero-cache-config#mutate-allowed-client-headers",
     "title": "zero-cache Config",
     "searchTitle": "Mutate Allowed Client Headers",
     "sectionTitle": "Mutate Allowed Client Headers",
@@ -7870,7 +7913,7 @@
     "kind": "section"
   },
   {
-    "id": "575-zero-cache-config#mutate-forward-cookies",
+    "id": "578-zero-cache-config#mutate-forward-cookies",
     "title": "zero-cache Config",
     "searchTitle": "Mutate Forward Cookies",
     "sectionTitle": "Mutate Forward Cookies",
@@ -7880,7 +7923,7 @@
     "kind": "section"
   },
   {
-    "id": "576-zero-cache-config#mutate-url",
+    "id": "579-zero-cache-config#mutate-url",
     "title": "zero-cache Config",
     "searchTitle": "Mutate URL",
     "sectionTitle": "Mutate URL",
@@ -7890,7 +7933,7 @@
     "kind": "section"
   },
   {
-    "id": "577-zero-cache-config#number-of-sync-workers",
+    "id": "580-zero-cache-config#number-of-sync-workers",
     "title": "zero-cache Config",
     "searchTitle": "Number of Sync Workers",
     "sectionTitle": "Number of Sync Workers",
@@ -7900,7 +7943,7 @@
     "kind": "section"
   },
   {
-    "id": "578-zero-cache-config#per-user-mutation-limit-max",
+    "id": "581-zero-cache-config#per-user-mutation-limit-max",
     "title": "zero-cache Config",
     "searchTitle": "Per User Mutation Limit Max",
     "sectionTitle": "Per User Mutation Limit Max",
@@ -7910,7 +7953,7 @@
     "kind": "section"
   },
   {
-    "id": "579-zero-cache-config#per-user-mutation-limit-window-ms",
+    "id": "582-zero-cache-config#per-user-mutation-limit-window-ms",
     "title": "zero-cache Config",
     "searchTitle": "Per User Mutation Limit Window (ms)",
     "sectionTitle": "Per User Mutation Limit Window (ms)",
@@ -7920,7 +7963,7 @@
     "kind": "section"
   },
   {
-    "id": "580-zero-cache-config#port",
+    "id": "583-zero-cache-config#port",
     "title": "zero-cache Config",
     "searchTitle": "Port",
     "sectionTitle": "Port",
@@ -7930,7 +7973,7 @@
     "kind": "section"
   },
   {
-    "id": "581-zero-cache-config#query-api-key",
+    "id": "584-zero-cache-config#query-api-key",
     "title": "zero-cache Config",
     "searchTitle": "Query API Key",
     "sectionTitle": "Query API Key",
@@ -7940,7 +7983,7 @@
     "kind": "section"
   },
   {
-    "id": "582-zero-cache-config#query-allowed-client-headers",
+    "id": "585-zero-cache-config#query-allowed-client-headers",
     "title": "zero-cache Config",
     "searchTitle": "Query Allowed Client Headers",
     "sectionTitle": "Query Allowed Client Headers",
@@ -7950,7 +7993,7 @@
     "kind": "section"
   },
   {
-    "id": "583-zero-cache-config#query-forward-cookies",
+    "id": "586-zero-cache-config#query-forward-cookies",
     "title": "zero-cache Config",
     "searchTitle": "Query Forward Cookies",
     "sectionTitle": "Query Forward Cookies",
@@ -7960,7 +8003,7 @@
     "kind": "section"
   },
   {
-    "id": "584-zero-cache-config#query-hydration-stats",
+    "id": "587-zero-cache-config#query-hydration-stats",
     "title": "zero-cache Config",
     "searchTitle": "Query Hydration Stats",
     "sectionTitle": "Query Hydration Stats",
@@ -7970,7 +8013,7 @@
     "kind": "section"
   },
   {
-    "id": "585-zero-cache-config#query-url",
+    "id": "588-zero-cache-config#query-url",
     "title": "zero-cache Config",
     "searchTitle": "Query URL",
     "sectionTitle": "Query URL",
@@ -7980,7 +8023,7 @@
     "kind": "section"
   },
   {
-    "id": "586-zero-cache-config#replica-file",
+    "id": "589-zero-cache-config#replica-file",
     "title": "zero-cache Config",
     "searchTitle": "Replica File",
     "sectionTitle": "Replica File",
@@ -7990,7 +8033,7 @@
     "kind": "section"
   },
   {
-    "id": "587-zero-cache-config#replica-vacuum-interval-hours",
+    "id": "590-zero-cache-config#replica-vacuum-interval-hours",
     "title": "zero-cache Config",
     "searchTitle": "Replica Vacuum Interval Hours",
     "sectionTitle": "Replica Vacuum Interval Hours",
@@ -8000,7 +8043,7 @@
     "kind": "section"
   },
   {
-    "id": "588-zero-cache-config#replication-lag-report-interval-ms",
+    "id": "591-zero-cache-config#replication-lag-report-interval-ms",
     "title": "zero-cache Config",
     "searchTitle": "Replication Lag Report Interval (ms)",
     "sectionTitle": "Replication Lag Report Interval (ms)",
@@ -8010,7 +8053,7 @@
     "kind": "section"
   },
   {
-    "id": "589-zero-cache-config#server-version",
+    "id": "592-zero-cache-config#server-version",
     "title": "zero-cache Config",
     "searchTitle": "Server Version",
     "sectionTitle": "Server Version",
@@ -8020,7 +8063,7 @@
     "kind": "section"
   },
   {
-    "id": "590-zero-cache-config#shadow-sync-enabled",
+    "id": "593-zero-cache-config#shadow-sync-enabled",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Enabled",
     "sectionTitle": "Shadow Sync Enabled",
@@ -8030,7 +8073,7 @@
     "kind": "section"
   },
   {
-    "id": "591-zero-cache-config#shadow-sync-interval-hours",
+    "id": "594-zero-cache-config#shadow-sync-interval-hours",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Interval Hours",
     "sectionTitle": "Shadow Sync Interval Hours",
@@ -8040,7 +8083,7 @@
     "kind": "section"
   },
   {
-    "id": "592-zero-cache-config#shadow-sync-sample-rate",
+    "id": "595-zero-cache-config#shadow-sync-sample-rate",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Sample Rate",
     "sectionTitle": "Shadow Sync Sample Rate",
@@ -8050,7 +8093,7 @@
     "kind": "section"
   },
   {
-    "id": "593-zero-cache-config#shadow-sync-max-rows-per-table",
+    "id": "596-zero-cache-config#shadow-sync-max-rows-per-table",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Max Rows Per Table",
     "sectionTitle": "Shadow Sync Max Rows Per Table",
@@ -8060,7 +8103,7 @@
     "kind": "section"
   },
   {
-    "id": "594-zero-cache-config#storage-db-temp-dir",
+    "id": "597-zero-cache-config#storage-db-temp-dir",
     "title": "zero-cache Config",
     "searchTitle": "Storage DB Temp Dir",
     "sectionTitle": "Storage DB Temp Dir",
@@ -8070,7 +8113,7 @@
     "kind": "section"
   },
   {
-    "id": "595-zero-cache-config#task-id",
+    "id": "598-zero-cache-config#task-id",
     "title": "zero-cache Config",
     "searchTitle": "Task ID",
     "sectionTitle": "Task ID",
@@ -8080,7 +8123,7 @@
     "kind": "section"
   },
   {
-    "id": "596-zero-cache-config#upstream-max-connections",
+    "id": "599-zero-cache-config#upstream-max-connections",
     "title": "zero-cache Config",
     "searchTitle": "Upstream Max Connections",
     "sectionTitle": "Upstream Max Connections",
@@ -8090,7 +8133,7 @@
     "kind": "section"
   },
   {
-    "id": "597-zero-cache-config#upstream-pg-replication-slot-failover",
+    "id": "600-zero-cache-config#upstream-pg-replication-slot-failover",
     "title": "zero-cache Config",
     "searchTitle": "Upstream PG Replication Slot Failover",
     "sectionTitle": "Upstream PG Replication Slot Failover",
@@ -8100,7 +8143,7 @@
     "kind": "section"
   },
   {
-    "id": "598-zero-cache-config#websocket-compression",
+    "id": "601-zero-cache-config#websocket-compression",
     "title": "zero-cache Config",
     "searchTitle": "Websocket Compression",
     "sectionTitle": "Websocket Compression",
@@ -8110,7 +8153,7 @@
     "kind": "section"
   },
   {
-    "id": "599-zero-cache-config#websocket-compression-options",
+    "id": "602-zero-cache-config#websocket-compression-options",
     "title": "zero-cache Config",
     "searchTitle": "Websocket Compression Options",
     "sectionTitle": "Websocket Compression Options",
@@ -8120,7 +8163,7 @@
     "kind": "section"
   },
   {
-    "id": "600-zero-cache-config#websocket-max-payload-bytes",
+    "id": "603-zero-cache-config#websocket-max-payload-bytes",
     "title": "zero-cache Config",
     "searchTitle": "Websocket Max Payload Bytes",
     "sectionTitle": "Websocket Max Payload Bytes",
@@ -8130,7 +8173,7 @@
     "kind": "section"
   },
   {
-    "id": "601-zero-cache-config#yield-threshold-ms",
+    "id": "604-zero-cache-config#yield-threshold-ms",
     "title": "zero-cache Config",
     "searchTitle": "Yield Threshold (ms)",
     "sectionTitle": "Yield Threshold (ms)",
@@ -8140,7 +8183,7 @@
     "kind": "section"
   },
   {
-    "id": "602-zero-cache-config#deprecated-flags",
+    "id": "605-zero-cache-config#deprecated-flags",
     "title": "zero-cache Config",
     "searchTitle": "Deprecated Flags",
     "sectionTitle": "Deprecated Flags",
@@ -8150,7 +8193,7 @@
     "kind": "section"
   },
   {
-    "id": "603-zero-cache-config#auth-jwk",
+    "id": "606-zero-cache-config#auth-jwk",
     "title": "zero-cache Config",
     "searchTitle": "Auth JWK",
     "sectionTitle": "Auth JWK",
@@ -8160,7 +8203,7 @@
     "kind": "section"
   },
   {
-    "id": "604-zero-cache-config#auth-jwks-url",
+    "id": "607-zero-cache-config#auth-jwks-url",
     "title": "zero-cache Config",
     "searchTitle": "Auth JWKS URL",
     "sectionTitle": "Auth JWKS URL",
@@ -8170,7 +8213,7 @@
     "kind": "section"
   },
   {
-    "id": "605-zero-cache-config#auth-secret",
+    "id": "608-zero-cache-config#auth-secret",
     "title": "zero-cache Config",
     "searchTitle": "Auth Secret",
     "sectionTitle": "Auth Secret",
@@ -8290,7 +8333,7 @@
     "kind": "page"
   },
   {
-    "id": "606-zql#create-a-builder",
+    "id": "609-zql#create-a-builder",
     "title": "ZQL",
     "searchTitle": "Create a Builder",
     "sectionTitle": "Create a Builder",
@@ -8300,7 +8343,7 @@
     "kind": "section"
   },
   {
-    "id": "607-zql#select",
+    "id": "610-zql#select",
     "title": "ZQL",
     "searchTitle": "Select",
     "sectionTitle": "Select",
@@ -8310,7 +8353,7 @@
     "kind": "section"
   },
   {
-    "id": "608-zql#ordering",
+    "id": "611-zql#ordering",
     "title": "ZQL",
     "searchTitle": "Ordering",
     "sectionTitle": "Ordering",
@@ -8320,7 +8363,7 @@
     "kind": "section"
   },
   {
-    "id": "609-zql#limit",
+    "id": "612-zql#limit",
     "title": "ZQL",
     "searchTitle": "Limit",
     "sectionTitle": "Limit",
@@ -8330,7 +8373,7 @@
     "kind": "section"
   },
   {
-    "id": "610-zql#paging",
+    "id": "613-zql#paging",
     "title": "ZQL",
     "searchTitle": "Paging",
     "sectionTitle": "Paging",
@@ -8340,7 +8383,7 @@
     "kind": "section"
   },
   {
-    "id": "611-zql#getting-a-single-result",
+    "id": "614-zql#getting-a-single-result",
     "title": "ZQL",
     "searchTitle": "Getting a Single Result",
     "sectionTitle": "Getting a Single Result",
@@ -8350,7 +8393,7 @@
     "kind": "section"
   },
   {
-    "id": "612-zql#relationships",
+    "id": "615-zql#relationships",
     "title": "ZQL",
     "searchTitle": "Relationships",
     "sectionTitle": "Relationships",
@@ -8360,7 +8403,7 @@
     "kind": "section"
   },
   {
-    "id": "613-zql#refining-relationships",
+    "id": "616-zql#refining-relationships",
     "title": "ZQL",
     "searchTitle": "Refining Relationships",
     "sectionTitle": "Refining Relationships",
@@ -8370,7 +8413,7 @@
     "kind": "section"
   },
   {
-    "id": "614-zql#nested-relationships",
+    "id": "617-zql#nested-relationships",
     "title": "ZQL",
     "searchTitle": "Nested Relationships",
     "sectionTitle": "Nested Relationships",
@@ -8380,7 +8423,7 @@
     "kind": "section"
   },
   {
-    "id": "615-zql#where",
+    "id": "618-zql#where",
     "title": "ZQL",
     "searchTitle": "Where",
     "sectionTitle": "Where",
@@ -8390,7 +8433,7 @@
     "kind": "section"
   },
   {
-    "id": "616-zql#comparison-operators",
+    "id": "619-zql#comparison-operators",
     "title": "ZQL",
     "searchTitle": "Comparison Operators",
     "sectionTitle": "Comparison Operators",
@@ -8400,7 +8443,7 @@
     "kind": "section"
   },
   {
-    "id": "617-zql#equals-is-the-default-comparison-operator",
+    "id": "620-zql#equals-is-the-default-comparison-operator",
     "title": "ZQL",
     "searchTitle": "Equals is the Default Comparison Operator",
     "sectionTitle": "Equals is the Default Comparison Operator",
@@ -8410,7 +8453,7 @@
     "kind": "section"
   },
   {
-    "id": "618-zql#comparing-to-null",
+    "id": "621-zql#comparing-to-null",
     "title": "ZQL",
     "searchTitle": "Comparing to null",
     "sectionTitle": "Comparing to null",
@@ -8420,7 +8463,7 @@
     "kind": "section"
   },
   {
-    "id": "619-zql#comparing-to-undefined",
+    "id": "622-zql#comparing-to-undefined",
     "title": "ZQL",
     "searchTitle": "Comparing to undefined",
     "sectionTitle": "Comparing to undefined",
@@ -8430,7 +8473,7 @@
     "kind": "section"
   },
   {
-    "id": "620-zql#compound-filters",
+    "id": "623-zql#compound-filters",
     "title": "ZQL",
     "searchTitle": "Compound Filters",
     "sectionTitle": "Compound Filters",
@@ -8440,7 +8483,7 @@
     "kind": "section"
   },
   {
-    "id": "621-zql#comparing-literal-values",
+    "id": "624-zql#comparing-literal-values",
     "title": "ZQL",
     "searchTitle": "Comparing Literal Values",
     "sectionTitle": "Comparing Literal Values",
@@ -8450,7 +8493,7 @@
     "kind": "section"
   },
   {
-    "id": "622-zql#relationship-filters",
+    "id": "625-zql#relationship-filters",
     "title": "ZQL",
     "searchTitle": "Relationship Filters",
     "sectionTitle": "Relationship Filters",
@@ -8460,7 +8503,7 @@
     "kind": "section"
   },
   {
-    "id": "623-zql#type-helpers",
+    "id": "626-zql#type-helpers",
     "title": "ZQL",
     "searchTitle": "Type Helpers",
     "sectionTitle": "Type Helpers",
@@ -8470,7 +8513,7 @@
     "kind": "section"
   },
   {
-    "id": "624-zql#planning",
+    "id": "627-zql#planning",
     "title": "ZQL",
     "searchTitle": "Planning",
     "sectionTitle": "Planning",
@@ -8480,7 +8523,7 @@
     "kind": "section"
   },
   {
-    "id": "625-zql#inspecting-query-plans",
+    "id": "628-zql#inspecting-query-plans",
     "title": "ZQL",
     "searchTitle": "Inspecting Query Plans",
     "sectionTitle": "Inspecting Query Plans",
@@ -8490,7 +8533,7 @@
     "kind": "section"
   },
   {
-    "id": "626-zql#manually-flipping-joins",
+    "id": "629-zql#manually-flipping-joins",
     "title": "ZQL",
     "searchTitle": "Manually Flipping Joins",
     "sectionTitle": "Manually Flipping Joins",
@@ -8500,7 +8543,7 @@
     "kind": "section"
   },
   {
-    "id": "627-zql#scalar-subqueries",
+    "id": "630-zql#scalar-subqueries",
     "title": "ZQL",
     "searchTitle": "Scalar Subqueries",
     "sectionTitle": "Scalar Subqueries",
@@ -8510,7 +8553,7 @@
     "kind": "section"
   },
   {
-    "id": "628-zql#why-it-matters",
+    "id": "631-zql#why-it-matters",
     "title": "ZQL",
     "searchTitle": "Why It Matters",
     "sectionTitle": "Why It Matters",
@@ -8520,7 +8563,7 @@
     "kind": "section"
   },
   {
-    "id": "629-zql#trade-offs",
+    "id": "632-zql#trade-offs",
     "title": "ZQL",
     "searchTitle": "Trade-offs",
     "sectionTitle": "Trade-offs",
@@ -8530,7 +8573,7 @@
     "kind": "section"
   },
   {
-    "id": "630-zql#future-work",
+    "id": "633-zql#future-work",
     "title": "ZQL",
     "searchTitle": "Future Work",
     "sectionTitle": "Future Work",

--- a/assets/search-index.json
+++ b/assets/search-index.json
@@ -14,7 +14,7 @@
     "kind": "page"
   },
   {
-    "id": "71-agents#options",
+    "id": "72-agents#options",
     "title": "Agent Support",
     "searchTitle": "Options",
     "sectionTitle": "Options",
@@ -130,7 +130,7 @@
     "kind": "page"
   },
   {
-    "id": "72-auth#setting-userid",
+    "id": "73-auth#setting-userid",
     "title": "Authentication",
     "searchTitle": "Setting userID",
     "sectionTitle": "Setting userID",
@@ -140,7 +140,7 @@
     "kind": "section"
   },
   {
-    "id": "73-auth#context",
+    "id": "74-auth#context",
     "title": "Authentication",
     "searchTitle": "Context",
     "sectionTitle": "Context",
@@ -150,7 +150,7 @@
     "kind": "section"
   },
   {
-    "id": "74-auth#sending-credentials",
+    "id": "75-auth#sending-credentials",
     "title": "Authentication",
     "searchTitle": "Sending Credentials",
     "sectionTitle": "Sending Credentials",
@@ -160,7 +160,7 @@
     "kind": "section"
   },
   {
-    "id": "75-auth#cookies",
+    "id": "76-auth#cookies",
     "title": "Authentication",
     "searchTitle": "Cookies",
     "sectionTitle": "Cookies",
@@ -170,7 +170,7 @@
     "kind": "section"
   },
   {
-    "id": "76-auth#query-handler",
+    "id": "77-auth#query-handler",
     "title": "Authentication",
     "searchTitle": "Query Handler",
     "sectionTitle": "Query Handler",
@@ -180,7 +180,7 @@
     "kind": "section"
   },
   {
-    "id": "77-auth#mutate-handler",
+    "id": "78-auth#mutate-handler",
     "title": "Authentication",
     "searchTitle": "Mutate Handler",
     "sectionTitle": "Mutate Handler",
@@ -190,7 +190,7 @@
     "kind": "section"
   },
   {
-    "id": "78-auth#deployment",
+    "id": "79-auth#deployment",
     "title": "Authentication",
     "searchTitle": "Deployment",
     "sectionTitle": "Deployment",
@@ -200,7 +200,7 @@
     "kind": "section"
   },
   {
-    "id": "79-auth#tokens",
+    "id": "80-auth#tokens",
     "title": "Authentication",
     "searchTitle": "Tokens",
     "sectionTitle": "Tokens",
@@ -210,7 +210,7 @@
     "kind": "section"
   },
   {
-    "id": "80-auth#query-handler-1",
+    "id": "81-auth#query-handler-1",
     "title": "Authentication",
     "searchTitle": "Query Handler",
     "sectionTitle": "Query Handler",
@@ -220,7 +220,7 @@
     "kind": "section"
   },
   {
-    "id": "81-auth#mutate-handler-1",
+    "id": "82-auth#mutate-handler-1",
     "title": "Authentication",
     "searchTitle": "Mutate Handler",
     "sectionTitle": "Mutate Handler",
@@ -230,7 +230,7 @@
     "kind": "section"
   },
   {
-    "id": "82-auth#updating-tokens",
+    "id": "83-auth#updating-tokens",
     "title": "Authentication",
     "searchTitle": "Updating Tokens",
     "sectionTitle": "Updating Tokens",
@@ -240,7 +240,7 @@
     "kind": "section"
   },
   {
-    "id": "83-auth#auth-failure-and-refresh",
+    "id": "84-auth#auth-failure-and-refresh",
     "title": "Authentication",
     "searchTitle": "Auth Failure and Refresh",
     "sectionTitle": "Auth Failure and Refresh",
@@ -250,7 +250,7 @@
     "kind": "section"
   },
   {
-    "id": "84-auth#permission-patterns",
+    "id": "85-auth#permission-patterns",
     "title": "Authentication",
     "searchTitle": "Permission Patterns",
     "sectionTitle": "Permission Patterns",
@@ -260,7 +260,7 @@
     "kind": "section"
   },
   {
-    "id": "85-auth#read-permissions",
+    "id": "86-auth#read-permissions",
     "title": "Authentication",
     "searchTitle": "Read Permissions",
     "sectionTitle": "Read Permissions",
@@ -270,7 +270,7 @@
     "kind": "section"
   },
   {
-    "id": "86-auth#only-owned-rows",
+    "id": "87-auth#only-owned-rows",
     "title": "Authentication",
     "searchTitle": "Only Owned Rows",
     "sectionTitle": "Only Owned Rows",
@@ -280,7 +280,7 @@
     "kind": "section"
   },
   {
-    "id": "87-auth#owned-or-shared-rows",
+    "id": "88-auth#owned-or-shared-rows",
     "title": "Authentication",
     "searchTitle": "Owned or Shared Rows",
     "sectionTitle": "Owned or Shared Rows",
@@ -290,7 +290,7 @@
     "kind": "section"
   },
   {
-    "id": "88-auth#owned-rows-or-all-if-admin",
+    "id": "89-auth#owned-rows-or-all-if-admin",
     "title": "Authentication",
     "searchTitle": "Owned Rows or All if Admin",
     "sectionTitle": "Owned Rows or All if Admin",
@@ -300,7 +300,7 @@
     "kind": "section"
   },
   {
-    "id": "89-auth#deny-by-returning-no-rows",
+    "id": "90-auth#deny-by-returning-no-rows",
     "title": "Authentication",
     "searchTitle": "Deny by Returning No Rows",
     "sectionTitle": "Deny by Returning No Rows",
@@ -310,7 +310,7 @@
     "kind": "section"
   },
   {
-    "id": "90-auth#write-permissions",
+    "id": "91-auth#write-permissions",
     "title": "Authentication",
     "searchTitle": "Write Permissions",
     "sectionTitle": "Write Permissions",
@@ -320,7 +320,7 @@
     "kind": "section"
   },
   {
-    "id": "91-auth#enforce-ownership",
+    "id": "92-auth#enforce-ownership",
     "title": "Authentication",
     "searchTitle": "Enforce Ownership",
     "sectionTitle": "Enforce Ownership",
@@ -330,7 +330,7 @@
     "kind": "section"
   },
   {
-    "id": "92-auth#edit-owned-rows",
+    "id": "93-auth#edit-owned-rows",
     "title": "Authentication",
     "searchTitle": "Edit Owned Rows",
     "sectionTitle": "Edit Owned Rows",
@@ -340,7 +340,7 @@
     "kind": "section"
   },
   {
-    "id": "93-auth#edit-owned-or-shared-rows",
+    "id": "94-auth#edit-owned-or-shared-rows",
     "title": "Authentication",
     "searchTitle": "Edit Owned or Shared Rows",
     "sectionTitle": "Edit Owned or Shared Rows",
@@ -350,7 +350,7 @@
     "kind": "section"
   },
   {
-    "id": "94-auth#edit-owned-or-all-if-admin",
+    "id": "95-auth#edit-owned-or-all-if-admin",
     "title": "Authentication",
     "searchTitle": "Edit Owned or All if Admin",
     "sectionTitle": "Edit Owned or All if Admin",
@@ -360,7 +360,7 @@
     "kind": "section"
   },
   {
-    "id": "95-auth#logging-out",
+    "id": "96-auth#logging-out",
     "title": "Authentication",
     "searchTitle": "Logging Out",
     "sectionTitle": "Logging Out",
@@ -397,7 +397,7 @@
     "kind": "page"
   },
   {
-    "id": "96-community#ui-frameworks",
+    "id": "97-community#ui-frameworks",
     "title": "From the Community",
     "searchTitle": "UI Frameworks",
     "sectionTitle": "UI Frameworks",
@@ -407,7 +407,7 @@
     "kind": "section"
   },
   {
-    "id": "97-community#miscellaneous",
+    "id": "98-community#miscellaneous",
     "title": "From the Community",
     "searchTitle": "Miscellaneous",
     "sectionTitle": "Miscellaneous",
@@ -499,7 +499,7 @@
     "kind": "page"
   },
   {
-    "id": "98-connecting-to-postgres#event-triggers",
+    "id": "99-connecting-to-postgres#event-triggers",
     "title": "Connecting to Postgres",
     "searchTitle": "Event Triggers",
     "sectionTitle": "Event Triggers",
@@ -509,7 +509,7 @@
     "kind": "section"
   },
   {
-    "id": "99-connecting-to-postgres#configuration",
+    "id": "100-connecting-to-postgres#configuration",
     "title": "Connecting to Postgres",
     "searchTitle": "Configuration",
     "sectionTitle": "Configuration",
@@ -519,7 +519,7 @@
     "kind": "section"
   },
   {
-    "id": "100-connecting-to-postgres#wal-level",
+    "id": "101-connecting-to-postgres#wal-level",
     "title": "Connecting to Postgres",
     "searchTitle": "WAL Level",
     "sectionTitle": "WAL Level",
@@ -529,7 +529,7 @@
     "kind": "section"
   },
   {
-    "id": "101-connecting-to-postgres#bounding-wal-size",
+    "id": "102-connecting-to-postgres#bounding-wal-size",
     "title": "Connecting to Postgres",
     "searchTitle": "Bounding WAL Size",
     "sectionTitle": "Bounding WAL Size",
@@ -539,7 +539,7 @@
     "kind": "section"
   },
   {
-    "id": "102-connecting-to-postgres#provider-specific-notes",
+    "id": "103-connecting-to-postgres#provider-specific-notes",
     "title": "Connecting to Postgres",
     "searchTitle": "Provider-Specific Notes",
     "sectionTitle": "Provider-Specific Notes",
@@ -549,7 +549,7 @@
     "kind": "section"
   },
   {
-    "id": "103-connecting-to-postgres#planetscale-for-postgres",
+    "id": "104-connecting-to-postgres#planetscale-for-postgres",
     "title": "Connecting to Postgres",
     "searchTitle": "PlanetScale for Postgres",
     "sectionTitle": "PlanetScale for Postgres",
@@ -559,7 +559,7 @@
     "kind": "section"
   },
   {
-    "id": "104-connecting-to-postgres#neon",
+    "id": "105-connecting-to-postgres#neon",
     "title": "Connecting to Postgres",
     "searchTitle": "Neon",
     "sectionTitle": "Neon",
@@ -569,7 +569,7 @@
     "kind": "section"
   },
   {
-    "id": "105-connecting-to-postgres#logical-replication",
+    "id": "106-connecting-to-postgres#logical-replication",
     "title": "Connecting to Postgres",
     "searchTitle": "Logical Replication",
     "sectionTitle": "Logical Replication",
@@ -579,7 +579,7 @@
     "kind": "section"
   },
   {
-    "id": "106-connecting-to-postgres#branching",
+    "id": "107-connecting-to-postgres#branching",
     "title": "Connecting to Postgres",
     "searchTitle": "Branching",
     "sectionTitle": "Branching",
@@ -589,7 +589,7 @@
     "kind": "section"
   },
   {
-    "id": "107-connecting-to-postgres#flyio",
+    "id": "108-connecting-to-postgres#flyio",
     "title": "Connecting to Postgres",
     "searchTitle": "Fly.io",
     "sectionTitle": "Fly.io",
@@ -599,7 +599,7 @@
     "kind": "section"
   },
   {
-    "id": "108-connecting-to-postgres#networking",
+    "id": "109-connecting-to-postgres#networking",
     "title": "Connecting to Postgres",
     "searchTitle": "Networking",
     "sectionTitle": "Networking",
@@ -609,7 +609,7 @@
     "kind": "section"
   },
   {
-    "id": "109-connecting-to-postgres#permissions",
+    "id": "110-connecting-to-postgres#permissions",
     "title": "Connecting to Postgres",
     "searchTitle": "Permissions",
     "sectionTitle": "Permissions",
@@ -619,7 +619,7 @@
     "kind": "section"
   },
   {
-    "id": "110-connecting-to-postgres#pooling",
+    "id": "111-connecting-to-postgres#pooling",
     "title": "Connecting to Postgres",
     "searchTitle": "Pooling",
     "sectionTitle": "Pooling",
@@ -629,7 +629,7 @@
     "kind": "section"
   },
   {
-    "id": "111-connecting-to-postgres#supabase",
+    "id": "112-connecting-to-postgres#supabase",
     "title": "Connecting to Postgres",
     "searchTitle": "Supabase",
     "sectionTitle": "Supabase",
@@ -639,7 +639,7 @@
     "kind": "section"
   },
   {
-    "id": "112-connecting-to-postgres#publication-changes",
+    "id": "113-connecting-to-postgres#publication-changes",
     "title": "Connecting to Postgres",
     "searchTitle": "Publication Changes",
     "sectionTitle": "Publication Changes",
@@ -649,7 +649,7 @@
     "kind": "section"
   },
   {
-    "id": "113-connecting-to-postgres#ipv4",
+    "id": "114-connecting-to-postgres#ipv4",
     "title": "Connecting to Postgres",
     "searchTitle": "IPv4",
     "sectionTitle": "IPv4",
@@ -659,7 +659,7 @@
     "kind": "section"
   },
   {
-    "id": "114-connecting-to-postgres#render",
+    "id": "115-connecting-to-postgres#render",
     "title": "Connecting to Postgres",
     "searchTitle": "Render",
     "sectionTitle": "Render",
@@ -669,7 +669,7 @@
     "kind": "section"
   },
   {
-    "id": "115-connecting-to-postgres#google-cloud-sql",
+    "id": "116-connecting-to-postgres#google-cloud-sql",
     "title": "Connecting to Postgres",
     "searchTitle": "Google Cloud SQL",
     "sectionTitle": "Google Cloud SQL",
@@ -749,7 +749,7 @@
     "kind": "page"
   },
   {
-    "id": "116-connection#overview",
+    "id": "117-connection#overview",
     "title": "Connection Status",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -759,7 +759,7 @@
     "kind": "section"
   },
   {
-    "id": "117-connection#usage",
+    "id": "118-connection#usage",
     "title": "Connection Status",
     "searchTitle": "Usage",
     "sectionTitle": "Usage",
@@ -769,7 +769,7 @@
     "kind": "section"
   },
   {
-    "id": "118-connection#offline",
+    "id": "119-connection#offline",
     "title": "Connection Status",
     "searchTitle": "Offline",
     "sectionTitle": "Offline",
@@ -779,7 +779,7 @@
     "kind": "section"
   },
   {
-    "id": "119-connection#offline-ui",
+    "id": "120-connection#offline-ui",
     "title": "Connection Status",
     "searchTitle": "Offline UI",
     "sectionTitle": "Offline UI",
@@ -789,7 +789,7 @@
     "kind": "section"
   },
   {
-    "id": "120-connection#details",
+    "id": "121-connection#details",
     "title": "Connection Status",
     "searchTitle": "Details",
     "sectionTitle": "Details",
@@ -799,7 +799,7 @@
     "kind": "section"
   },
   {
-    "id": "121-connection#connecting",
+    "id": "122-connection#connecting",
     "title": "Connection Status",
     "searchTitle": "Connecting",
     "sectionTitle": "Connecting",
@@ -809,7 +809,7 @@
     "kind": "section"
   },
   {
-    "id": "122-connection#connected",
+    "id": "123-connection#connected",
     "title": "Connection Status",
     "searchTitle": "Connected",
     "sectionTitle": "Connected",
@@ -819,7 +819,7 @@
     "kind": "section"
   },
   {
-    "id": "123-connection#disconnected",
+    "id": "124-connection#disconnected",
     "title": "Connection Status",
     "searchTitle": "Disconnected",
     "sectionTitle": "Disconnected",
@@ -829,7 +829,7 @@
     "kind": "section"
   },
   {
-    "id": "124-connection#error",
+    "id": "125-connection#error",
     "title": "Connection Status",
     "searchTitle": "Error",
     "sectionTitle": "Error",
@@ -839,7 +839,7 @@
     "kind": "section"
   },
   {
-    "id": "125-connection#needs-auth",
+    "id": "126-connection#needs-auth",
     "title": "Connection Status",
     "searchTitle": "Needs-Auth",
     "sectionTitle": "Needs-Auth",
@@ -849,7 +849,7 @@
     "kind": "section"
   },
   {
-    "id": "126-connection#closed",
+    "id": "127-connection#closed",
     "title": "Connection Status",
     "searchTitle": "Closed",
     "sectionTitle": "Closed",
@@ -859,7 +859,7 @@
     "kind": "section"
   },
   {
-    "id": "127-connection#why-zero-doesnt-support-offline-writes",
+    "id": "128-connection#why-zero-doesnt-support-offline-writes",
     "title": "Connection Status",
     "searchTitle": "Why Zero Doesn't Support Offline Writes",
     "sectionTitle": "Why Zero Doesn't Support Offline Writes",
@@ -869,7 +869,7 @@
     "kind": "section"
   },
   {
-    "id": "128-connection#example",
+    "id": "129-connection#example",
     "title": "Connection Status",
     "searchTitle": "Example",
     "sectionTitle": "Example",
@@ -879,7 +879,7 @@
     "kind": "section"
   },
   {
-    "id": "129-connection#tradeoffs",
+    "id": "130-connection#tradeoffs",
     "title": "Connection Status",
     "searchTitle": "Tradeoffs",
     "sectionTitle": "Tradeoffs",
@@ -889,7 +889,7 @@
     "kind": "section"
   },
   {
-    "id": "130-connection#zeros-position",
+    "id": "131-connection#zeros-position",
     "title": "Connection Status",
     "searchTitle": "Zero's Position",
     "sectionTitle": "Zero's Position",
@@ -937,7 +937,7 @@
     "kind": "page"
   },
   {
-    "id": "131-debug/analyze-query-cli#set-up",
+    "id": "132-debug/analyze-query-cli#set-up",
     "title": "Analyze Query CLI",
     "searchTitle": "Set Up",
     "sectionTitle": "Set Up",
@@ -947,7 +947,7 @@
     "kind": "section"
   },
   {
-    "id": "132-debug/analyze-query-cli#run-zql-queries",
+    "id": "133-debug/analyze-query-cli#run-zql-queries",
     "title": "Analyze Query CLI",
     "searchTitle": "Run ZQL Queries",
     "sectionTitle": "Run ZQL Queries",
@@ -957,7 +957,7 @@
     "kind": "section"
   },
   {
-    "id": "133-debug/analyze-query-cli#production-use",
+    "id": "134-debug/analyze-query-cli#production-use",
     "title": "Analyze Query CLI",
     "searchTitle": "Production Use",
     "sectionTitle": "Production Use",
@@ -967,7 +967,7 @@
     "kind": "section"
   },
   {
-    "id": "134-debug/analyze-query-cli#env-var-shorthand",
+    "id": "135-debug/analyze-query-cli#env-var-shorthand",
     "title": "Analyze Query CLI",
     "searchTitle": "Env Var Shorthand",
     "sectionTitle": "Env Var Shorthand",
@@ -977,7 +977,7 @@
     "kind": "section"
   },
   {
-    "id": "135-debug/analyze-query-cli#other-input-modes",
+    "id": "136-debug/analyze-query-cli#other-input-modes",
     "title": "Analyze Query CLI",
     "searchTitle": "Other Input Modes",
     "sectionTitle": "Other Input Modes",
@@ -987,7 +987,7 @@
     "kind": "section"
   },
   {
-    "id": "136-debug/analyze-query-cli#output",
+    "id": "137-debug/analyze-query-cli#output",
     "title": "Analyze Query CLI",
     "searchTitle": "Output",
     "sectionTitle": "Output",
@@ -997,7 +997,7 @@
     "kind": "section"
   },
   {
-    "id": "137-debug/analyze-query-cli#optional-output",
+    "id": "138-debug/analyze-query-cli#optional-output",
     "title": "Analyze Query CLI",
     "searchTitle": "Optional Output",
     "sectionTitle": "Optional Output",
@@ -1057,7 +1057,7 @@
     "kind": "page"
   },
   {
-    "id": "138-debug/inspector#accessing-the-inspector",
+    "id": "139-debug/inspector#accessing-the-inspector",
     "title": "Inspector",
     "searchTitle": "Accessing the Inspector",
     "sectionTitle": "Accessing the Inspector",
@@ -1067,7 +1067,7 @@
     "kind": "section"
   },
   {
-    "id": "139-debug/inspector#clients-and-groups",
+    "id": "140-debug/inspector#clients-and-groups",
     "title": "Inspector",
     "searchTitle": "Clients and Groups",
     "sectionTitle": "Clients and Groups",
@@ -1077,7 +1077,7 @@
     "kind": "section"
   },
   {
-    "id": "140-debug/inspector#queries",
+    "id": "141-debug/inspector#queries",
     "title": "Inspector",
     "searchTitle": "Queries",
     "sectionTitle": "Queries",
@@ -1087,7 +1087,7 @@
     "kind": "section"
   },
   {
-    "id": "141-debug/inspector#analyzing-queries",
+    "id": "142-debug/inspector#analyzing-queries",
     "title": "Inspector",
     "searchTitle": "Analyzing Queries",
     "sectionTitle": "Analyzing Queries",
@@ -1097,7 +1097,7 @@
     "kind": "section"
   },
   {
-    "id": "142-debug/inspector#interpreting-query-analysis",
+    "id": "143-debug/inspector#interpreting-query-analysis",
     "title": "Inspector",
     "searchTitle": "Interpreting Query Analysis",
     "sectionTitle": "Interpreting Query Analysis",
@@ -1107,7 +1107,7 @@
     "kind": "section"
   },
   {
-    "id": "143-debug/inspector#viewing-sqlite-plans",
+    "id": "144-debug/inspector#viewing-sqlite-plans",
     "title": "Inspector",
     "searchTitle": "Viewing SQLite Plans",
     "sectionTitle": "Viewing SQLite Plans",
@@ -1117,7 +1117,7 @@
     "kind": "section"
   },
   {
-    "id": "144-debug/inspector#viewing-zero-plans",
+    "id": "145-debug/inspector#viewing-zero-plans",
     "title": "Inspector",
     "searchTitle": "Viewing Zero Plans",
     "sectionTitle": "Viewing Zero Plans",
@@ -1127,7 +1127,7 @@
     "kind": "section"
   },
   {
-    "id": "145-debug/inspector#analyzing-arbitrary-zql",
+    "id": "146-debug/inspector#analyzing-arbitrary-zql",
     "title": "Inspector",
     "searchTitle": "Analyzing Arbitrary ZQL",
     "sectionTitle": "Analyzing Arbitrary ZQL",
@@ -1137,7 +1137,7 @@
     "kind": "section"
   },
   {
-    "id": "146-debug/inspector#table-data",
+    "id": "147-debug/inspector#table-data",
     "title": "Inspector",
     "searchTitle": "Table Data",
     "sectionTitle": "Table Data",
@@ -1147,7 +1147,7 @@
     "kind": "section"
   },
   {
-    "id": "147-debug/inspector#server-version",
+    "id": "148-debug/inspector#server-version",
     "title": "Inspector",
     "searchTitle": "Server Version",
     "sectionTitle": "Server Version",
@@ -1188,7 +1188,7 @@
     "kind": "page"
   },
   {
-    "id": "148-debug/replication#resetting",
+    "id": "149-debug/replication#resetting",
     "title": "Replication",
     "searchTitle": "Resetting",
     "sectionTitle": "Resetting",
@@ -1198,7 +1198,7 @@
     "kind": "section"
   },
   {
-    "id": "149-debug/replication#inspecting",
+    "id": "150-debug/replication#inspecting",
     "title": "Replication",
     "searchTitle": "Inspecting",
     "sectionTitle": "Inspecting",
@@ -1208,7 +1208,7 @@
     "kind": "section"
   },
   {
-    "id": "150-debug/replication#miscellaneous",
+    "id": "151-debug/replication#miscellaneous",
     "title": "Replication",
     "searchTitle": "Miscellaneous",
     "sectionTitle": "Miscellaneous",
@@ -1248,7 +1248,7 @@
     "kind": "page"
   },
   {
-    "id": "151-debug/slow-queries#analyze-queries",
+    "id": "152-debug/slow-queries#analyze-queries",
     "title": "Slow Queries",
     "searchTitle": "Analyze Queries",
     "sectionTitle": "Analyze Queries",
@@ -1258,7 +1258,7 @@
     "kind": "section"
   },
   {
-    "id": "152-debug/slow-queries#check-ttl",
+    "id": "153-debug/slow-queries#check-ttl",
     "title": "Slow Queries",
     "searchTitle": "Check ttl",
     "sectionTitle": "Check ttl",
@@ -1268,7 +1268,7 @@
     "kind": "section"
   },
   {
-    "id": "153-debug/slow-queries#locality",
+    "id": "154-debug/slow-queries#locality",
     "title": "Slow Queries",
     "searchTitle": "Locality",
     "sectionTitle": "Locality",
@@ -1278,7 +1278,7 @@
     "kind": "section"
   },
   {
-    "id": "154-debug/slow-queries#check-storage",
+    "id": "155-debug/slow-queries#check-storage",
     "title": "Slow Queries",
     "searchTitle": "Check Storage",
     "sectionTitle": "Check Storage",
@@ -1288,7 +1288,7 @@
     "kind": "section"
   },
   {
-    "id": "155-debug/slow-queries#statz",
+    "id": "156-debug/slow-queries#statz",
     "title": "Slow Queries",
     "searchTitle": "/statz",
     "sectionTitle": "/statz",
@@ -1321,7 +1321,7 @@
     "kind": "page"
   },
   {
-    "id": "156-deprecated/ad-hoc-queries#overview",
+    "id": "157-deprecated/ad-hoc-queries#overview",
     "title": "Ad-Hoc Queries (Deprecated)",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -1335,7 +1335,7 @@
     "title": "CRUD Mutators (Deprecated)",
     "searchTitle": "CRUD Mutators (Deprecated)",
     "url": "/docs/deprecated/crud-mutators",
-    "content": "It will be removed in a future release of Zero. Please move to the new mutator API. Overview Zero generates basic CRUD mutators for every table you sync. To enable, set the enableLegacyMutators option to true in your schema: const schema = createSchema({ // ... enableLegacyMutators: true }) Once enabled, mutators are available at z.mutate.<tablename>: const zero = new Zero(...); zero.mutate.user.insert({ id: nanoid(), username: 'abby', language: 'en-us', }); See Writing Data with Mutators for more information. z.mutate contains the same methods as tx.mutate but is available on the Zero instance instead of the Transaction instance.",
+    "content": "It will be removed in a future release of Zero. Please move to the new mutator API. Overview Zero generates basic CRUD mutators for every table you sync. To enable, set the enableLegacyMutators option to true in your schema: const schema = createSchema({ // ... enableLegacyMutators: true }) Once enabled, mutators are available at z.mutate.<tablename>: const zero = new Zero(...); zero.mutate.user.insert({ id: crypto.randomUUID(), username: 'abby', language: 'en-us', }); See Writing Data with Mutators for more information. z.mutate contains the same methods as tx.mutate but is available on the Zero instance instead of the Transaction instance.",
     "headings": [
       {
         "text": "Overview",
@@ -1345,13 +1345,13 @@
     "kind": "page"
   },
   {
-    "id": "157-deprecated/crud-mutators#overview",
+    "id": "158-deprecated/crud-mutators#overview",
     "title": "CRUD Mutators (Deprecated)",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
     "sectionId": "overview",
     "url": "/docs/deprecated/crud-mutators",
-    "content": "Zero generates basic CRUD mutators for every table you sync. To enable, set the enableLegacyMutators option to true in your schema: const schema = createSchema({ // ... enableLegacyMutators: true }) Once enabled, mutators are available at z.mutate.<tablename>: const zero = new Zero(...); zero.mutate.user.insert({ id: nanoid(), username: 'abby', language: 'en-us', }); See Writing Data with Mutators for more information. z.mutate contains the same methods as tx.mutate but is available on the Zero instance instead of the Transaction instance.",
+    "content": "Zero generates basic CRUD mutators for every table you sync. To enable, set the enableLegacyMutators option to true in your schema: const schema = createSchema({ // ... enableLegacyMutators: true }) Once enabled, mutators are available at z.mutate.<tablename>: const zero = new Zero(...); zero.mutate.user.insert({ id: crypto.randomUUID(), username: 'abby', language: 'en-us', }); See Writing Data with Mutators for more information. z.mutate contains the same methods as tx.mutate but is available on the Zero instance instead of the Transaction instance.",
     "kind": "section"
   },
   {
@@ -1359,7 +1359,7 @@
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "RLS Permissions (Deprecated)",
     "url": "/docs/deprecated/rls-permissions",
-    "content": "It will be removed in a future release of Zero. See Permissions for more information. Permissions are expressed using ZQL and run automatically with every read and write. Permissions are currently row based. Zero will eventually also have column permissions. Define Permissions Permissions are defined in schema.ts using the definePermissions function. Here's an example of limiting reads to members of an organization and deletes to only the creator of an issue: // The decoded value of your JWT. type AuthData = { // The logged-in user. sub: string } export const permissions = definePermissions< AuthData, Schema >(schema, () => { // Checks if the user exists in a related organization const allowIfInOrganization = ( authData: AuthData, eb: ExpressionBuilder<Schema, 'issue'> ) => eb.exists('organization', q => q.whereExists('user', q => q.where('id', authData.sub) ) ) // Checks if the user is the creator const allowIfIssueCreator = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('creatorID', authData.sub) return { issue: { row: { select: [allowIfInOrganization], delete: [allowIfIssueCreator] } } } satisfies PermissionsConfig<AuthData, Schema> }) definePermission returns a policy object for each table in the schema. Each policy defines a ruleset for the operations that are possible on a table: select, insert, update, and delete. Access is Denied by Default If you don't specify any rules for an operation, it is denied by default. This is an important safety feature that helps ensure data isn't accidentally exposed. To enable full access to an action (i.e., during development) use the ANYONE_CAN helper: import {ANYONE_CAN} from '@rocicorp/zero' const permissions = definePermissions<AuthData, Schema>( schema, () => { return { issue: { row: { select: ANYONE_CAN // Other operations are denied by default. } } // Other tables are denied by default. } satisfies PermissionsConfig<AuthData, Schema> } ) To do this for all actions, use ANYONE_CAN_DO_ANYTHING: import {ANYONE_CAN_DO_ANYTHING} from '@rocicorp/zero' const permissions = definePermissions<AuthData, Schema>( schema, () => { return { // All operations on issue are allowed to all users. issue: ANYONE_CAN_DO_ANYTHING // Other tables are denied by default. } satisfies PermissionsConfig<AuthData, Schema> } ) Permission Evaluation Zero permissions are \"compiled\" into a JSON-based format at build-time. This file is stored in the {ZERO_APP_ID}.permissions table of your upstream database. Like other tables, it replicates live down to zero-cache. zero-cache then parses this file, and applies the encoded rules to every read and write operation. The compilation process is very simple-minded (read: dumb). Despite looking like normal TypeScript functions that receive an AuthData parameter, rule functions are not actually invoked at runtime. Instead, they are invoked with a \"placeholder\" AuthData at build time. We track which fields of this placeholder are accessed and construct a ZQL expression that accesses the right field of AuthData at runtime. The end result is that you can't really use most features of JS in these rules. Specifically you cannot: Iterate over properties or array elements in the auth token Use any JS features beyond property access of AuthData Use any conditional or global state Basically only property access is allowed. This is really confusing and we're working on a better solution. Permission Deployment During development, permissions are compiled and uploaded to your database completely automatically as part of the zero-cache-dev script. For production, you need to call npx zero-deploy-permissions within your app to update the permissions in the production database whenever they change. You would typically do this as part of your normal schema migration or CI process. For example, the SST deployment script for zbugs looks like this: new command.local.Command( 'zero-deploy-permissions', { create: `npx zero-deploy-permissions -p ../../src/schema.ts`, // Run the Command on every deploy ... triggers: [Date.now()], environment: { ZERO_UPSTREAM_DB: commonEnv.ZERO_UPSTREAM_DB, // If the application has a non-default App ID ... ZERO_APP_ID: commonEnv.ZERO_APP_ID } }, // after the view-syncer is deployed. {dependsOn: viewSyncer} ) See the SST Deployment Guide for more details. Rules Each operation on a policy has a ruleset containing zero or more rules. A rule is just a TypeScript function that receives the logged in user's AuthData and generates a ZQL where expression. At least one rule in a ruleset must return a row for the operation to be allowed. Select Permissions You can limit the data a user can read by specifying a select ruleset. Select permissions act like filters. If a user does not have permission to read a row, it will be filtered out of the result set. It will not generate an error. For example, imagine a select permission that restricts reads to only issues created by the user: definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueCreator = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('creatorID', authData.sub) return { issue: { row: { select: [allowIfIssueCreator] } } } satisfies PermissionsConfig<AuthData, Schema> }) If the issue table has two rows, one created by the user and one by someone else, the user will only see the row they created in any queries. Select permission applies to every column. The recommended approach for now is to factor out private fields into a separate table, e.g. user_private. Column permissions are planned but currently not a high priority. Note that although the same limitation applies to declarative insert/update permissions, custom mutators support arbitrary server-side logic and so can easily control which columns are writable. Insert Permissions You can limit what rows can be inserted and by whom by specifying an insert ruleset. Insert rules are evaluated after the entity is inserted. So if they query the database, they will see the inserted row present. If any rule in the insert ruleset returns a row, the insert is allowed. Here's an example of an insert rule that disallows inserting users that have the role 'admin'. definePermissions<AuthData, Schema>(schema, () => { const allowIfNonAdmin = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'user'> ) => cmp('role', '!=', 'admin') return { user: { row: { insert: [allowIfNonAdmin] } } } satisfies PermissionsConfig<AuthData, Schema> }) Update Permissions There are two types of update rulesets: preMutation and postMutation. Both rulesets must pass for an update to be allowed. preMutation rules see the version of a row before the mutation is applied. This is useful for things like checking whether a user owns an entity before editing it. postMutation rules see the version of a row after the mutation is applied. This is useful for things like ensuring a user can only mark themselves as the creator of an entity and not other users. Like other rulesets, preMutation and postMutation default to NOBODY_CAN. This means that every table must define both these rulesets in order for any updates to be allowed. For example, the following ruleset allows an issue's owner to edit, but not re-assign the issue. The postMutation rule enforces that the current user still own the issue after edit. definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: [allowIfIssueOwner], postMutation: [allowIfIssueOwner] } } } } satisfies PermissionsConfig<AuthData, Schema> }) This ruleset allows an issue's owner to edit and re-assign the issue: definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: [allowIfIssueOwner], postMutation: ANYONE_CAN } } } } satisfies PermissionsConfig<AuthData, Schema> }) And this allows anyone to edit an issue, but only if they also assign it to themselves. Useful for enforcing \"patches welcome\"? 🙃 definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: ANYONE_CAN, postMutation: [allowIfIssueOwner] } } } } satisfies PermissionsConfig<AuthData, Schema> }) Delete Permissions Delete permissions work in the same way as insert permissions except they run before the delete is applied. So if a delete rule queries the database, it will see that the deleted row is present. If any rule in the ruleset returns a row, the delete is allowed. Permissions Based on Auth Data You can use the cmpLit helper to define permissions based on a field of the authData parameter: definePermissions<AuthData, Schema>(schema, () => { const allowIfAdmin = ( authData: AuthData, {cmpLit}: ExpressionBuilder<Schema, 'issue'> ) => cmpLit(authData.role, 'admin') return { issue: { row: { select: [allowIfAdmin] } } } satisfies PermissionsConfig<AuthData, Schema> }) Debugging Given that permissions are defined in their own file and internally applied to queries, it can be hard to figure out if or why a permission check is failing. Read Permissions You can use the analyze-query utility with the --apply-permissions flag to see the complete query Zero runs, including read permissions. npx analyze-query --schema-path='./shared/schema.ts' --query='issue.related(\"comments\")' --apply-permissions --auth-data='{\"userId\":\"user-123\"}' If the result looks right, the problem may be that Zero is not receiving the AuthData that you think it is. You can retrieve a query hash from websocket or server logs, then ask Zero for the details on that specific query. Run this command with the same environment you run zero-cache with. It will use your upstream or cvr configuration to look up the query hash in the cvr database. npx analyze-query --schema-path='./shared/schema.ts' --hash='3rhuw19xt9vry' --apply-permissions --auth-data='{\"userId\":\"user-123\"}' The printed query can be different than the source ZQL string, because it is rebuilt from the query AST. But it should be logically equivalent to the query you wrote. Write Permissions Look for a WARN level log in the output from zero-cache like this: Permission check failed for {\"op\":\"update\",\"tableName\":\"message\",...}, action update, phase preMutation, authData: {...}, rowPolicies: [...], cellPolicies: [] Zero prints the row, auth data, and permission policies that was applied to any failed writes. The ZQL query is printed in AST format. See Query ASTs to convert it to a more readable format.",
+    "content": "It will be removed in a future release of Zero. See Permissions for more information. Permissions are expressed using ZQL and run automatically with every read and write. Permissions are currently row based. Zero will eventually also have column permissions. Define Permissions Permissions are defined in schema.ts using the definePermissions function. Here's an example of limiting reads to members of an organization and deletes to only the creator of an issue: // The decoded value of your JWT. type AuthData = { // The logged-in user. sub: string } export const permissions = definePermissions< AuthData, Schema >(schema, () => { // Checks if the user exists in a related organization const allowIfInOrganization = ( authData: AuthData, eb: ExpressionBuilder<Schema, 'issue'> ) => eb.exists('organization', q => q.whereExists('user', q => q.where('id', authData.sub) ) ) // Checks if the user is the creator const allowIfIssueCreator = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('creatorID', authData.sub) return { issue: { row: { select: [allowIfInOrganization], delete: [allowIfIssueCreator] } } } satisfies PermissionsConfig<AuthData, Schema> }) definePermission returns a policy object for each table in the schema. Each policy defines a ruleset for the operations that are possible on a table: select, insert, update, and delete. Access is Denied by Default If you don't specify any rules for an operation, it is denied by default. This is an important safety feature that helps ensure data isn't accidentally exposed. To enable full access to an action (i.e., during development) use the ANYONE_CAN helper: import {ANYONE_CAN} from '@rocicorp/zero' const permissions = definePermissions<AuthData, Schema>( schema, () => { return { issue: { row: { select: ANYONE_CAN // Other operations are denied by default. } } // Other tables are denied by default. } satisfies PermissionsConfig<AuthData, Schema> } ) To do this for all actions, use ANYONE_CAN_DO_ANYTHING: import {ANYONE_CAN_DO_ANYTHING} from '@rocicorp/zero' const permissions = definePermissions<AuthData, Schema>( schema, () => { return { // All operations on issue are allowed to all users. issue: ANYONE_CAN_DO_ANYTHING // Other tables are denied by default. } satisfies PermissionsConfig<AuthData, Schema> } ) Permission Evaluation Zero permissions are \"compiled\" into a JSON-based format at build-time. This file is stored in the {ZERO_APP_ID}.permissions table of your upstream database. Like other tables, it replicates live down to zero-cache. zero-cache then parses this file, and applies the encoded rules to every read and write operation. The compilation process is very simple-minded (read: dumb). Despite looking like normal TypeScript functions that receive an AuthData parameter, rule functions are not actually invoked at runtime. Instead, they are invoked with a \"placeholder\" AuthData at build time. We track which fields of this placeholder are accessed and construct a ZQL expression that accesses the right field of AuthData at runtime. The end result is that you can't really use most features of JS in these rules. Specifically you cannot: Iterate over properties or array elements in the auth token Use any JS features beyond property access of AuthData Use any conditional or global state Basically only property access is allowed. This is really confusing and we're working on a better solution. Permission Deployment During development, permissions are compiled and uploaded to your database completely automatically as part of the zero-cache-dev script. For production, you need to call npx zero-deploy-permissions within your app to update the permissions in the production database whenever they change. You would typically do this as part of your normal schema migration or CI process. For example, the SST deployment script for Gigabugs looks like this: new command.local.Command( 'zero-deploy-permissions', { create: `npx zero-deploy-permissions -p ../../src/schema.ts`, // Run the Command on every deploy ... triggers: [Date.now()], environment: { ZERO_UPSTREAM_DB: commonEnv.ZERO_UPSTREAM_DB, // If the application has a non-default App ID ... ZERO_APP_ID: commonEnv.ZERO_APP_ID } }, // after the view-syncer is deployed. {dependsOn: viewSyncer} ) See the deployment guide for more details. Rules Each operation on a policy has a ruleset containing zero or more rules. A rule is just a TypeScript function that receives the logged in user's AuthData and generates a ZQL where expression. At least one rule in a ruleset must return a row for the operation to be allowed. Select Permissions You can limit the data a user can read by specifying a select ruleset. Select permissions act like filters. If a user does not have permission to read a row, it will be filtered out of the result set. It will not generate an error. For example, imagine a select permission that restricts reads to only issues created by the user: definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueCreator = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('creatorID', authData.sub) return { issue: { row: { select: [allowIfIssueCreator] } } } satisfies PermissionsConfig<AuthData, Schema> }) If the issue table has two rows, one created by the user and one by someone else, the user will only see the row they created in any queries. Select permission applies to every column. The recommended approach for now is to factor out private fields into a separate table, e.g. user_private. Column permissions are planned but currently not a high priority. Note that although the same limitation applies to declarative insert/update permissions, custom mutators support arbitrary server-side logic and so can easily control which columns are writable. Insert Permissions You can limit what rows can be inserted and by whom by specifying an insert ruleset. Insert rules are evaluated after the entity is inserted. So if they query the database, they will see the inserted row present. If any rule in the insert ruleset returns a row, the insert is allowed. Here's an example of an insert rule that disallows inserting users that have the role 'admin'. definePermissions<AuthData, Schema>(schema, () => { const allowIfNonAdmin = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'user'> ) => cmp('role', '!=', 'admin') return { user: { row: { insert: [allowIfNonAdmin] } } } satisfies PermissionsConfig<AuthData, Schema> }) Update Permissions There are two types of update rulesets: preMutation and postMutation. Both rulesets must pass for an update to be allowed. preMutation rules see the version of a row before the mutation is applied. This is useful for things like checking whether a user owns an entity before editing it. postMutation rules see the version of a row after the mutation is applied. This is useful for things like ensuring a user can only mark themselves as the creator of an entity and not other users. Like other rulesets, preMutation and postMutation default to NOBODY_CAN. This means that every table must define both these rulesets in order for any updates to be allowed. For example, the following ruleset allows an issue's owner to edit, but not re-assign the issue. The postMutation rule enforces that the current user still own the issue after edit. definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: [allowIfIssueOwner], postMutation: [allowIfIssueOwner] } } } } satisfies PermissionsConfig<AuthData, Schema> }) This ruleset allows an issue's owner to edit and re-assign the issue: definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: [allowIfIssueOwner], postMutation: ANYONE_CAN } } } } satisfies PermissionsConfig<AuthData, Schema> }) And this allows anyone to edit an issue, but only if they also assign it to themselves. Useful for enforcing \"patches welcome\"? 🙃 definePermissions<AuthData, Schema>(schema, () => { const allowIfIssueOwner = ( authData: AuthData, {cmp}: ExpressionBuilder<Schema, 'issue'> ) => cmp('ownerID', authData.sub) return { issue: { row: { update: { preMutation: ANYONE_CAN, postMutation: [allowIfIssueOwner] } } } } satisfies PermissionsConfig<AuthData, Schema> }) Delete Permissions Delete permissions work in the same way as insert permissions except they run before the delete is applied. So if a delete rule queries the database, it will see that the deleted row is present. If any rule in the ruleset returns a row, the delete is allowed. Permissions Based on Auth Data You can use the cmpLit helper to define permissions based on a field of the authData parameter: definePermissions<AuthData, Schema>(schema, () => { const allowIfAdmin = ( authData: AuthData, {cmpLit}: ExpressionBuilder<Schema, 'issue'> ) => cmpLit(authData.role, 'admin') return { issue: { row: { select: [allowIfAdmin] } } } satisfies PermissionsConfig<AuthData, Schema> }) Debugging Given that permissions are defined in their own file and internally applied to queries, it can be hard to figure out if or why a permission check is failing. Read Permissions You can use the analyze-query utility with the --apply-permissions flag to see the complete query Zero runs, including read permissions. npx analyze-query --schema-path='./shared/schema.ts' --query='issue.related(\"comments\")' --apply-permissions --auth-data='{\"userId\":\"user-123\"}' If the result looks right, the problem may be that Zero is not receiving the AuthData that you think it is. You can retrieve a query hash from websocket or server logs, then ask Zero for the details on that specific query. Run this command with the same environment you run zero-cache with. It will use your upstream or cvr configuration to look up the query hash in the cvr database. npx analyze-query --schema-path='./shared/schema.ts' --hash='3rhuw19xt9vry' --apply-permissions --auth-data='{\"userId\":\"user-123\"}' The printed query can be different than the source ZQL string, because it is rebuilt from the query AST. But it should be logically equivalent to the query you wrote. Write Permissions Look for a WARN level log in the output from zero-cache like this: Permission check failed for {\"op\":\"update\",\"tableName\":\"message\",...}, action update, phase preMutation, authData: {...}, rowPolicies: [...], cellPolicies: [] Zero prints the row, auth data, and permission policies that was applied to any failed writes. The ZQL query is printed in AST format. See Query ASTs to convert it to a more readable format.",
     "headings": [
       {
         "text": "Define Permissions",
@@ -1417,7 +1417,7 @@
     "kind": "page"
   },
   {
-    "id": "158-deprecated/rls-permissions#define-permissions",
+    "id": "159-deprecated/rls-permissions#define-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Define Permissions",
     "sectionTitle": "Define Permissions",
@@ -1427,7 +1427,7 @@
     "kind": "section"
   },
   {
-    "id": "159-deprecated/rls-permissions#access-is-denied-by-default",
+    "id": "160-deprecated/rls-permissions#access-is-denied-by-default",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Access is Denied by Default",
     "sectionTitle": "Access is Denied by Default",
@@ -1437,7 +1437,7 @@
     "kind": "section"
   },
   {
-    "id": "160-deprecated/rls-permissions#permission-evaluation",
+    "id": "161-deprecated/rls-permissions#permission-evaluation",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Permission Evaluation",
     "sectionTitle": "Permission Evaluation",
@@ -1447,17 +1447,17 @@
     "kind": "section"
   },
   {
-    "id": "161-deprecated/rls-permissions#permission-deployment",
+    "id": "162-deprecated/rls-permissions#permission-deployment",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Permission Deployment",
     "sectionTitle": "Permission Deployment",
     "sectionId": "permission-deployment",
     "url": "/docs/deprecated/rls-permissions",
-    "content": "During development, permissions are compiled and uploaded to your database completely automatically as part of the zero-cache-dev script. For production, you need to call npx zero-deploy-permissions within your app to update the permissions in the production database whenever they change. You would typically do this as part of your normal schema migration or CI process. For example, the SST deployment script for zbugs looks like this: new command.local.Command( 'zero-deploy-permissions', { create: `npx zero-deploy-permissions -p ../../src/schema.ts`, // Run the Command on every deploy ... triggers: [Date.now()], environment: { ZERO_UPSTREAM_DB: commonEnv.ZERO_UPSTREAM_DB, // If the application has a non-default App ID ... ZERO_APP_ID: commonEnv.ZERO_APP_ID } }, // after the view-syncer is deployed. {dependsOn: viewSyncer} ) See the SST Deployment Guide for more details.",
+    "content": "During development, permissions are compiled and uploaded to your database completely automatically as part of the zero-cache-dev script. For production, you need to call npx zero-deploy-permissions within your app to update the permissions in the production database whenever they change. You would typically do this as part of your normal schema migration or CI process. For example, the SST deployment script for Gigabugs looks like this: new command.local.Command( 'zero-deploy-permissions', { create: `npx zero-deploy-permissions -p ../../src/schema.ts`, // Run the Command on every deploy ... triggers: [Date.now()], environment: { ZERO_UPSTREAM_DB: commonEnv.ZERO_UPSTREAM_DB, // If the application has a non-default App ID ... ZERO_APP_ID: commonEnv.ZERO_APP_ID } }, // after the view-syncer is deployed. {dependsOn: viewSyncer} ) See the deployment guide for more details.",
     "kind": "section"
   },
   {
-    "id": "162-deprecated/rls-permissions#rules",
+    "id": "163-deprecated/rls-permissions#rules",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Rules",
     "sectionTitle": "Rules",
@@ -1467,7 +1467,7 @@
     "kind": "section"
   },
   {
-    "id": "163-deprecated/rls-permissions#select-permissions",
+    "id": "164-deprecated/rls-permissions#select-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Select Permissions",
     "sectionTitle": "Select Permissions",
@@ -1477,7 +1477,7 @@
     "kind": "section"
   },
   {
-    "id": "164-deprecated/rls-permissions#insert-permissions",
+    "id": "165-deprecated/rls-permissions#insert-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Insert Permissions",
     "sectionTitle": "Insert Permissions",
@@ -1487,7 +1487,7 @@
     "kind": "section"
   },
   {
-    "id": "165-deprecated/rls-permissions#update-permissions",
+    "id": "166-deprecated/rls-permissions#update-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Update Permissions",
     "sectionTitle": "Update Permissions",
@@ -1497,7 +1497,7 @@
     "kind": "section"
   },
   {
-    "id": "166-deprecated/rls-permissions#delete-permissions",
+    "id": "167-deprecated/rls-permissions#delete-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Delete Permissions",
     "sectionTitle": "Delete Permissions",
@@ -1507,7 +1507,7 @@
     "kind": "section"
   },
   {
-    "id": "167-deprecated/rls-permissions#permissions-based-on-auth-data",
+    "id": "168-deprecated/rls-permissions#permissions-based-on-auth-data",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Permissions Based on Auth Data",
     "sectionTitle": "Permissions Based on Auth Data",
@@ -1517,7 +1517,7 @@
     "kind": "section"
   },
   {
-    "id": "168-deprecated/rls-permissions#debugging",
+    "id": "169-deprecated/rls-permissions#debugging",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Debugging",
     "sectionTitle": "Debugging",
@@ -1527,7 +1527,7 @@
     "kind": "section"
   },
   {
-    "id": "169-deprecated/rls-permissions#read-permissions",
+    "id": "170-deprecated/rls-permissions#read-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Read Permissions",
     "sectionTitle": "Read Permissions",
@@ -1537,7 +1537,7 @@
     "kind": "section"
   },
   {
-    "id": "170-deprecated/rls-permissions#write-permissions",
+    "id": "171-deprecated/rls-permissions#write-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Write Permissions",
     "sectionTitle": "Write Permissions",
@@ -1551,7 +1551,7 @@
     "title": "Install Zero",
     "searchTitle": "Install Zero",
     "url": "/docs/install",
-    "content": "This guide walks you through adding Zero to any TypeScript-based web app. It should take about 20 minutes to complete. When you're done, you'll have Zero up and running and will understand its core ideas. Integrate Zero Set Up Your Database You'll need a Postgres database for development. If you don't have a preferred method, we recommend using Docker: # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:16-alpine \\ postgres -c wal_level=logical See Provider Support for developing locally with popular cloud Postgres providers. You may just want to try out Zero with some sample data. We have an onboarding example to get you started. Follow along with the 💿 Try it out! sections. At the end of this guide, we'll help you safely remove the data. # Creates new _z_albums, _z_artists, _z_fans, # and _z_favorites tables with some sample data curl -L https://raw.githubusercontent.com/rocicorp/onboarding/1-install/migrations/0000_seed_music.sql \\ | psql postgresql://postgres:pass@localhost:5432/zero Install and Run Zero-Cache Add Zero to your project: npm install @rocicorp/zeropnpm add @rocicorp/zero # Note: pnpm disables postinstall scripts by default for security. # Either approve the build: pnpm approve-builds # Or add to package.json: # \"pnpm\": { # \"onlyBuiltDependencies\": [\"@rocicorp/zero-sqlite3\"] # }bun add @rocicorp/zero # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } Start the development zero-cache by running the following command: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" yarn exec zero-cache-dev Zero works by continuously replicating your upstream database into a SQLite replica, which is created by default at zero.db. You can use the zero-sqlite3 tool in another terminal to explore the music data that just synced to zero.db: npx @rocicorp/zero-sqlite3 ./zero.db \\ \"SELECT title FROM _z_albums;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Try connecting to both Postgres and the Zero replica. If you change something in Postgres, you'll see it immediately show up in the replica: Zero-cache runs client queries against the replica. If there are tables or columns that will not be queried by Zero clients, you can exclude them with a custom publication. Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate schema.ts automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate// zero/schema.ts import {table, string, createSchema} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string() // ... other columns ... }) .primaryKey('id') // ... more tables and relationships ... // See \"Schema\" page in left nav for complete schema API. export const schema = createSchema({ tables: [user] }) // Register the schema for type safety declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } If you don't want to use your own schema, you can use the sample schema.ts provided. Put it in a new zero directory in your project: curl https://raw.githubusercontent.com/rocicorp/onboarding/1-install/packages/zero/src/schema.ts \\ -o schema.ts Set Up the Zero Client Zero has first-class support for React and SolidJS, and community support for Svelte and Vue. There is also a low-level API you can use in any TypeScript-based project. // root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) } // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' function MyComponent() { const zero = useZero() console.log('clientID', zero.clientID) }// root.tsx import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) } // mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' function MyComponent() { const zero = useZero() console.log('clientID', zero().clientID) }// zero.ts import {Zero} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) console.log('clientID', zero.clientID) export {zero} Sync Data Define Query Alright, let's sync some data! In Zero, we do this with queries. Queries are conventionally found in a queries.ts file. Use zql from schema.ts to construct and return a ZQL query: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema.ts' export const queries = defineQueries({ users: defineQuery(() => zql.user) }) For example, you can query the music data for albums by a particular artist: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema.ts' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('createdAt', 'asc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: See queries for more information on defining queries. Add Query Endpoint Zero doesn't allow clients to run any arbitrary ZQL against zero-cache, for both security and performance reasons. Instead, Zero sends the name and arguments of the query to a queries endpoint on your server that is responsible for transforming the named query into ZQL. Zero provides utilities to make it easy to implement the queries endpoint in any full-stack framework: // app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries.ts' import {schema} from '../zero/schema.ts' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Stop and re-run zero-cache to point to the URL of the queries endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" yarn exec zero-cache-dev Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' const [users] = useQuery(queries.users())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' const [users] = useQuery(() => queries.users())import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const users = await zero.run(queries.users()) Use the query we defined earlier for the sample data to get albums for artist_1: // mycomponent.tsx import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' function MyComponent() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return albums.map(a => <div key={a.id}>{a.title}</div>) }// mycomponent.tsx import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' function MyComponent() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <For each={albums()}> {album => <div key={album.id}>{album.title}</div>} </For> ) }// albums.ts import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) Zero queries are reactive, so if you edit data in Postgres directly, you will see it update in the Zero replica AND the UI: More about Queries You now know the basics, but there are a few more important pieces you'll need to learn for your first real app: How authentication and permissions work. Preloading queries to create instantly responsive UI. For these details and more, see Reading Data. But for now, let's move on to writes! Mutate Data Define Mutators Data is written in Zero apps using mutators. Similar to queries, we use a shared mutators.ts file: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. You can create a mutator to add a new album: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) Once you've defined your mutators, you must register them with Zero: import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, etc. mutators } Add Mutate Endpoint Zero requires a mutate endpoint which runs on your server and connects directly to your Postgres database. Zero provides helpers to implement this easily. First, use the Zero Postgres adapters to create a dbProvider instance: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import type {Database} from '../../kysely/database.ts' const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' // pass a prisma client instance. for example: const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then, use the dbProvider and helpers to define the mutate endpoint: // app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' import {mustGetMutator} from '@rocicorp/zero' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Restart zero-cache with an environment variable for this new endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" yarn exec zero-cache-dev Invoke Mutators You can now call mutators via zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' await zero.mutate(mutators.activateUser({id: '1'})) Use the query we defined earlier to get albums for artist_1: // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const client = await zero.mutate( mutators.albums.create({ id: nanoid(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client if (client.type === 'success') { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const client = await zero().mutate( mutators.albums.create({ id: nanoid(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client if (client.type === 'success') { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// albums.ts import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' const client = await zero.mutate( mutators.albums.create({ id: nanoid(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client if (client.type === 'success') { console.log('Album created!') } If you run this app now, you will see the UI update optimistically, and the mutation will commit to the database and sync to other clients: More about Mutators Just as with queries, the separate server implementation of mutators extends elegantly to enable write permissions. Zero also has built-in helpers to do work after a mutator runs on the server, like send notifications. For these details and more, see Writing Data. To remove the sample and zero-cache data from your Postgres database, use the zero-out CLI tool and the cleanup SQL: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" # Remove all traces of zero-cache from Postgres: npx zero-out # Remove the _z_albums, _z_artists, _z_fans, # and _z_favorites tables curl -L https://raw.githubusercontent.com/rocicorp/onboarding/1-install/out.sql \\ | psql $ZERO_UPSTREAM_DB That's It! Congratulations! You now know the basics for building with Zero 🤯. Possible next steps: Learn about authentication and permissions See some samples of built-out Zero apps Learn how to deploy your app to production",
+    "content": "This guide shows how to add Zero to an existing TypeScript-based web app. For a concrete end-to-end walkthrough, build the music app in the tutorial. Integrate Zero Set Up Your Database You'll need a Postgres database for development. If you don't have a preferred method, we recommend using Docker: # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical See Provider Support for developing locally with popular cloud Postgres providers. Install and Run Zero-Cache Add Zero to your project: npm install @rocicorp/zeropnpm add @rocicorp/zero # Note: pnpm disables postinstall scripts by default for security. # Either approve the build: pnpm approve-builds # Or add to package.json: # \"pnpm\": { # \"onlyBuiltDependencies\": [\"@rocicorp/zero-sqlite3\"] # }bun add @rocicorp/zero # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate schema.ts automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate// zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Set Up the Zero Client Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. // root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// root.tsx import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) console.log('clientID', zero.clientID) export {zero} Sync Data Define Query Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema.ts' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries.ts' import {schema} from '../zero/schema.ts' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const users = await zero.run(queries.allUsers()) More about Queries Filters, sorting, relationships, preloading, and more Server-driven authentication Mutate Data Define Mutators Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, schema, etc. mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import type {Database} from '../../kysely/database.ts' const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Now you can run zero-cache locally with ZERO_UPSTREAM_DB, ZERO_QUERY_URL, and ZERO_MUTATE_URL configured: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev Invoke Mutators You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients. More about Mutators CRUD, server-specific code, permissions, and more Server-driven auth and Context Learn how to deploy your app to production",
     "headings": [
       {
         "text": "Integrate Zero",
@@ -1612,172 +1612,158 @@
       {
         "text": "More about Mutators",
         "id": "more-about-mutators"
-      },
-      {
-        "text": "That's It!",
-        "id": "thats-it"
       }
     ],
     "kind": "page"
   },
   {
-    "id": "171-install#integrate-zero",
+    "id": "172-install#integrate-zero",
     "title": "Install Zero",
     "searchTitle": "Integrate Zero",
     "sectionTitle": "Integrate Zero",
     "sectionId": "integrate-zero",
     "url": "/docs/install",
-    "content": "Set Up Your Database You'll need a Postgres database for development. If you don't have a preferred method, we recommend using Docker: # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:16-alpine \\ postgres -c wal_level=logical See Provider Support for developing locally with popular cloud Postgres providers. You may just want to try out Zero with some sample data. We have an onboarding example to get you started. Follow along with the 💿 Try it out! sections. At the end of this guide, we'll help you safely remove the data. # Creates new _z_albums, _z_artists, _z_fans, # and _z_favorites tables with some sample data curl -L https://raw.githubusercontent.com/rocicorp/onboarding/1-install/migrations/0000_seed_music.sql \\ | psql postgresql://postgres:pass@localhost:5432/zero Install and Run Zero-Cache Add Zero to your project: npm install @rocicorp/zeropnpm add @rocicorp/zero # Note: pnpm disables postinstall scripts by default for security. # Either approve the build: pnpm approve-builds # Or add to package.json: # \"pnpm\": { # \"onlyBuiltDependencies\": [\"@rocicorp/zero-sqlite3\"] # }bun add @rocicorp/zero # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } Start the development zero-cache by running the following command: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" yarn exec zero-cache-dev Zero works by continuously replicating your upstream database into a SQLite replica, which is created by default at zero.db. You can use the zero-sqlite3 tool in another terminal to explore the music data that just synced to zero.db: npx @rocicorp/zero-sqlite3 ./zero.db \\ \"SELECT title FROM _z_albums;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Try connecting to both Postgres and the Zero replica. If you change something in Postgres, you'll see it immediately show up in the replica: Zero-cache runs client queries against the replica. If there are tables or columns that will not be queried by Zero clients, you can exclude them with a custom publication. Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate schema.ts automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate// zero/schema.ts import {table, string, createSchema} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string() // ... other columns ... }) .primaryKey('id') // ... more tables and relationships ... // See \"Schema\" page in left nav for complete schema API. export const schema = createSchema({ tables: [user] }) // Register the schema for type safety declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } If you don't want to use your own schema, you can use the sample schema.ts provided. Put it in a new zero directory in your project: curl https://raw.githubusercontent.com/rocicorp/onboarding/1-install/packages/zero/src/schema.ts \\ -o schema.ts Set Up the Zero Client Zero has first-class support for React and SolidJS, and community support for Svelte and Vue. There is also a low-level API you can use in any TypeScript-based project. // root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) } // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' function MyComponent() { const zero = useZero() console.log('clientID', zero.clientID) }// root.tsx import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) } // mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' function MyComponent() { const zero = useZero() console.log('clientID', zero().clientID) }// zero.ts import {Zero} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) console.log('clientID', zero.clientID) export {zero}",
+    "content": "Set Up Your Database You'll need a Postgres database for development. If you don't have a preferred method, we recommend using Docker: # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical See Provider Support for developing locally with popular cloud Postgres providers. Install and Run Zero-Cache Add Zero to your project: npm install @rocicorp/zeropnpm add @rocicorp/zero # Note: pnpm disables postinstall scripts by default for security. # Either approve the build: pnpm approve-builds # Or add to package.json: # \"pnpm\": { # \"onlyBuiltDependencies\": [\"@rocicorp/zero-sqlite3\"] # }bun add @rocicorp/zero # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate schema.ts automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate// zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Set Up the Zero Client Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. // root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// root.tsx import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) console.log('clientID', zero.clientID) export {zero}",
     "kind": "section"
   },
   {
-    "id": "172-install#set-up-your-database",
+    "id": "173-install#set-up-your-database",
     "title": "Install Zero",
     "searchTitle": "Set Up Your Database",
     "sectionTitle": "Set Up Your Database",
     "sectionId": "set-up-your-database",
     "url": "/docs/install",
-    "content": "You'll need a Postgres database for development. If you don't have a preferred method, we recommend using Docker: # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:16-alpine \\ postgres -c wal_level=logical See Provider Support for developing locally with popular cloud Postgres providers. You may just want to try out Zero with some sample data. We have an onboarding example to get you started. Follow along with the 💿 Try it out! sections. At the end of this guide, we'll help you safely remove the data. # Creates new _z_albums, _z_artists, _z_fans, # and _z_favorites tables with some sample data curl -L https://raw.githubusercontent.com/rocicorp/onboarding/1-install/migrations/0000_seed_music.sql \\ | psql postgresql://postgres:pass@localhost:5432/zero",
+    "content": "You'll need a Postgres database for development. If you don't have a preferred method, we recommend using Docker: # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical See Provider Support for developing locally with popular cloud Postgres providers.",
     "kind": "section"
   },
   {
-    "id": "173-install#install-and-run-zero-cache",
+    "id": "174-install#install-and-run-zero-cache",
     "title": "Install Zero",
     "searchTitle": "Install and Run Zero-Cache",
     "sectionTitle": "Install and Run Zero-Cache",
     "sectionId": "install-and-run-zero-cache",
     "url": "/docs/install",
-    "content": "Add Zero to your project: npm install @rocicorp/zeropnpm add @rocicorp/zero # Note: pnpm disables postinstall scripts by default for security. # Either approve the build: pnpm approve-builds # Or add to package.json: # \"pnpm\": { # \"onlyBuiltDependencies\": [\"@rocicorp/zero-sqlite3\"] # }bun add @rocicorp/zero # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } Start the development zero-cache by running the following command: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" yarn exec zero-cache-dev Zero works by continuously replicating your upstream database into a SQLite replica, which is created by default at zero.db. You can use the zero-sqlite3 tool in another terminal to explore the music data that just synced to zero.db: npx @rocicorp/zero-sqlite3 ./zero.db \\ \"SELECT title FROM _z_albums;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Try connecting to both Postgres and the Zero replica. If you change something in Postgres, you'll see it immediately show up in the replica: Zero-cache runs client queries against the replica. If there are tables or columns that will not be queried by Zero clients, you can exclude them with a custom publication.",
+    "content": "Add Zero to your project: npm install @rocicorp/zeropnpm add @rocicorp/zero # Note: pnpm disables postinstall scripts by default for security. # Either approve the build: pnpm approve-builds # Or add to package.json: # \"pnpm\": { # \"onlyBuiltDependencies\": [\"@rocicorp/zero-sqlite3\"] # }bun add @rocicorp/zero # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # }",
     "kind": "section"
   },
   {
-    "id": "174-install#set-up-your-zero-schema",
+    "id": "175-install#set-up-your-zero-schema",
     "title": "Install Zero",
     "searchTitle": "Set Up Your Zero Schema",
     "sectionTitle": "Set Up Your Zero Schema",
     "sectionId": "set-up-your-zero-schema",
     "url": "/docs/install",
-    "content": "Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate schema.ts automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate// zero/schema.ts import {table, string, createSchema} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string() // ... other columns ... }) .primaryKey('id') // ... more tables and relationships ... // See \"Schema\" page in left nav for complete schema API. export const schema = createSchema({ tables: [user] }) // Register the schema for type safety declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } If you don't want to use your own schema, you can use the sample schema.ts provided. Put it in a new zero directory in your project: curl https://raw.githubusercontent.com/rocicorp/onboarding/1-install/packages/zero/src/schema.ts \\ -o schema.ts",
+    "content": "Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate schema.ts automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate// zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } }",
     "kind": "section"
   },
   {
-    "id": "175-install#set-up-the-zero-client",
+    "id": "176-install#set-up-the-zero-client",
     "title": "Install Zero",
     "searchTitle": "Set Up the Zero Client",
     "sectionTitle": "Set Up the Zero Client",
     "sectionId": "set-up-the-zero-client",
     "url": "/docs/install",
-    "content": "Zero has first-class support for React and SolidJS, and community support for Svelte and Vue. There is also a low-level API you can use in any TypeScript-based project. // root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) } // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' function MyComponent() { const zero = useZero() console.log('clientID', zero.clientID) }// root.tsx import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) } // mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' function MyComponent() { const zero = useZero() console.log('clientID', zero().clientID) }// zero.ts import {Zero} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) console.log('clientID', zero.clientID) export {zero}",
+    "content": "Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. // root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// root.tsx import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } function Root() { return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> ) }// zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema.ts' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) console.log('clientID', zero.clientID) export {zero}",
     "kind": "section"
   },
   {
-    "id": "176-install#sync-data",
+    "id": "177-install#sync-data",
     "title": "Install Zero",
     "searchTitle": "Sync Data",
     "sectionTitle": "Sync Data",
     "sectionId": "sync-data",
     "url": "/docs/install",
-    "content": "Define Query Alright, let's sync some data! In Zero, we do this with queries. Queries are conventionally found in a queries.ts file. Use zql from schema.ts to construct and return a ZQL query: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema.ts' export const queries = defineQueries({ users: defineQuery(() => zql.user) }) For example, you can query the music data for albums by a particular artist: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema.ts' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('createdAt', 'asc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: See queries for more information on defining queries. Add Query Endpoint Zero doesn't allow clients to run any arbitrary ZQL against zero-cache, for both security and performance reasons. Instead, Zero sends the name and arguments of the query to a queries endpoint on your server that is responsible for transforming the named query into ZQL. Zero provides utilities to make it easy to implement the queries endpoint in any full-stack framework: // app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries.ts' import {schema} from '../zero/schema.ts' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Stop and re-run zero-cache to point to the URL of the queries endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" yarn exec zero-cache-dev Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' const [users] = useQuery(queries.users())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' const [users] = useQuery(() => queries.users())import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const users = await zero.run(queries.users()) Use the query we defined earlier for the sample data to get albums for artist_1: // mycomponent.tsx import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' function MyComponent() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return albums.map(a => <div key={a.id}>{a.title}</div>) }// mycomponent.tsx import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' function MyComponent() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <For each={albums()}> {album => <div key={album.id}>{album.title}</div>} </For> ) }// albums.ts import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) Zero queries are reactive, so if you edit data in Postgres directly, you will see it update in the Zero replica AND the UI: More about Queries You now know the basics, but there are a few more important pieces you'll need to learn for your first real app: How authentication and permissions work. Preloading queries to create instantly responsive UI. For these details and more, see Reading Data. But for now, let's move on to writes!",
+    "content": "Define Query Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema.ts' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries.ts' import {schema} from '../zero/schema.ts' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const users = await zero.run(queries.allUsers()) More about Queries Filters, sorting, relationships, preloading, and more Server-driven authentication",
     "kind": "section"
   },
   {
-    "id": "177-install#define-query",
+    "id": "178-install#define-query",
     "title": "Install Zero",
     "searchTitle": "Define Query",
     "sectionTitle": "Define Query",
     "sectionId": "define-query",
     "url": "/docs/install",
-    "content": "Alright, let's sync some data! In Zero, we do this with queries. Queries are conventionally found in a queries.ts file. Use zql from schema.ts to construct and return a ZQL query: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema.ts' export const queries = defineQueries({ users: defineQuery(() => zql.user) }) For example, you can query the music data for albums by a particular artist: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema.ts' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('createdAt', 'asc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: See queries for more information on defining queries.",
+    "content": "Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema.ts' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions.",
     "kind": "section"
   },
   {
-    "id": "178-install#add-query-endpoint",
+    "id": "179-install#add-query-endpoint",
     "title": "Install Zero",
     "searchTitle": "Add Query Endpoint",
     "sectionTitle": "Add Query Endpoint",
     "sectionId": "add-query-endpoint",
     "url": "/docs/install",
-    "content": "Zero doesn't allow clients to run any arbitrary ZQL against zero-cache, for both security and performance reasons. Instead, Zero sends the name and arguments of the query to a queries endpoint on your server that is responsible for transforming the named query into ZQL. Zero provides utilities to make it easy to implement the queries endpoint in any full-stack framework: // app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries.ts' import {schema} from '../zero/schema.ts' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Stop and re-run zero-cache to point to the URL of the queries endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" yarn exec zero-cache-dev",
+    "content": "Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries.ts' import {schema} from '../../zero/schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries.ts' import {schema} from '../zero/schema.ts' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) })",
     "kind": "section"
   },
   {
-    "id": "179-install#invoke-query",
+    "id": "180-install#invoke-query",
     "title": "Install Zero",
     "searchTitle": "Invoke Query",
     "sectionTitle": "Invoke Query",
     "sectionId": "invoke-query",
     "url": "/docs/install",
-    "content": "Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' const [users] = useQuery(queries.users())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' const [users] = useQuery(() => queries.users())import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const users = await zero.run(queries.users()) Use the query we defined earlier for the sample data to get albums for artist_1: // mycomponent.tsx import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' function MyComponent() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return albums.map(a => <div key={a.id}>{a.title}</div>) }// mycomponent.tsx import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' function MyComponent() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <For each={albums()}> {album => <div key={album.id}>{album.title}</div>} </For> ) }// albums.ts import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) Zero queries are reactive, so if you edit data in Postgres directly, you will see it update in the Zero replica AND the UI:",
+    "content": "Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries.ts' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries.ts' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero.ts' import {queries} from './zero/queries.ts' const users = await zero.run(queries.allUsers())",
     "kind": "section"
   },
   {
-    "id": "180-install#more-about-queries",
+    "id": "181-install#more-about-queries",
     "title": "Install Zero",
     "searchTitle": "More about Queries",
     "sectionTitle": "More about Queries",
     "sectionId": "more-about-queries",
     "url": "/docs/install",
-    "content": "You now know the basics, but there are a few more important pieces you'll need to learn for your first real app: How authentication and permissions work. Preloading queries to create instantly responsive UI. For these details and more, see Reading Data. But for now, let's move on to writes!",
+    "content": "Filters, sorting, relationships, preloading, and more Server-driven authentication",
     "kind": "section"
   },
   {
-    "id": "181-install#mutate-data",
+    "id": "182-install#mutate-data",
     "title": "Install Zero",
     "searchTitle": "Mutate Data",
     "sectionTitle": "Mutate Data",
     "sectionId": "mutate-data",
     "url": "/docs/install",
-    "content": "Define Mutators Data is written in Zero apps using mutators. Similar to queries, we use a shared mutators.ts file: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. You can create a mutator to add a new album: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) Once you've defined your mutators, you must register them with Zero: import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, etc. mutators } Add Mutate Endpoint Zero requires a mutate endpoint which runs on your server and connects directly to your Postgres database. Zero provides helpers to implement this easily. First, use the Zero Postgres adapters to create a dbProvider instance: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import type {Database} from '../../kysely/database.ts' const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' // pass a prisma client instance. for example: const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then, use the dbProvider and helpers to define the mutate endpoint: // app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' import {mustGetMutator} from '@rocicorp/zero' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Restart zero-cache with an environment variable for this new endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" yarn exec zero-cache-dev Invoke Mutators You can now call mutators via zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' await zero.mutate(mutators.activateUser({id: '1'})) Use the query we defined earlier to get albums for artist_1: // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const client = await zero.mutate( mutators.albums.create({ id: nanoid(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client if (client.type === 'success') { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const client = await zero().mutate( mutators.albums.create({ id: nanoid(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client if (client.type === 'success') { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// albums.ts import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' const client = await zero.mutate( mutators.albums.create({ id: nanoid(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client if (client.type === 'success') { console.log('Album created!') } If you run this app now, you will see the UI update optimistically, and the mutation will commit to the database and sync to other clients: More about Mutators Just as with queries, the separate server implementation of mutators extends elegantly to enable write permissions. Zero also has built-in helpers to do work after a mutator runs on the server, like send notifications. For these details and more, see Writing Data. To remove the sample and zero-cache data from your Postgres database, use the zero-out CLI tool and the cleanup SQL: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" # Remove all traces of zero-cache from Postgres: npx zero-out # Remove the _z_albums, _z_artists, _z_fans, # and _z_favorites tables curl -L https://raw.githubusercontent.com/rocicorp/onboarding/1-install/out.sql \\ | psql $ZERO_UPSTREAM_DB",
+    "content": "Define Mutators Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, schema, etc. mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import type {Database} from '../../kysely/database.ts' const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Now you can run zero-cache locally with ZERO_UPSTREAM_DB, ZERO_QUERY_URL, and ZERO_MUTATE_URL configured: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev Invoke Mutators You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients. More about Mutators CRUD, server-specific code, permissions, and more Server-driven auth and Context Learn how to deploy your app to production",
     "kind": "section"
   },
   {
-    "id": "182-install#define-mutators",
+    "id": "183-install#define-mutators",
     "title": "Install Zero",
     "searchTitle": "Define Mutators",
     "sectionTitle": "Define Mutators",
     "sectionId": "define-mutators",
     "url": "/docs/install",
-    "content": "Data is written in Zero apps using mutators. Similar to queries, we use a shared mutators.ts file: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. You can create a mutator to add a new album: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) Once you've defined your mutators, you must register them with Zero: import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, etc. mutators }",
+    "content": "Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators.ts' const opts: ZeroOptions = { // ... userID, cacheURL, schema, etc. mutators }",
     "kind": "section"
   },
   {
-    "id": "183-install#add-mutate-endpoint",
+    "id": "184-install#add-mutate-endpoint",
     "title": "Install Zero",
     "searchTitle": "Add Mutate Endpoint",
     "sectionTitle": "Add Mutate Endpoint",
     "sectionId": "add-mutate-endpoint",
     "url": "/docs/install",
-    "content": "Zero requires a mutate endpoint which runs on your server and connects directly to your Postgres database. Zero provides helpers to implement this easily. First, use the Zero Postgres adapters to create a dbProvider instance: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import type {Database} from '../../kysely/database.ts' const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' // pass a prisma client instance. for example: const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then, use the dbProvider and helpers to define the mutate endpoint: // app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' import {mustGetMutator} from '@rocicorp/zero' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Restart zero-cache with an environment variable for this new endpoint: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" npx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" pnpm exec zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" bunx zero-cache-devexport ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" export ZERO_QUERY_URL=\"http://localhost:3000/api/query\" export ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" yarn exec zero-cache-dev",
+    "content": "Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack: // src/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' import type {Database} from '../../kysely/database.ts' const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators.ts' import {dbProvider} from '../../db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators.ts' import {dbProvider} from './db-provider.ts' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Now you can run zero-cache locally with ZERO_UPSTREAM_DB, ZERO_QUERY_URL, and ZERO_MUTATE_URL configured: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" \\ ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev",
     "kind": "section"
   },
   {
-    "id": "184-install#invoke-mutators",
+    "id": "185-install#invoke-mutators",
     "title": "Install Zero",
     "searchTitle": "Invoke Mutators",
     "sectionTitle": "Invoke Mutators",
     "sectionId": "invoke-mutators",
     "url": "/docs/install",
-    "content": "You can now call mutators via zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' await zero.mutate(mutators.activateUser({id: '1'})) Use the query we defined earlier to get albums for artist_1: // mycomponent.tsx import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const client = await zero.mutate( mutators.albums.create({ id: nanoid(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client if (client.type === 'success') { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// mycomponent.tsx import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' function MyComponent() { const zero = useZero() const onClick = async () => { const client = await zero().mutate( mutators.albums.create({ id: nanoid(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client if (client.type === 'success') { console.log('Album created!') } } return <button onClick={onClick}>Create Album</button> }// albums.ts import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' import {nanoid} from 'nanoid' const client = await zero.mutate( mutators.albums.create({ id: nanoid(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client if (client.type === 'success') { console.log('Album created!') } If you run this app now, you will see the UI update optimistically, and the mutation will commit to the database and sync to other clients:",
+    "content": "You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators.ts' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero.ts' import {mutators} from './zero/mutators.ts' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients.",
     "kind": "section"
   },
   {
-    "id": "185-install#more-about-mutators",
+    "id": "186-install#more-about-mutators",
     "title": "Install Zero",
     "searchTitle": "More about Mutators",
     "sectionTitle": "More about Mutators",
     "sectionId": "more-about-mutators",
     "url": "/docs/install",
-    "content": "Just as with queries, the separate server implementation of mutators extends elegantly to enable write permissions. Zero also has built-in helpers to do work after a mutator runs on the server, like send notifications. For these details and more, see Writing Data. To remove the sample and zero-cache data from your Postgres database, use the zero-out CLI tool and the cleanup SQL: export ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" # Remove all traces of zero-cache from Postgres: npx zero-out # Remove the _z_albums, _z_artists, _z_fans, # and _z_favorites tables curl -L https://raw.githubusercontent.com/rocicorp/onboarding/1-install/out.sql \\ | psql $ZERO_UPSTREAM_DB",
-    "kind": "section"
-  },
-  {
-    "id": "186-install#thats-it",
-    "title": "Install Zero",
-    "searchTitle": "That's It!",
-    "sectionTitle": "That's It!",
-    "sectionId": "thats-it",
-    "url": "/docs/install",
-    "content": "Congratulations! You now know the basics for building with Zero 🤯. Possible next steps: Learn about authentication and permissions See some samples of built-out Zero apps Learn how to deploy your app to production",
+    "content": "CRUD, server-specific code, permissions, and more Server-driven auth and Context Learn how to deploy your app to production",
     "kind": "section"
   },
   {
@@ -1785,31 +1771,16 @@
     "title": "Welcome to Zero",
     "searchTitle": "Welcome to Zero",
     "url": "/docs/introduction",
-    "content": "Zero enables instant web applications by syncing a subset of data to the client, before it is needed. Reads and writes happen directly against this local datastore, and are synced with the server continuously in the background. Unlike previous sync engines that sync entire tables to the client, or use static rules to control what syncs, you control what to sync in Zero by writing normal queries directly in your application code. This provides a huge amount of control over what data is synced and when. Zero caches query results in a normalized client-side datastore, and reuses that data automatically to answer future queries whenever possible. The result is that for typical applications, queries are almost always instantly resolved using local data. It feels like you have access to the entire backend database directly from the client in memory. Occasionally, when you do a more specific query, Zero falls back to the server. But this happens automatically without any extra work required. Ready to get started? Choose your adventure: Install Zero into an existing project Clone a minimal quickstart app Play with a full-featured sample",
-    "headings": [
-      {
-        "text": "Ready to get started?",
-        "id": "ready-to-get-started"
-      }
-    ],
+    "content": "",
+    "headings": [],
     "kind": "page"
-  },
-  {
-    "id": "187-introduction#ready-to-get-started",
-    "title": "Welcome to Zero",
-    "searchTitle": "Ready to get started?",
-    "sectionTitle": "Ready to get started?",
-    "sectionId": "ready-to-get-started",
-    "url": "/docs/introduction",
-    "content": "Choose your adventure: Install Zero into an existing project Clone a minimal quickstart app Play with a full-featured sample",
-    "kind": "section"
   },
   {
     "id": "17-mutators",
     "title": "Mutators",
     "searchTitle": "Mutators",
     "url": "/docs/mutators",
-    "content": "Mutators are how you write data with Zero. Here's a simple example: import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ updateIssue: defineMutator( z.object({ id: z.string(), title: z.string() }), async ({tx, args: {id, title}}) => { if (title.length > 100) { throw new Error(`Title is too long`) } await tx.mutate.issue.update({ id, title }) } ) }) Architecture A copy of each mutator exists on both the client and on your server: Often the implementations will be the same, and you can just share their code. This is easy with full-stack frameworks like TanStack Start or Next.js. But the implementations don't have to be the same, or even compute the same result. For example, the server can add extra checks to enforce permissions, or send notifications or interact with other systems. Life of a Mutation When a mutator is invoked, it initially runs on the client, against the client-side datastore. Any changes are immediately applied to open queries and the user sees the changes. In the background, Zero sends a mutation (a record of the mutator having run with certain arguments) to your server's push endpoint. Your push endpoint runs the push protocol, executing the server-side mutator in a transaction against your database and recording the fact that the mutation ran. The @rocicorp/zero package contains utilities to make it easy to implement this endpoint in TypeScript. The changes to the database are then replicated to zero-cache using logical replication. zero-cache calculates the updates to active queries and sends rows that have changed to each client. It also sends information about the mutations that have been applied to the database. Clients receive row updates and apply them to their local cache. Any pending mutations which have been applied to the server have their local effects rolled back. Client-side queries are updated and the user sees the changes. Defining Mutators Basics Create a mutator using defineMutator. The only required argument is a MutatorFn, which must be async: import {defineMutator} from '@rocicorp/zero' const myMutator = defineMutator(async () => { // ... }) Mutators almost always complete in the same frame on the client, within milliseconds. The reason they are marked async is because on the server, reading from the tx object goes over the network to Postgres. Writing Data The MutatorFn receives a tx parameter which can be used to write data with a CRUD-style API. Each table in your Zero schema has a corresponding field on tx.mutate: const myMutator = defineMutator(async ({tx}) => { // This is here because there's a `user` table in your schema. await tx.mutate.user.insert(...) }) Mutators almost always run in the same frame on the client, against local data. The reason mutators are marked async is because on the server, reading from the tx object goes over the network to Postgres. Also, in edge cases on the client, reads and writes can go to local storage (IndexedDB or SQLite). Insert Create new records with insert: tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: 'js' }) Optional fields can be set to null to explicitly set the new field to null. They can also be set to undefined to take the default value (which is often null but can also be some generated value server-side): // Sets language to `null` specifically tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: null }) // Sets language to the default server-side value. // Could be null, or some generated or constant default value too. tx.mutate.user.insert({ id: 'user-123', username: 'sam' }) // Same as above tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: undefined }) Upsert Create new records or update existing ones with upsert: tx.mutate.user.upsert({ id: samID, username: 'sam', language: 'ts' }) upsert supports the same null / undefined semantics for optional fields that insert does (see above). Update Update an existing record. Does nothing if the specified record (by PK) does not exist. You can pass a partial object, leaving fields out that you don’t want to change. For example here we leave the username the same: // Leaves username field to previous value. tx.mutate.user.update({ id: samID, language: 'golang' }) // Same as above tx.mutate.user.update({ id: samID, username: undefined, language: 'haskell' }) // Reset language field to `null` tx.mutate.user.update({ id: samID, language: null }) Delete Delete an existing record. Does nothing if specified record does not exist. tx.mutate.user.delete({ id: samID }) Arguments The MutatorFn can take a single args parameter. To enable this, pass a validator to defineMutator: import {defineMutator} from '@rocicorp/zero' const initStats = defineMutator( z.object({issueCount: z.number()}), async ({tx, args: {issueCount}}) => { if (issueCount < 0) { throw new Error(`issueCount cannot be negative`) } await tx.mutate.stats.insert({ id: 'global', issueCount }) } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. It's most common for mutators to be a pure function of the database state plus arguments. But it's not required. Impure mutators can be useful, e.g., to consult some external system on the server for authorization or validation. Reading Data You can read data within a mutator by passing ZQL to tx.run: const updateIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { const issue = await tx.run( zql.issue.where('id', id).one() ) if (issue?.status === 'closed') { throw new Error(`Cannot update closed issue`) } await tx.mutate.issue.update({ id, title }) } ) You have the full power of ZQL at your disposal, including relationships, filters, ordering, and limits. Reads and writes within a mutator are transactional, meaning that the datastore is guaranteed to not change while your mutator is running. And if the mutator throws, the entire mutation is rolled back. Unlike zero.run(), there is no type parameter that can be used to wait for server results inside mutators. This is because waiting for server results in mutators makes no sense – it would defeat the purpose of running optimistically to begin with. When a mutator runs on the client (tx.location === \"client\"), ZQL reads only return data already cached on the client. When mutators run on the server (tx.location === \"server\"), ZQL reads always return all data. Context Mutator parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero mutators also support the concept of a context object. Access your context with the ctx parameter to your mutator: const createIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, ctx: {userID}, args: {id, title}}) => { // Note: User cannot control ctx.userID, so this // enforces authorship of created issue. await tx.mutate.issue.insert({ id, title, authorID: userID }) } ) Mutator Registries The result of defineMutator is a MutatorDefinition. By itself this isn't super useful. You need to register it using defineMutators: export const mutators = defineMutators({ issue: { update: updateIssue } }) Typically these are done together in one step: export const mutators = defineMutators({ issue: { update: defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { await tx.mutate.issue.update({ id, title }) } ) } }) The result of defineMutators is called a MutatorRegistry. Each field in the registry is a callable Mutator that you can use to perform mutations: import {mutators} from 'mutators.ts' zero.mutate( mutators.issue.update({ id: 'issue-123', title: 'New title' }) ) Mutator Names Each Mutator has a mutatorName which is computed by defineMutators. When you run a mutator, Zero sends this name along with the arguments to your server to execute the server-side mutation. console.log(mutators.issue.update.mutatorName) // \"issue.update\" mutators.ts By convention, mutators are listed in a central mutators.ts file. This allows them to be easily used on both the client and server: import {defineMutators, defineMutator} from '@rocicorp/zero' import {zql} from './schema.ts' import {z} from 'zod' export const mutators = defineMutators({ posts: { create: defineMutator( z.object({ id: z.string(), title: z.string() }), async ({ tx, context: {userID}, args: {id, title} }) => { await tx.mutate.post.insert({ id, title, authorID: userID }) } ), update: defineMutator( z.object({ id: z.string(), title: z.string().optional() }), async ({ tx, context: {userID}, args: {id, title} }) => { const prev = await tx.run( zql.post.where('id', id).one() ) if (prev?.authorID !== userID) { throw new Error(`Access denied`) } await tx.mutate.post.update({ id, title, authorID: userID }) } ) } }) You can use as many levels of nesting as you want to organize your mutators. As your application grows, you can move mutators to different files to keep them organized: // posts.ts export const postMutators = { create: defineMutator( z.object({ id: z.string(), title: z.string(), }), async ({tx, context: {userID}, args: {id, title}}) => { await tx.mutate.post.insert({ id, title, authorID: userID, }) }, ), } // user.ts export const userMutators = { updateRole: defineMutator( z.object({ role: z.string(), }), async ({tx, ctx: {userID}, args: {role}}) => { await tx.mutate.user.update({ id: userID, role, }) }, ), } // mutators.ts import {postMutators} from 'zero/mutators/posts.ts' import {userMutators} from 'zero/mutators/users.ts' export const mutators = defineMutators{{ posts: postMutators, users: userMutators, }) defineMutators establishes the full name for each mutator (i.e., posts.create, users.updateRole), which is later sent to the server. So this should only be used once at the top level of your mutators.ts file. Registration Before you can use your mutators, you need to register them with Zero: import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } const zero = new Zero(opts) Mutators need to be registered with Zero because Zero calls them during sync for conflict resolution. If you invoke a mutator that is not registered, Zero will throw an error. Server Setup In order for mutations to sync, you must provide an implementation of the mutate endpoint on your server. zero-cache calls this endpoint to process each mutation. Registering the Endpoint Use ZERO_MUTATE_URL to tell zero-cache where to find your mutate implementation: export ZERO_MUTATE_URL=\"http://localhost:3000/api/zero/mutate\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleMutateRequest and mustGetMutator functions to implement the endpoint. Plug in whatever dbProvider you set up (see server-zql or the install guide). // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), c.req.raw ) return c.json(result) }) Zero includes several built-in database adapters. You can also easily create your own. See ZQL on the Server for more information. handleMutateRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetMutator looks up the mutator in the registry and throws an error if not found. The mutator.fn function is your mutator implementation wrapped in the validator you provided. These examples have only public mutators, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the mutate handler. See Authentication. Handling Errors The handleMutateRequest function skips any mutations that throw: const result = await handleMutateRequest( dbProvider, transact => transact(async (tx, name, args) => { // The mutation is skipped and the next mutation runs as normal. // The optimistic mutation on the client will be reverted. throw new Error('bonk') }), c.req.raw ) handleMutateRequest catches such errors and turns them into a structured response that gets sent back to the client. You can recover the errors and show UI if you want. It is also of course possible for the entire push endpoint to return an HTTP error, or to not reply at all: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async () => { throw new Error('zonk') // will trigger resend } } } })export async function POST() { throw new Error('zonk') // will trigger resend }export async function POST() { throw new Error('zonk') // will trigger resend }app.post('/api/zero/mutate', async c => { // This will cause the client to resend all queued mutations. throw new Error('zonk') }) If Zero receives any response from the mutate endpoint other than HTTP 200, 401, or 403, it will disconnect and enter the error state. If Zero receives HTTP 401 or 403, the client will enter the needs auth state and require a manual reconnect. Use zero.connection.connect() for cookie auth or zero.connection.connect({auth: newToken}) for token auth, then Zero will retry all queued mutations. If you want a different behavior, it is possible to implement the mutate endpoint yourself and handle errors differently. Custom Mutate URL By default, Zero sends mutations to the URL specified in the ZERO_MUTATE_URL parameter. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in the ZERO_MUTATE_URL parameter: export ZERO_MUTATE_URL=\"https://api.example.com/mutate,https://api.staging.example.com/mutate\" Then choose one of those URLs by passing it to mutateURL on the Zero constructor: const opts: ZeroOptions = { // ... mutateURL: 'https://api.staging.example.com/mutate' } URL Patterns The strings listed in ZERO_MUTATE_URL can also be URLPatterns: export ZERO_MUTATE_URL=\"https://mybranch-*.preview.myapp.com/mutate\" For more information, see the URLPattern section of the Queries docs. It works the same way for mutations. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints. Server-Specific Code To implement server-specific code, just run different mutators in your mutate endpoint. Server authority to the rescue! defineMutators accepts a baseMutators parameter that makes this easy. The returned mutator registry will contain all the mutators from baseMutators, plus any new ones you define or override: // server-mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' import {zql} from 'schema.ts' import {mutators as sharedMutators} from 'mutators.ts' export const serverMutators = defineMutators( sharedMutators, { posts: { // Overrides the shared mutator definition with same name. update: defineMutator( z.object({ id: z.string(), title: z.string().optional(), priority: z.number().optional() }), async ({ tx, ctx: {userID}, args: {id, title, priority} }) => { // Run the shared mutator first. await sharedMutators.posts.update.fn({ tx, ctx, args }) // Record a history of this operation happening in an audit log table. await tx.mutate.auditLog.insert({ issueId: id, action: 'update-title', timestamp: Date.getTime() }) } ) } } ) For simple things, we also expose a location field on the transaction object that you can use to branch your code: const myMutator = defineMutator(async ({tx}) => { if (tx.location === 'client') { // Client-side code } else { // Server-side code } }) Running Mutators Once you have registered your mutators, you can invoke them with zero.mutate: import {mutators} from 'mutators.ts' import {nanoid} from 'nanoid' zero.mutate( mutators.issue.update({ id: nanoid(), title: 'New title' }) ) Client-generated random IDs from libraries like uuid, ulid, or nanoid work much better with sync engines like Zero. See IDs for more details. Waiting for Results We typically recommend that you \"fire and forget\" mutators. Optimistic mutations make sense when the common case is that a mutation succeeds. If a mutation frequently fails, then showing the user an optimistic result isn't very useful, because it will likely be wrong. That said there are cases where it is nice to know when a write succeeded on either the client or server. One example is if you need to read a row directly after writing it. Zero's local writes are very fast (almost always < 1 frame), but because Zero is backed by IndexedDB, writes are still technically asynchronous and reads directly after a write may not return the new data. You can use the .client promise in this case to wait for a write to complete on the client side: const write = zero.mutate( mutators.issue.insert({ id: nanoid(), title: 'New title' }) ) // issue-123 not guaranteed to be present here. read1 may be undefined. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await client write – almost always less than 1 frame, and same // macrotask, so no browser paint will occur here. const res = await write.client if (res.type === 'error') { console.error('Mutator failed on client', res.error) } // issue-123 definitely can be read now. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) You can also wait for the server write to succeed: const write = zero.mutate( mutators.issue.insert({ id: nanoid(), title: 'New title' }) ) const clientRes = await write.client if (clientRes.type === 'error') { throw new Error( `Mutator failed on client`, clientRes.error ) } // optimistic write guaranteed to be present here, but not // server write. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await server write – this involves a round-trip. const serverRes = await write.server if (serverRes.type === 'error') { throw new Error( `Mutator failed on server`, serverRes.error ) } // issue-123 is written to server and any results are // synced to this client. // read2 could potentially be undefined here, for example if the // server mutator rejected the write. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) If the client-side mutator fails, the .server promise is also rejected with the same error. You don't have to listen to both promises, the server promise covers both cases. There is not yet a way to return data from mutators in the success case. Let us know if you need this. Permissions Because mutators are just normal TypeScript functions that run server-side, there is no need for a special permissions system. You can implement whatever permission checks you want using plain TypeScript code. See Permissions for more information. Dropping Down to Raw SQL The ServerTransaction interface has a dbTransaction property that exposes the underlying database connection. This allows you to run raw SQL queries directly against the database. This is useful for complex queries, or for using Postgres features that Zero doesn't support yet: const markAllAsRead = defineMutator( z.object({ userId: z.string() }), async ({tx, args: {userId}}) => { // shared stuff ... if (tx.location === 'server') { // `tx` is now narrowed to `ServerTransaction`. // Do special server-only stuff with raw SQL. await tx.dbTransaction.query( ` UPDATE notification SET read = true WHERE user_id = $1 `, [userId] ) } } ) See ZQL on the Server for more information. Notifications and Async Work The best way to handle notifications and async work is a transactional outbox. This ensures that notifications actually do eventually get sent, without holding open database transactions to talk over the network. This can be implemented very easily in Zero by writing notifications to an outbox table as part of your mutator, then processing that table periodically with a background job. However sometimes it's still nice to do a quick and dirty async send as part of a mutation, for example early on in development, or to record metrics. For this, the createMutators pattern is useful: // server-mutators.ts import {defineMutator} from '@rocicorp/zero' import z from 'zod' import {zql} from 'schema.ts' import {mutators as clientMutators} from 'mutators.ts' // Instead of defining server mutators as a constant, // define them as a function of a list of async tasks. export function createMutators( asyncTasks: Array<() => Promise<void>> ) { return defineMutators(clientMutators, { issue: { update: defineMutator( z.object({ id: z.string(), title: z.string() }), async (tx, {id, title}) => { await tx.mutate.issue.update({id, title}) asyncTasks.push(() => sendEmailToSubscribers(id)) } ) } }) } Then in your mutate handler: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), request ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled( asyncTasks.map(task => task()) ) return Response.json(result) } } } })export async function POST(req: Request) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), req ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }export async function POST(event: APIEvent) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), event.request ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }app.post('/api/zero/mutate', async c => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), c.req.raw ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return c.json(result) }) Custom Mutate Implementation You can manually implement the mutate endpoint in any programming language. This will be documented in the future, but you can refer to the handleMutateRequest source code for an example for now.",
+    "content": "Mutators are how you write data with Zero. Here's a simple example: // src/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ updateIssue: defineMutator( z.object({ id: z.string(), title: z.string() }), async ({tx, args: {id, title}}) => { if (title.length > 100) { throw new Error(`Title is too long`) } await tx.mutate.issue.update({ id, title }) } ) }) Architecture A copy of each mutator exists on both the client and on your server: Often the implementations will be the same, and you can just share their code. This is easy with full-stack frameworks like TanStack Start or Next.js. But the implementations don't have to be the same, or even compute the same result. For example, the server can add extra checks to enforce permissions, or send notifications or interact with other systems. Life of a Mutation When a mutator is invoked, it initially runs on the client, against the client-side datastore. Any changes are immediately applied to open queries and the user sees the changes. In the background, Zero sends a mutation (a record of the mutator having run with certain arguments) to your server's push endpoint. Your push endpoint runs the push protocol, executing the server-side mutator in a transaction against your database and recording the fact that the mutation ran. The @rocicorp/zero package contains utilities to make it easy to implement this endpoint in TypeScript. The changes to the database are then replicated to zero-cache using logical replication. zero-cache calculates the updates to active queries and sends rows that have changed to each client. It also sends information about the mutations that have been applied to the database. Clients receive row updates and apply them to their local cache. Any pending mutations which have been applied to the server have their local effects rolled back. Client-side queries are updated and the user sees the changes. Defining Mutators Basics Create a mutator using defineMutator. The only required argument is a MutatorFn, which must be async: import {defineMutator} from '@rocicorp/zero' const myMutator = defineMutator(async () => { // ... }) Mutators almost always complete in the same frame on the client, within milliseconds. The reason they are marked async is because on the server, reading from the tx object goes over the network to Postgres. Writing Data The MutatorFn receives a tx parameter which can be used to write data with a CRUD-style API. Each table in your Zero schema has a corresponding field on tx.mutate: const myMutator = defineMutator(async ({tx}) => { // This is here because there's a `user` table in your schema. await tx.mutate.user.insert(...) }) Mutators almost always run in the same frame on the client, against local data. The reason mutators are marked async is because on the server, reading from the tx object goes over the network to Postgres. Also, in edge cases on the client, reads and writes can go to local storage (IndexedDB or SQLite). Insert Create new records with insert: tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: 'js' }) Optional fields can be set to null to explicitly set the new field to null. They can also be set to undefined to take the default value (which is often null but can also be some generated value server-side): // Sets language to `null` specifically tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: null }) // Sets language to the default server-side value. // Could be null, or some generated or constant default value too. tx.mutate.user.insert({ id: 'user-123', username: 'sam' }) // Same as above tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: undefined }) Upsert Create new records or update existing ones with upsert: tx.mutate.user.upsert({ id: samID, username: 'sam', language: 'ts' }) upsert supports the same null / undefined semantics for optional fields that insert does (see above). Update Update an existing record. Does nothing if the specified record (by PK) does not exist. You can pass a partial object, leaving fields out that you don’t want to change. For example here we leave the username the same: // Leaves username field to previous value. tx.mutate.user.update({ id: samID, language: 'golang' }) // Same as above tx.mutate.user.update({ id: samID, username: undefined, language: 'haskell' }) // Reset language field to `null` tx.mutate.user.update({ id: samID, language: null }) Delete Delete an existing record. Does nothing if specified record does not exist. tx.mutate.user.delete({ id: samID }) Arguments The MutatorFn can take a single args parameter. To enable this, pass a validator to defineMutator: import {defineMutator} from '@rocicorp/zero' const initStats = defineMutator( z.object({issueCount: z.number()}), async ({tx, args: {issueCount}}) => { if (issueCount < 0) { throw new Error(`issueCount cannot be negative`) } await tx.mutate.stats.insert({ id: 'global', issueCount }) } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. It's most common for mutators to be a pure function of the database state plus arguments. But it's not required. Impure mutators can be useful, e.g., to consult some external system on the server for authorization or validation. Reading Data You can read data within a mutator by passing ZQL to tx.run: const updateIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { const issue = await tx.run( zql.issue.where('id', id).one() ) if (issue?.status === 'closed') { throw new Error(`Cannot update closed issue`) } await tx.mutate.issue.update({ id, title }) } ) You have the full power of ZQL at your disposal, including relationships, filters, ordering, and limits. Reads and writes within a mutator are transactional, meaning that the datastore is guaranteed to not change while your mutator is running. And if the mutator throws, the entire mutation is rolled back. Unlike zero.run(), there is no type parameter that can be used to wait for server results inside mutators. This is because waiting for server results in mutators makes no sense – it would defeat the purpose of running optimistically to begin with. When a mutator runs on the client (tx.location === \"client\"), ZQL reads only return data already cached on the client. When mutators run on the server (tx.location === \"server\"), ZQL reads always return all data. Context Mutator parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero mutators also support the concept of a context object. Access your context with the ctx parameter to your mutator: const createIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, ctx: {userID}, args: {id, title}}) => { // Note: User cannot control ctx.userID, so this // enforces authorship of created issue. await tx.mutate.issue.insert({ id, title, authorID: userID }) } ) If you don't want to register your Context and Schema types globally, you can use defineMutatorWithType and defineMutatorsWithType: import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {DrizzleTransaction} from '@rocicorp/zero/server/adapters/drizzle' import type {drizzleClient} from 'db-provider.ts' const defineMutator = defineMutatorWithType< Schema, ZeroContext, DrizzleTransaction<typeof drizzleClient> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {KyselyTransaction} from '@rocicorp/zero/server/adapters/kysely' import type {Database} from 'db-provider.ts' const defineMutator = defineMutatorWithType< Schema, ZeroContext, KyselyTransaction<Database> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {PrismaTransaction} from '@rocicorp/zero/server/adapters/prisma' import type {PrismaClient} from '@prisma/client' const defineMutator = defineMutatorWithType< Schema, ZeroContext, PrismaTransaction<PrismaClient> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {NodePgTransaction} from '@rocicorp/zero/server/adapters/pg' const defineMutator = defineMutatorWithType< Schema, ZeroContext, NodePgTransaction >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {PostgresJsTransaction} from '@rocicorp/zero/server/adapters/postgresjs' const defineMutator = defineMutatorWithType< Schema, ZeroContext, PostgresJsTransaction >() const defineMutators = defineMutatorsWithType<Schema>() Mutator Registries The result of defineMutator is a MutatorDefinition. By itself this isn't super useful. You need to register it using defineMutators: export const mutators = defineMutators({ issue: { update: updateIssue } }) Typically these are done together in one step: export const mutators = defineMutators({ issue: { update: defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { await tx.mutate.issue.update({ id, title }) } ) } }) The result of defineMutators is called a MutatorRegistry. Each field in the registry is a callable Mutator that you can use to perform mutations: import {mutators} from 'mutators.ts' zero.mutate( mutators.issue.update({ id: 'issue-123', title: 'New title' }) ) Mutator Names Each Mutator has a mutatorName which is computed by defineMutators. When you run a mutator, Zero sends this name along with the arguments to your server to execute the server-side mutation. console.log(mutators.issue.update.mutatorName) // \"issue.update\" mutators.ts By convention, mutators are listed in a central mutators.ts file. This allows them to be easily used on both the client and server: import {defineMutators, defineMutator} from '@rocicorp/zero' import {zql} from './schema.ts' import {z} from 'zod' export const mutators = defineMutators({ posts: { create: defineMutator( z.object({ id: z.string(), title: z.string() }), async ({ tx, context: {userID}, args: {id, title} }) => { await tx.mutate.post.insert({ id, title, authorID: userID }) } ), update: defineMutator( z.object({ id: z.string(), title: z.string().optional() }), async ({ tx, context: {userID}, args: {id, title} }) => { const prev = await tx.run( zql.post.where('id', id).one() ) if (prev?.authorID !== userID) { throw new Error(`Access denied`) } await tx.mutate.post.update({ id, title, authorID: userID }) } ) } }) You can use as many levels of nesting as you want to organize your mutators. As your application grows, you can move mutators to different files to keep them organized: // posts.ts export const postMutators = { create: defineMutator( z.object({ id: z.string(), title: z.string(), }), async ({tx, context: {userID}, args: {id, title}}) => { await tx.mutate.post.insert({ id, title, authorID: userID, }) }, ), } // user.ts export const userMutators = { updateRole: defineMutator( z.object({ role: z.string(), }), async ({tx, ctx: {userID}, args: {role}}) => { await tx.mutate.user.update({ id: userID, role, }) }, ), } // mutators.ts import {postMutators} from 'zero/mutators/posts.ts' import {userMutators} from 'zero/mutators/users.ts' export const mutators = defineMutators{{ posts: postMutators, users: userMutators, }) defineMutators establishes the full name for each mutator (i.e., posts.create, users.updateRole), which is later sent to the server. So this should only be used once at the top level of your mutators.ts file. Registration Before you can use your mutators, you need to register them with Zero: import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } const zero = new Zero(opts) Mutators need to be registered with Zero because Zero calls them during sync for conflict resolution. If you invoke a mutator that is not registered, Zero will throw an error. Server Setup In order for mutations to sync, you must provide an implementation of the mutate endpoint on your server. zero-cache calls this endpoint to process each mutation. Registering the Endpoint Use ZERO_MUTATE_URL to tell zero-cache where to find your mutate implementation: export ZERO_MUTATE_URL=\"http://localhost:3000/api/zero/mutate\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleMutateRequest and mustGetMutator functions to implement the endpoint. Plug in whatever dbProvider you set up (see server-zql or the install guide). // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), c.req.raw ) return c.json(result) }) Zero includes several built-in database adapters. You can also easily create your own. See ZQL on the Server for more information. handleMutateRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetMutator looks up the mutator in the registry and throws an error if not found. The mutator.fn function is your mutator implementation wrapped in the validator you provided. These examples have only public mutators, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the mutate handler. See Authentication. Handling Errors The handleMutateRequest function skips any mutations that throw: const result = await handleMutateRequest( dbProvider, transact => transact(async (tx, name, args) => { // The mutation is skipped and the next mutation runs as normal. // The optimistic mutation on the client will be reverted. throw new Error('bonk') }), c.req.raw ) handleMutateRequest catches such errors and turns them into a structured response that gets sent back to the client. You can recover the errors and show UI if you want. It is also of course possible for the entire push endpoint to return an HTTP error, or to not reply at all: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async () => { throw new Error('zonk') // will trigger resend } } } })export async function POST() { throw new Error('zonk') // will trigger resend }export async function POST() { throw new Error('zonk') // will trigger resend }app.post('/api/zero/mutate', async c => { // This will cause the client to resend all queued mutations. throw new Error('zonk') }) If Zero receives any response from the mutate endpoint other than HTTP 200, 401, or 403, it will disconnect and enter the error state. If Zero receives HTTP 401 or 403, the client will enter the needs auth state and require a manual reconnect. Use zero.connection.connect() for cookie auth or zero.connection.connect({auth: newToken}) for token auth, then Zero will retry all queued mutations. If you want a different behavior, it is possible to implement the mutate endpoint yourself and handle errors differently. Custom Mutate URL By default, Zero sends mutations to the URL specified in the ZERO_MUTATE_URL parameter. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in the ZERO_MUTATE_URL parameter: export ZERO_MUTATE_URL=\"https://api.example.com/mutate,https://api.staging.example.com/mutate\" Then choose one of those URLs by passing it to mutateURL on the Zero constructor: const opts: ZeroOptions = { // ... mutateURL: 'https://api.staging.example.com/mutate' } URL Patterns The strings listed in ZERO_MUTATE_URL can also be URLPatterns: export ZERO_MUTATE_URL=\"https://mybranch-*.preview.myapp.com/mutate\" For more information, see the URLPattern section of the Queries docs. It works the same way for mutations. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints. Server-Specific Code To implement server-specific code, just run different mutators in your mutate endpoint. Server authority to the rescue! defineMutators accepts a baseMutators parameter that makes this easy. The returned mutator registry will contain all the mutators from baseMutators, plus any new ones you define or override: // server-mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' import {zql} from 'schema.ts' import {mutators as sharedMutators} from 'mutators.ts' export const serverMutators = defineMutators( sharedMutators, { posts: { // Overrides the shared mutator definition with same name. update: defineMutator( z.object({ id: z.string(), title: z.string().optional(), priority: z.number().optional() }), async ({ tx, ctx: {userID}, args: {id, title, priority} }) => { // Run the shared mutator first. await sharedMutators.posts.update.fn({ tx, ctx, args }) // Record a history of this operation happening in an audit log table. await tx.mutate.auditLog.insert({ issueId: id, action: 'update-title', timestamp: Date.getTime() }) } ) } } ) For simple things, we also expose a location field on the transaction object that you can use to branch your code: const myMutator = defineMutator(async ({tx}) => { if (tx.location === 'client') { // Client-side code } else { // Server-side code } }) Running Mutators Once you have registered your mutators, you can invoke them with zero.mutate: import {mutators} from 'mutators.ts' zero.mutate( mutators.issue.update({ id: crypto.randomUUID(), title: 'New title' }) ) Client-generated random IDs from crypto.randomUUID(), uuid, ulid, or nanoid work much better with sync engines like Zero. See IDs for more details. Waiting for Results We typically recommend that you \"fire and forget\" mutators. Optimistic mutations make sense when the common case is that a mutation succeeds. If a mutation frequently fails, then showing the user an optimistic result isn't very useful, because it will likely be wrong. That said there are cases where it is nice to know when a write succeeded on either the client or server. One example is if you need to read a row directly after writing it. Zero's local writes are very fast (almost always < 1 frame), but because Zero is backed by IndexedDB, writes are still technically asynchronous and reads directly after a write may not return the new data. You can use the .client promise in this case to wait for a write to complete on the client side: const write = zero.mutate( mutators.issue.insert({ id: crypto.randomUUID(), title: 'New title' }) ) // issue-123 not guaranteed to be present here. read1 may be undefined. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await client write – almost always less than 1 frame, and same // macrotask, so no browser paint will occur here. const res = await write.client if (res.type === 'error') { console.error('Mutator failed on client', res.error) } // issue-123 definitely can be read now. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) You can also wait for the server write to succeed: const write = zero.mutate( mutators.issue.insert({ id: crypto.randomUUID(), title: 'New title' }) ) const clientRes = await write.client if (clientRes.type === 'error') { throw new Error( `Mutator failed on client`, clientRes.error ) } // optimistic write guaranteed to be present here, but not // server write. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await server write – this involves a round-trip. const serverRes = await write.server if (serverRes.type === 'error') { throw new Error( `Mutator failed on server`, serverRes.error ) } // issue-123 is written to server and any results are // synced to this client. // read2 could potentially be undefined here, for example if the // server mutator rejected the write. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) If the client-side mutator fails, the .server promise is also rejected with the same error. You don't have to listen to both promises, the server promise covers both cases. There is not yet a way to return data from mutators in the success case. Let us know if you need this. Permissions Because mutators are just normal TypeScript functions that run server-side, there is no need for a special permissions system. You can implement whatever permission checks you want using plain TypeScript code. See Permissions for more information. Dropping Down to Raw SQL The ServerTransaction interface has a dbTransaction property that exposes the underlying database connection. This allows you to run raw SQL queries directly against the database. This is useful for complex queries, or for using Postgres features that Zero doesn't support yet: const markAllAsRead = defineMutator( z.object({ userId: z.string() }), async ({tx, args: {userId}}) => { // shared stuff ... if (tx.location === 'server') { // `tx` is now narrowed to `ServerTransaction`. // Do special server-only stuff with raw SQL. await tx.dbTransaction.query( ` UPDATE notification SET read = true WHERE user_id = $1 `, [userId] ) } } ) See ZQL on the Server for more information. Notifications and Async Work The best way to handle notifications and async work is a transactional outbox. This ensures that notifications actually do eventually get sent, without holding open database transactions to talk over the network. This can be implemented very easily in Zero by writing notifications to an outbox table as part of your mutator, then processing that table periodically with a background job. However sometimes it's still nice to do a quick and dirty async send as part of a mutation, for example early on in development, or to record metrics. For this, the createMutators pattern is useful: // server-mutators.ts import {defineMutator} from '@rocicorp/zero' import z from 'zod' import {zql} from 'schema.ts' import {mutators as clientMutators} from 'mutators.ts' // Instead of defining server mutators as a constant, // define them as a function of a list of async tasks. export function createMutators( asyncTasks: Array<() => Promise<void>> ) { return defineMutators(clientMutators, { issue: { update: defineMutator( z.object({ id: z.string(), title: z.string() }), async (tx, {id, title}) => { await tx.mutate.issue.update({id, title}) asyncTasks.push(() => sendEmailToSubscribers(id)) } ) } }) } Then in your mutate handler: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), request ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled( asyncTasks.map(task => task()) ) return Response.json(result) } } } })export async function POST(req: Request) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), req ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }export async function POST(event: APIEvent) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), event.request ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }app.post('/api/zero/mutate', async c => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), c.req.raw ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return c.json(result) }) Custom Mutate Implementation You can manually implement the mutate endpoint in any programming language. This will be documented in the future, but you can refer to the handleMutateRequest source code for an example for now.",
     "headings": [
       {
         "text": "Architecture",
@@ -1931,7 +1902,7 @@
     "kind": "page"
   },
   {
-    "id": "188-mutators#architecture",
+    "id": "187-mutators#architecture",
     "title": "Mutators",
     "searchTitle": "Architecture",
     "sectionTitle": "Architecture",
@@ -1941,7 +1912,7 @@
     "kind": "section"
   },
   {
-    "id": "189-mutators#life-of-a-mutation",
+    "id": "188-mutators#life-of-a-mutation",
     "title": "Mutators",
     "searchTitle": "Life of a Mutation",
     "sectionTitle": "Life of a Mutation",
@@ -1951,17 +1922,17 @@
     "kind": "section"
   },
   {
-    "id": "190-mutators#defining-mutators",
+    "id": "189-mutators#defining-mutators",
     "title": "Mutators",
     "searchTitle": "Defining Mutators",
     "sectionTitle": "Defining Mutators",
     "sectionId": "defining-mutators",
     "url": "/docs/mutators",
-    "content": "Basics Create a mutator using defineMutator. The only required argument is a MutatorFn, which must be async: import {defineMutator} from '@rocicorp/zero' const myMutator = defineMutator(async () => { // ... }) Mutators almost always complete in the same frame on the client, within milliseconds. The reason they are marked async is because on the server, reading from the tx object goes over the network to Postgres. Writing Data The MutatorFn receives a tx parameter which can be used to write data with a CRUD-style API. Each table in your Zero schema has a corresponding field on tx.mutate: const myMutator = defineMutator(async ({tx}) => { // This is here because there's a `user` table in your schema. await tx.mutate.user.insert(...) }) Mutators almost always run in the same frame on the client, against local data. The reason mutators are marked async is because on the server, reading from the tx object goes over the network to Postgres. Also, in edge cases on the client, reads and writes can go to local storage (IndexedDB or SQLite). Insert Create new records with insert: tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: 'js' }) Optional fields can be set to null to explicitly set the new field to null. They can also be set to undefined to take the default value (which is often null but can also be some generated value server-side): // Sets language to `null` specifically tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: null }) // Sets language to the default server-side value. // Could be null, or some generated or constant default value too. tx.mutate.user.insert({ id: 'user-123', username: 'sam' }) // Same as above tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: undefined }) Upsert Create new records or update existing ones with upsert: tx.mutate.user.upsert({ id: samID, username: 'sam', language: 'ts' }) upsert supports the same null / undefined semantics for optional fields that insert does (see above). Update Update an existing record. Does nothing if the specified record (by PK) does not exist. You can pass a partial object, leaving fields out that you don’t want to change. For example here we leave the username the same: // Leaves username field to previous value. tx.mutate.user.update({ id: samID, language: 'golang' }) // Same as above tx.mutate.user.update({ id: samID, username: undefined, language: 'haskell' }) // Reset language field to `null` tx.mutate.user.update({ id: samID, language: null }) Delete Delete an existing record. Does nothing if specified record does not exist. tx.mutate.user.delete({ id: samID }) Arguments The MutatorFn can take a single args parameter. To enable this, pass a validator to defineMutator: import {defineMutator} from '@rocicorp/zero' const initStats = defineMutator( z.object({issueCount: z.number()}), async ({tx, args: {issueCount}}) => { if (issueCount < 0) { throw new Error(`issueCount cannot be negative`) } await tx.mutate.stats.insert({ id: 'global', issueCount }) } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. It's most common for mutators to be a pure function of the database state plus arguments. But it's not required. Impure mutators can be useful, e.g., to consult some external system on the server for authorization or validation. Reading Data You can read data within a mutator by passing ZQL to tx.run: const updateIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { const issue = await tx.run( zql.issue.where('id', id).one() ) if (issue?.status === 'closed') { throw new Error(`Cannot update closed issue`) } await tx.mutate.issue.update({ id, title }) } ) You have the full power of ZQL at your disposal, including relationships, filters, ordering, and limits. Reads and writes within a mutator are transactional, meaning that the datastore is guaranteed to not change while your mutator is running. And if the mutator throws, the entire mutation is rolled back. Unlike zero.run(), there is no type parameter that can be used to wait for server results inside mutators. This is because waiting for server results in mutators makes no sense – it would defeat the purpose of running optimistically to begin with. When a mutator runs on the client (tx.location === \"client\"), ZQL reads only return data already cached on the client. When mutators run on the server (tx.location === \"server\"), ZQL reads always return all data. Context Mutator parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero mutators also support the concept of a context object. Access your context with the ctx parameter to your mutator: const createIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, ctx: {userID}, args: {id, title}}) => { // Note: User cannot control ctx.userID, so this // enforces authorship of created issue. await tx.mutate.issue.insert({ id, title, authorID: userID }) } ) Mutator Registries The result of defineMutator is a MutatorDefinition. By itself this isn't super useful. You need to register it using defineMutators: export const mutators = defineMutators({ issue: { update: updateIssue } }) Typically these are done together in one step: export const mutators = defineMutators({ issue: { update: defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { await tx.mutate.issue.update({ id, title }) } ) } }) The result of defineMutators is called a MutatorRegistry. Each field in the registry is a callable Mutator that you can use to perform mutations: import {mutators} from 'mutators.ts' zero.mutate( mutators.issue.update({ id: 'issue-123', title: 'New title' }) ) Mutator Names Each Mutator has a mutatorName which is computed by defineMutators. When you run a mutator, Zero sends this name along with the arguments to your server to execute the server-side mutation. console.log(mutators.issue.update.mutatorName) // \"issue.update\" mutators.ts By convention, mutators are listed in a central mutators.ts file. This allows them to be easily used on both the client and server: import {defineMutators, defineMutator} from '@rocicorp/zero' import {zql} from './schema.ts' import {z} from 'zod' export const mutators = defineMutators({ posts: { create: defineMutator( z.object({ id: z.string(), title: z.string() }), async ({ tx, context: {userID}, args: {id, title} }) => { await tx.mutate.post.insert({ id, title, authorID: userID }) } ), update: defineMutator( z.object({ id: z.string(), title: z.string().optional() }), async ({ tx, context: {userID}, args: {id, title} }) => { const prev = await tx.run( zql.post.where('id', id).one() ) if (prev?.authorID !== userID) { throw new Error(`Access denied`) } await tx.mutate.post.update({ id, title, authorID: userID }) } ) } }) You can use as many levels of nesting as you want to organize your mutators. As your application grows, you can move mutators to different files to keep them organized: // posts.ts export const postMutators = { create: defineMutator( z.object({ id: z.string(), title: z.string(), }), async ({tx, context: {userID}, args: {id, title}}) => { await tx.mutate.post.insert({ id, title, authorID: userID, }) }, ), } // user.ts export const userMutators = { updateRole: defineMutator( z.object({ role: z.string(), }), async ({tx, ctx: {userID}, args: {role}}) => { await tx.mutate.user.update({ id: userID, role, }) }, ), } // mutators.ts import {postMutators} from 'zero/mutators/posts.ts' import {userMutators} from 'zero/mutators/users.ts' export const mutators = defineMutators{{ posts: postMutators, users: userMutators, }) defineMutators establishes the full name for each mutator (i.e., posts.create, users.updateRole), which is later sent to the server. So this should only be used once at the top level of your mutators.ts file.",
+    "content": "Basics Create a mutator using defineMutator. The only required argument is a MutatorFn, which must be async: import {defineMutator} from '@rocicorp/zero' const myMutator = defineMutator(async () => { // ... }) Mutators almost always complete in the same frame on the client, within milliseconds. The reason they are marked async is because on the server, reading from the tx object goes over the network to Postgres. Writing Data The MutatorFn receives a tx parameter which can be used to write data with a CRUD-style API. Each table in your Zero schema has a corresponding field on tx.mutate: const myMutator = defineMutator(async ({tx}) => { // This is here because there's a `user` table in your schema. await tx.mutate.user.insert(...) }) Mutators almost always run in the same frame on the client, against local data. The reason mutators are marked async is because on the server, reading from the tx object goes over the network to Postgres. Also, in edge cases on the client, reads and writes can go to local storage (IndexedDB or SQLite). Insert Create new records with insert: tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: 'js' }) Optional fields can be set to null to explicitly set the new field to null. They can also be set to undefined to take the default value (which is often null but can also be some generated value server-side): // Sets language to `null` specifically tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: null }) // Sets language to the default server-side value. // Could be null, or some generated or constant default value too. tx.mutate.user.insert({ id: 'user-123', username: 'sam' }) // Same as above tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: undefined }) Upsert Create new records or update existing ones with upsert: tx.mutate.user.upsert({ id: samID, username: 'sam', language: 'ts' }) upsert supports the same null / undefined semantics for optional fields that insert does (see above). Update Update an existing record. Does nothing if the specified record (by PK) does not exist. You can pass a partial object, leaving fields out that you don’t want to change. For example here we leave the username the same: // Leaves username field to previous value. tx.mutate.user.update({ id: samID, language: 'golang' }) // Same as above tx.mutate.user.update({ id: samID, username: undefined, language: 'haskell' }) // Reset language field to `null` tx.mutate.user.update({ id: samID, language: null }) Delete Delete an existing record. Does nothing if specified record does not exist. tx.mutate.user.delete({ id: samID }) Arguments The MutatorFn can take a single args parameter. To enable this, pass a validator to defineMutator: import {defineMutator} from '@rocicorp/zero' const initStats = defineMutator( z.object({issueCount: z.number()}), async ({tx, args: {issueCount}}) => { if (issueCount < 0) { throw new Error(`issueCount cannot be negative`) } await tx.mutate.stats.insert({ id: 'global', issueCount }) } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. It's most common for mutators to be a pure function of the database state plus arguments. But it's not required. Impure mutators can be useful, e.g., to consult some external system on the server for authorization or validation. Reading Data You can read data within a mutator by passing ZQL to tx.run: const updateIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { const issue = await tx.run( zql.issue.where('id', id).one() ) if (issue?.status === 'closed') { throw new Error(`Cannot update closed issue`) } await tx.mutate.issue.update({ id, title }) } ) You have the full power of ZQL at your disposal, including relationships, filters, ordering, and limits. Reads and writes within a mutator are transactional, meaning that the datastore is guaranteed to not change while your mutator is running. And if the mutator throws, the entire mutation is rolled back. Unlike zero.run(), there is no type parameter that can be used to wait for server results inside mutators. This is because waiting for server results in mutators makes no sense – it would defeat the purpose of running optimistically to begin with. When a mutator runs on the client (tx.location === \"client\"), ZQL reads only return data already cached on the client. When mutators run on the server (tx.location === \"server\"), ZQL reads always return all data. Context Mutator parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero mutators also support the concept of a context object. Access your context with the ctx parameter to your mutator: const createIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, ctx: {userID}, args: {id, title}}) => { // Note: User cannot control ctx.userID, so this // enforces authorship of created issue. await tx.mutate.issue.insert({ id, title, authorID: userID }) } ) If you don't want to register your Context and Schema types globally, you can use defineMutatorWithType and defineMutatorsWithType: import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {DrizzleTransaction} from '@rocicorp/zero/server/adapters/drizzle' import type {drizzleClient} from 'db-provider.ts' const defineMutator = defineMutatorWithType< Schema, ZeroContext, DrizzleTransaction<typeof drizzleClient> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {KyselyTransaction} from '@rocicorp/zero/server/adapters/kysely' import type {Database} from 'db-provider.ts' const defineMutator = defineMutatorWithType< Schema, ZeroContext, KyselyTransaction<Database> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {PrismaTransaction} from '@rocicorp/zero/server/adapters/prisma' import type {PrismaClient} from '@prisma/client' const defineMutator = defineMutatorWithType< Schema, ZeroContext, PrismaTransaction<PrismaClient> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {NodePgTransaction} from '@rocicorp/zero/server/adapters/pg' const defineMutator = defineMutatorWithType< Schema, ZeroContext, NodePgTransaction >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {PostgresJsTransaction} from '@rocicorp/zero/server/adapters/postgresjs' const defineMutator = defineMutatorWithType< Schema, ZeroContext, PostgresJsTransaction >() const defineMutators = defineMutatorsWithType<Schema>() Mutator Registries The result of defineMutator is a MutatorDefinition. By itself this isn't super useful. You need to register it using defineMutators: export const mutators = defineMutators({ issue: { update: updateIssue } }) Typically these are done together in one step: export const mutators = defineMutators({ issue: { update: defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { await tx.mutate.issue.update({ id, title }) } ) } }) The result of defineMutators is called a MutatorRegistry. Each field in the registry is a callable Mutator that you can use to perform mutations: import {mutators} from 'mutators.ts' zero.mutate( mutators.issue.update({ id: 'issue-123', title: 'New title' }) ) Mutator Names Each Mutator has a mutatorName which is computed by defineMutators. When you run a mutator, Zero sends this name along with the arguments to your server to execute the server-side mutation. console.log(mutators.issue.update.mutatorName) // \"issue.update\" mutators.ts By convention, mutators are listed in a central mutators.ts file. This allows them to be easily used on both the client and server: import {defineMutators, defineMutator} from '@rocicorp/zero' import {zql} from './schema.ts' import {z} from 'zod' export const mutators = defineMutators({ posts: { create: defineMutator( z.object({ id: z.string(), title: z.string() }), async ({ tx, context: {userID}, args: {id, title} }) => { await tx.mutate.post.insert({ id, title, authorID: userID }) } ), update: defineMutator( z.object({ id: z.string(), title: z.string().optional() }), async ({ tx, context: {userID}, args: {id, title} }) => { const prev = await tx.run( zql.post.where('id', id).one() ) if (prev?.authorID !== userID) { throw new Error(`Access denied`) } await tx.mutate.post.update({ id, title, authorID: userID }) } ) } }) You can use as many levels of nesting as you want to organize your mutators. As your application grows, you can move mutators to different files to keep them organized: // posts.ts export const postMutators = { create: defineMutator( z.object({ id: z.string(), title: z.string(), }), async ({tx, context: {userID}, args: {id, title}}) => { await tx.mutate.post.insert({ id, title, authorID: userID, }) }, ), } // user.ts export const userMutators = { updateRole: defineMutator( z.object({ role: z.string(), }), async ({tx, ctx: {userID}, args: {role}}) => { await tx.mutate.user.update({ id: userID, role, }) }, ), } // mutators.ts import {postMutators} from 'zero/mutators/posts.ts' import {userMutators} from 'zero/mutators/users.ts' export const mutators = defineMutators{{ posts: postMutators, users: userMutators, }) defineMutators establishes the full name for each mutator (i.e., posts.create, users.updateRole), which is later sent to the server. So this should only be used once at the top level of your mutators.ts file.",
     "kind": "section"
   },
   {
-    "id": "191-mutators#basics",
+    "id": "190-mutators#basics",
     "title": "Mutators",
     "searchTitle": "Basics",
     "sectionTitle": "Basics",
@@ -1971,7 +1942,7 @@
     "kind": "section"
   },
   {
-    "id": "192-mutators#writing-data",
+    "id": "191-mutators#writing-data",
     "title": "Mutators",
     "searchTitle": "Writing Data",
     "sectionTitle": "Writing Data",
@@ -1981,7 +1952,7 @@
     "kind": "section"
   },
   {
-    "id": "193-mutators#insert",
+    "id": "192-mutators#insert",
     "title": "Mutators",
     "searchTitle": "Insert",
     "sectionTitle": "Insert",
@@ -1991,7 +1962,7 @@
     "kind": "section"
   },
   {
-    "id": "194-mutators#upsert",
+    "id": "193-mutators#upsert",
     "title": "Mutators",
     "searchTitle": "Upsert",
     "sectionTitle": "Upsert",
@@ -2001,7 +1972,7 @@
     "kind": "section"
   },
   {
-    "id": "195-mutators#update",
+    "id": "194-mutators#update",
     "title": "Mutators",
     "searchTitle": "Update",
     "sectionTitle": "Update",
@@ -2011,7 +1982,7 @@
     "kind": "section"
   },
   {
-    "id": "196-mutators#delete",
+    "id": "195-mutators#delete",
     "title": "Mutators",
     "searchTitle": "Delete",
     "sectionTitle": "Delete",
@@ -2021,7 +1992,7 @@
     "kind": "section"
   },
   {
-    "id": "197-mutators#arguments",
+    "id": "196-mutators#arguments",
     "title": "Mutators",
     "searchTitle": "Arguments",
     "sectionTitle": "Arguments",
@@ -2031,7 +2002,7 @@
     "kind": "section"
   },
   {
-    "id": "198-mutators#reading-data",
+    "id": "197-mutators#reading-data",
     "title": "Mutators",
     "searchTitle": "Reading Data",
     "sectionTitle": "Reading Data",
@@ -2041,17 +2012,17 @@
     "kind": "section"
   },
   {
-    "id": "199-mutators#context",
+    "id": "198-mutators#context",
     "title": "Mutators",
     "searchTitle": "Context",
     "sectionTitle": "Context",
     "sectionId": "context",
     "url": "/docs/mutators",
-    "content": "Mutator parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero mutators also support the concept of a context object. Access your context with the ctx parameter to your mutator: const createIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, ctx: {userID}, args: {id, title}}) => { // Note: User cannot control ctx.userID, so this // enforces authorship of created issue. await tx.mutate.issue.insert({ id, title, authorID: userID }) } )",
+    "content": "Mutator parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero mutators also support the concept of a context object. Access your context with the ctx parameter to your mutator: const createIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, ctx: {userID}, args: {id, title}}) => { // Note: User cannot control ctx.userID, so this // enforces authorship of created issue. await tx.mutate.issue.insert({ id, title, authorID: userID }) } ) If you don't want to register your Context and Schema types globally, you can use defineMutatorWithType and defineMutatorsWithType: import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {DrizzleTransaction} from '@rocicorp/zero/server/adapters/drizzle' import type {drizzleClient} from 'db-provider.ts' const defineMutator = defineMutatorWithType< Schema, ZeroContext, DrizzleTransaction<typeof drizzleClient> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {KyselyTransaction} from '@rocicorp/zero/server/adapters/kysely' import type {Database} from 'db-provider.ts' const defineMutator = defineMutatorWithType< Schema, ZeroContext, KyselyTransaction<Database> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {PrismaTransaction} from '@rocicorp/zero/server/adapters/prisma' import type {PrismaClient} from '@prisma/client' const defineMutator = defineMutatorWithType< Schema, ZeroContext, PrismaTransaction<PrismaClient> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {NodePgTransaction} from '@rocicorp/zero/server/adapters/pg' const defineMutator = defineMutatorWithType< Schema, ZeroContext, NodePgTransaction >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {PostgresJsTransaction} from '@rocicorp/zero/server/adapters/postgresjs' const defineMutator = defineMutatorWithType< Schema, ZeroContext, PostgresJsTransaction >() const defineMutators = defineMutatorsWithType<Schema>()",
     "kind": "section"
   },
   {
-    "id": "200-mutators#mutator-registries",
+    "id": "199-mutators#mutator-registries",
     "title": "Mutators",
     "searchTitle": "Mutator Registries",
     "sectionTitle": "Mutator Registries",
@@ -2061,7 +2032,7 @@
     "kind": "section"
   },
   {
-    "id": "201-mutators#mutator-names",
+    "id": "200-mutators#mutator-names",
     "title": "Mutators",
     "searchTitle": "Mutator Names",
     "sectionTitle": "Mutator Names",
@@ -2071,7 +2042,7 @@
     "kind": "section"
   },
   {
-    "id": "202-mutators#mutatorsts",
+    "id": "201-mutators#mutatorsts",
     "title": "Mutators",
     "searchTitle": "mutators.ts",
     "sectionTitle": "mutators.ts",
@@ -2081,7 +2052,7 @@
     "kind": "section"
   },
   {
-    "id": "203-mutators#registration",
+    "id": "202-mutators#registration",
     "title": "Mutators",
     "searchTitle": "Registration",
     "sectionTitle": "Registration",
@@ -2091,7 +2062,7 @@
     "kind": "section"
   },
   {
-    "id": "204-mutators#server-setup",
+    "id": "203-mutators#server-setup",
     "title": "Mutators",
     "searchTitle": "Server Setup",
     "sectionTitle": "Server Setup",
@@ -2101,7 +2072,7 @@
     "kind": "section"
   },
   {
-    "id": "205-mutators#registering-the-endpoint",
+    "id": "204-mutators#registering-the-endpoint",
     "title": "Mutators",
     "searchTitle": "Registering the Endpoint",
     "sectionTitle": "Registering the Endpoint",
@@ -2111,7 +2082,7 @@
     "kind": "section"
   },
   {
-    "id": "206-mutators#implementing-the-endpoint",
+    "id": "205-mutators#implementing-the-endpoint",
     "title": "Mutators",
     "searchTitle": "Implementing the Endpoint",
     "sectionTitle": "Implementing the Endpoint",
@@ -2121,7 +2092,7 @@
     "kind": "section"
   },
   {
-    "id": "207-mutators#handling-errors",
+    "id": "206-mutators#handling-errors",
     "title": "Mutators",
     "searchTitle": "Handling Errors",
     "sectionTitle": "Handling Errors",
@@ -2131,7 +2102,7 @@
     "kind": "section"
   },
   {
-    "id": "208-mutators#custom-mutate-url",
+    "id": "207-mutators#custom-mutate-url",
     "title": "Mutators",
     "searchTitle": "Custom Mutate URL",
     "sectionTitle": "Custom Mutate URL",
@@ -2141,7 +2112,7 @@
     "kind": "section"
   },
   {
-    "id": "209-mutators#url-patterns",
+    "id": "208-mutators#url-patterns",
     "title": "Mutators",
     "searchTitle": "URL Patterns",
     "sectionTitle": "URL Patterns",
@@ -2151,7 +2122,7 @@
     "kind": "section"
   },
   {
-    "id": "210-mutators#server-specific-code",
+    "id": "209-mutators#server-specific-code",
     "title": "Mutators",
     "searchTitle": "Server-Specific Code",
     "sectionTitle": "Server-Specific Code",
@@ -2161,27 +2132,27 @@
     "kind": "section"
   },
   {
-    "id": "211-mutators#running-mutators",
+    "id": "210-mutators#running-mutators",
     "title": "Mutators",
     "searchTitle": "Running Mutators",
     "sectionTitle": "Running Mutators",
     "sectionId": "running-mutators",
     "url": "/docs/mutators",
-    "content": "Once you have registered your mutators, you can invoke them with zero.mutate: import {mutators} from 'mutators.ts' import {nanoid} from 'nanoid' zero.mutate( mutators.issue.update({ id: nanoid(), title: 'New title' }) ) Client-generated random IDs from libraries like uuid, ulid, or nanoid work much better with sync engines like Zero. See IDs for more details. Waiting for Results We typically recommend that you \"fire and forget\" mutators. Optimistic mutations make sense when the common case is that a mutation succeeds. If a mutation frequently fails, then showing the user an optimistic result isn't very useful, because it will likely be wrong. That said there are cases where it is nice to know when a write succeeded on either the client or server. One example is if you need to read a row directly after writing it. Zero's local writes are very fast (almost always < 1 frame), but because Zero is backed by IndexedDB, writes are still technically asynchronous and reads directly after a write may not return the new data. You can use the .client promise in this case to wait for a write to complete on the client side: const write = zero.mutate( mutators.issue.insert({ id: nanoid(), title: 'New title' }) ) // issue-123 not guaranteed to be present here. read1 may be undefined. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await client write – almost always less than 1 frame, and same // macrotask, so no browser paint will occur here. const res = await write.client if (res.type === 'error') { console.error('Mutator failed on client', res.error) } // issue-123 definitely can be read now. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) You can also wait for the server write to succeed: const write = zero.mutate( mutators.issue.insert({ id: nanoid(), title: 'New title' }) ) const clientRes = await write.client if (clientRes.type === 'error') { throw new Error( `Mutator failed on client`, clientRes.error ) } // optimistic write guaranteed to be present here, but not // server write. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await server write – this involves a round-trip. const serverRes = await write.server if (serverRes.type === 'error') { throw new Error( `Mutator failed on server`, serverRes.error ) } // issue-123 is written to server and any results are // synced to this client. // read2 could potentially be undefined here, for example if the // server mutator rejected the write. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) If the client-side mutator fails, the .server promise is also rejected with the same error. You don't have to listen to both promises, the server promise covers both cases. There is not yet a way to return data from mutators in the success case. Let us know if you need this.",
+    "content": "Once you have registered your mutators, you can invoke them with zero.mutate: import {mutators} from 'mutators.ts' zero.mutate( mutators.issue.update({ id: crypto.randomUUID(), title: 'New title' }) ) Client-generated random IDs from crypto.randomUUID(), uuid, ulid, or nanoid work much better with sync engines like Zero. See IDs for more details. Waiting for Results We typically recommend that you \"fire and forget\" mutators. Optimistic mutations make sense when the common case is that a mutation succeeds. If a mutation frequently fails, then showing the user an optimistic result isn't very useful, because it will likely be wrong. That said there are cases where it is nice to know when a write succeeded on either the client or server. One example is if you need to read a row directly after writing it. Zero's local writes are very fast (almost always < 1 frame), but because Zero is backed by IndexedDB, writes are still technically asynchronous and reads directly after a write may not return the new data. You can use the .client promise in this case to wait for a write to complete on the client side: const write = zero.mutate( mutators.issue.insert({ id: crypto.randomUUID(), title: 'New title' }) ) // issue-123 not guaranteed to be present here. read1 may be undefined. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await client write – almost always less than 1 frame, and same // macrotask, so no browser paint will occur here. const res = await write.client if (res.type === 'error') { console.error('Mutator failed on client', res.error) } // issue-123 definitely can be read now. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) You can also wait for the server write to succeed: const write = zero.mutate( mutators.issue.insert({ id: crypto.randomUUID(), title: 'New title' }) ) const clientRes = await write.client if (clientRes.type === 'error') { throw new Error( `Mutator failed on client`, clientRes.error ) } // optimistic write guaranteed to be present here, but not // server write. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await server write – this involves a round-trip. const serverRes = await write.server if (serverRes.type === 'error') { throw new Error( `Mutator failed on server`, serverRes.error ) } // issue-123 is written to server and any results are // synced to this client. // read2 could potentially be undefined here, for example if the // server mutator rejected the write. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) If the client-side mutator fails, the .server promise is also rejected with the same error. You don't have to listen to both promises, the server promise covers both cases. There is not yet a way to return data from mutators in the success case. Let us know if you need this.",
     "kind": "section"
   },
   {
-    "id": "212-mutators#waiting-for-results",
+    "id": "211-mutators#waiting-for-results",
     "title": "Mutators",
     "searchTitle": "Waiting for Results",
     "sectionTitle": "Waiting for Results",
     "sectionId": "waiting-for-results",
     "url": "/docs/mutators",
-    "content": "We typically recommend that you \"fire and forget\" mutators. Optimistic mutations make sense when the common case is that a mutation succeeds. If a mutation frequently fails, then showing the user an optimistic result isn't very useful, because it will likely be wrong. That said there are cases where it is nice to know when a write succeeded on either the client or server. One example is if you need to read a row directly after writing it. Zero's local writes are very fast (almost always < 1 frame), but because Zero is backed by IndexedDB, writes are still technically asynchronous and reads directly after a write may not return the new data. You can use the .client promise in this case to wait for a write to complete on the client side: const write = zero.mutate( mutators.issue.insert({ id: nanoid(), title: 'New title' }) ) // issue-123 not guaranteed to be present here. read1 may be undefined. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await client write – almost always less than 1 frame, and same // macrotask, so no browser paint will occur here. const res = await write.client if (res.type === 'error') { console.error('Mutator failed on client', res.error) } // issue-123 definitely can be read now. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) You can also wait for the server write to succeed: const write = zero.mutate( mutators.issue.insert({ id: nanoid(), title: 'New title' }) ) const clientRes = await write.client if (clientRes.type === 'error') { throw new Error( `Mutator failed on client`, clientRes.error ) } // optimistic write guaranteed to be present here, but not // server write. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await server write – this involves a round-trip. const serverRes = await write.server if (serverRes.type === 'error') { throw new Error( `Mutator failed on server`, serverRes.error ) } // issue-123 is written to server and any results are // synced to this client. // read2 could potentially be undefined here, for example if the // server mutator rejected the write. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) If the client-side mutator fails, the .server promise is also rejected with the same error. You don't have to listen to both promises, the server promise covers both cases. There is not yet a way to return data from mutators in the success case. Let us know if you need this.",
+    "content": "We typically recommend that you \"fire and forget\" mutators. Optimistic mutations make sense when the common case is that a mutation succeeds. If a mutation frequently fails, then showing the user an optimistic result isn't very useful, because it will likely be wrong. That said there are cases where it is nice to know when a write succeeded on either the client or server. One example is if you need to read a row directly after writing it. Zero's local writes are very fast (almost always < 1 frame), but because Zero is backed by IndexedDB, writes are still technically asynchronous and reads directly after a write may not return the new data. You can use the .client promise in this case to wait for a write to complete on the client side: const write = zero.mutate( mutators.issue.insert({ id: crypto.randomUUID(), title: 'New title' }) ) // issue-123 not guaranteed to be present here. read1 may be undefined. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await client write – almost always less than 1 frame, and same // macrotask, so no browser paint will occur here. const res = await write.client if (res.type === 'error') { console.error('Mutator failed on client', res.error) } // issue-123 definitely can be read now. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) You can also wait for the server write to succeed: const write = zero.mutate( mutators.issue.insert({ id: crypto.randomUUID(), title: 'New title' }) ) const clientRes = await write.client if (clientRes.type === 'error') { throw new Error( `Mutator failed on client`, clientRes.error ) } // optimistic write guaranteed to be present here, but not // server write. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await server write – this involves a round-trip. const serverRes = await write.server if (serverRes.type === 'error') { throw new Error( `Mutator failed on server`, serverRes.error ) } // issue-123 is written to server and any results are // synced to this client. // read2 could potentially be undefined here, for example if the // server mutator rejected the write. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) If the client-side mutator fails, the .server promise is also rejected with the same error. You don't have to listen to both promises, the server promise covers both cases. There is not yet a way to return data from mutators in the success case. Let us know if you need this.",
     "kind": "section"
   },
   {
-    "id": "213-mutators#permissions",
+    "id": "212-mutators#permissions",
     "title": "Mutators",
     "searchTitle": "Permissions",
     "sectionTitle": "Permissions",
@@ -2191,7 +2162,7 @@
     "kind": "section"
   },
   {
-    "id": "214-mutators#dropping-down-to-raw-sql",
+    "id": "213-mutators#dropping-down-to-raw-sql",
     "title": "Mutators",
     "searchTitle": "Dropping Down to Raw SQL",
     "sectionTitle": "Dropping Down to Raw SQL",
@@ -2201,7 +2172,7 @@
     "kind": "section"
   },
   {
-    "id": "215-mutators#notifications-and-async-work",
+    "id": "214-mutators#notifications-and-async-work",
     "title": "Mutators",
     "searchTitle": "Notifications and Async Work",
     "sectionTitle": "Notifications and Async Work",
@@ -2211,7 +2182,7 @@
     "kind": "section"
   },
   {
-    "id": "216-mutators#custom-mutate-implementation",
+    "id": "215-mutators#custom-mutate-implementation",
     "title": "Mutators",
     "searchTitle": "Custom Mutate Implementation",
     "sectionTitle": "Custom Mutate Implementation",
@@ -2235,7 +2206,7 @@
     "kind": "page"
   },
   {
-    "id": "217-open-source#business-model",
+    "id": "216-open-source#business-model",
     "title": "Zero is Open Source Software",
     "searchTitle": "Business Model",
     "sectionTitle": "Business Model",
@@ -2287,7 +2258,7 @@
     "kind": "page"
   },
   {
-    "id": "218-otel#grafana-cloud-walkthrough",
+    "id": "217-otel#grafana-cloud-walkthrough",
     "title": "OpenTelemetry",
     "searchTitle": "Grafana Cloud Walkthrough",
     "sectionTitle": "Grafana Cloud Walkthrough",
@@ -2297,7 +2268,7 @@
     "kind": "section"
   },
   {
-    "id": "219-otel#distributed-tracing",
+    "id": "218-otel#distributed-tracing",
     "title": "OpenTelemetry",
     "searchTitle": "Distributed Tracing",
     "sectionTitle": "Distributed Tracing",
@@ -2307,7 +2278,7 @@
     "kind": "section"
   },
   {
-    "id": "220-otel#metrics-reference",
+    "id": "219-otel#metrics-reference",
     "title": "OpenTelemetry",
     "searchTitle": "Metrics Reference",
     "sectionTitle": "Metrics Reference",
@@ -2317,7 +2288,7 @@
     "kind": "section"
   },
   {
-    "id": "221-otel#zeroserver",
+    "id": "220-otel#zeroserver",
     "title": "OpenTelemetry",
     "searchTitle": "zero.server",
     "sectionTitle": "zero.server",
@@ -2327,7 +2298,7 @@
     "kind": "section"
   },
   {
-    "id": "222-otel#zeroreplica",
+    "id": "221-otel#zeroreplica",
     "title": "OpenTelemetry",
     "searchTitle": "zero.replica",
     "sectionTitle": "zero.replica",
@@ -2337,7 +2308,7 @@
     "kind": "section"
   },
   {
-    "id": "223-otel#zeroreplication",
+    "id": "222-otel#zeroreplication",
     "title": "OpenTelemetry",
     "searchTitle": "zero.replication",
     "sectionTitle": "zero.replication",
@@ -2347,7 +2318,7 @@
     "kind": "section"
   },
   {
-    "id": "224-otel#zerosync",
+    "id": "223-otel#zerosync",
     "title": "OpenTelemetry",
     "searchTitle": "zero.sync",
     "sectionTitle": "zero.sync",
@@ -2357,7 +2328,7 @@
     "kind": "section"
   },
   {
-    "id": "225-otel#zeromutation",
+    "id": "224-otel#zeromutation",
     "title": "OpenTelemetry",
     "searchTitle": "zero.mutation",
     "sectionTitle": "zero.mutation",
@@ -2371,7 +2342,7 @@
     "title": "Supported Postgres Features",
     "searchTitle": "Supported Postgres Features",
     "url": "/docs/postgres-support",
-    "content": "Postgres has a massive feature set, and Zero supports a growing subset of it. Object Names Table and column names must begin with a letter or underscore This can be followed by letters, numbers, underscores, and hyphens Regex: /^[A-Za-z_]+[A-Za-z0-9_-]*$/ The column name _0_version is reserved for internal use Object Types Tables are synced. Views are not synced. generated as identity columns are synced. In Postgres 18+, generated stored columns are synced. In lower Postgres versions they aren't. Indexes aren't synced per-se, but we do implicitly add indexes to the replica that match the upstream indexes. In the future, this will be customizable. Column Types Postgres Type Type to put in schema.ts Resulting JS/TS Type All numeric types number number char, varchar, text, uuid string string bool boolean boolean date, timestamp, timestampz, time, timetz number number json, jsonb json JSONValue enum enumeration string T[] where T is a supported Postgres type (but please see ⚠️ below) json<U[]> where U is the schema.ts type for T V[] where V is the JS/TS type for T Zero will sync arrays to the client, but there is no support for filtering or joining on array elements yet in ZQL. Other Postgres column types aren’t supported. They will be ignored when replicating (the synced data will be missing that column) and you will get a warning when zero-cache starts up. If your schema has a pg type not listed here, you can support it in Zero by using a trigger to map it to some type that Zero can support. For example if you have a GIS polygon type in the column my_poly polygon, you can use a trigger to map it to a my_poly_json json column. You could either use another trigger to map in the reverse direction to support changes for writes, or you could use a mutator to write to the polygon type directly on the server. Let us know if the lack of a particular column type is hindering your use of Zero. It can likely be added. Column Defaults Default values are allowed in the Postgres schema, but there currently is no way to use them from a Zero app. An insert() mutation requires all columns to be specified, except when columns are nullable (in which case, they default to null). Since there is no way to leave non-nullable columns off the insert on the client, there is no way for PG to apply the default. This is a known issue and will be fixed in the future. IDs It is strongly recommended to use client-generated random strings like uuid, ulid, nanoid, etc for primary keys. This makes optimistic creation and updates much easier. Imagine that the PK of your table is an auto-incrementing integer. If you optimistically create an entity of this type, you will have to give it some ID – the type will require it locally, but also if you want to optimistically create relationships to this row you’ll need an ID. You could sync the highest value seen for that table, but there are race conditions and it is possible for that ID to be taken by the time the creation makes it to the server. Your database can resolve this and assign the next ID, but now the relationships you created optimistically will be against the wrong row. Blech. GUIDs makes a lot more sense in synced applications. If your table has a natural key you can use that and it has less problems. But there is still the chance for a conflict. Imagine you are modeling orgs and you choose domainName as the natural key. It is possible for a race to happen and when the creation gets to the server, somebody has already chosen that domain name. In that case, the best thing to do is reject the write and show the user an error. If you want to have a short auto-incrementing numeric ID for UX reasons (i.e., a bug number), that is possible - see this video. Primary Keys Each table synced with Zero must have either a primary key or at least one unique index. This is needed so that Zero can identify rows during sync, to distinguish between an edit and a remove/add. Multi-column primary and foreign keys are supported. Limiting Replication There are two levels of replication to consider with Zero: replicating from Postgres to zero-cache, and from zero-cache to the Zero browser client. zero-cache replication By default, Zero creates a Postgres publication that publishes all tables in the public schema to zero-cache. To limit which tables or columns are replicated to zero-cache, you can create a Postgres publication with the tables and columns you want: CREATE PUBLICATION zero_data FOR TABLE users (col1, col2, col3, ...), issues, comments; Then, specify this publication in the App Publications zero-cache option. Browser client replication You can use Read Permissions to control which rows are synced from the zero-cache replica to actual clients (e.g., web browsers). Currently, Permissions can limit which tables and rows can be replicated to the client. In the near future, you'll also be able to use Permissions to limit syncing individual columns. Until then, you will need to create a publication to control which columns are synced to zero-cache. Schema changes All Postgres schema changes are supported. See Schema Migrations.",
+    "content": "Postgres has a massive feature set, and Zero supports a growing subset of it. Object Names Table and column names must begin with a letter or underscore This can be followed by letters, numbers, underscores, and hyphens Regex: /^[A-Za-z_]+[A-Za-z0-9_-]*$/ The column name _0_version is reserved for internal use Object Types Tables are synced. Views are not synced. generated as identity columns are synced. In Postgres 18+, generated stored columns are synced. In lower Postgres versions they aren't. Indexes aren't synced per-se, but we do implicitly add indexes to the replica that match the upstream indexes. In the future, this will be customizable. Column Types Postgres Type Type to put in schema.ts Resulting JS/TS Type All numeric types number number char, varchar, text, uuid string string bool boolean boolean date, timestamp, timestampz, time, timetz number number json, jsonb json JSONValue enum enumeration string T[] where T is a supported Postgres type (but please see ⚠️ below) json<U[]> where U is the schema.ts type for T V[] where V is the JS/TS type for T Zero will sync arrays to the client, but there is no support for filtering or joining on array elements yet in ZQL. Other Postgres column types aren’t supported. They will be ignored when replicating (the synced data will be missing that column) and you will get a warning when zero-cache starts up. If your schema has a pg type not listed here, you can support it in Zero by using a trigger to map it to some type that Zero can support. For example if you have a GIS polygon type in the column my_poly polygon, you can use a trigger to map it to a my_poly_json json column. You could either use another trigger to map in the reverse direction to support changes for writes, or you could use a mutator to write to the polygon type directly on the server. Let us know if the lack of a particular column type is hindering your use of Zero. It can likely be added. Column Defaults Default values are allowed in the Postgres schema, but there currently is no way to use them from a Zero app. An insert() mutation requires all columns to be specified, except when columns are nullable (in which case, they default to null). Since there is no way to leave non-nullable columns off the insert on the client, there is no way for PG to apply the default. This is a known issue and will be fixed in the future. IDs It is strongly recommended to use client-generated random strings like crypto.randomUUID(), uuid, ulid, nanoid, etc for primary keys. This makes optimistic creation and updates much easier. Imagine that the PK of your table is an auto-incrementing integer. If you optimistically create an entity of this type, you will have to give it some ID – the type will require it locally, but also if you want to optimistically create relationships to this row you’ll need an ID. You could sync the highest value seen for that table, but there are race conditions and it is possible for that ID to be taken by the time the creation makes it to the server. Your database can resolve this and assign the next ID, but now the relationships you created optimistically will be against the wrong row. Blech. GUIDs makes a lot more sense in synced applications. If your table has a natural key you can use that and it has less problems. But there is still the chance for a conflict. Imagine you are modeling orgs and you choose domainName as the natural key. It is possible for a race to happen and when the creation gets to the server, somebody has already chosen that domain name. In that case, the best thing to do is reject the write and show the user an error. If you want to have a short auto-incrementing numeric ID for UX reasons (i.e., a bug number), that is possible - see this video. Primary Keys Each table synced with Zero must have either a primary key or at least one unique index. This is needed so that Zero can identify rows during sync, to distinguish between an edit and a remove/add. Multi-column primary and foreign keys are supported. Limiting Replication There are two levels of replication to consider with Zero: replicating from Postgres to zero-cache, and from zero-cache to the Zero browser client. zero-cache replication By default, Zero creates a Postgres publication that publishes all tables in the public schema to zero-cache. To limit which tables or columns are replicated to zero-cache, you can create a Postgres publication with the tables and columns you want: CREATE PUBLICATION zero_data FOR TABLE users (col1, col2, col3, ...), issues, comments; Then, specify this publication in the App Publications zero-cache option. Browser client replication You can use Read Permissions to control which rows are synced from the zero-cache replica to actual clients (e.g., web browsers). Currently, Permissions can limit which tables and rows can be replicated to the client. In the near future, you'll also be able to use Permissions to limit syncing individual columns. Until then, you will need to create a publication to control which columns are synced to zero-cache. Schema changes All Postgres schema changes are supported. See Schema Migrations.",
     "headings": [
       {
         "text": "Object Names",
@@ -2417,7 +2388,7 @@
     "kind": "page"
   },
   {
-    "id": "226-postgres-support#object-names",
+    "id": "225-postgres-support#object-names",
     "title": "Supported Postgres Features",
     "searchTitle": "Object Names",
     "sectionTitle": "Object Names",
@@ -2427,7 +2398,7 @@
     "kind": "section"
   },
   {
-    "id": "227-postgres-support#object-types",
+    "id": "226-postgres-support#object-types",
     "title": "Supported Postgres Features",
     "searchTitle": "Object Types",
     "sectionTitle": "Object Types",
@@ -2437,7 +2408,7 @@
     "kind": "section"
   },
   {
-    "id": "228-postgres-support#column-types",
+    "id": "227-postgres-support#column-types",
     "title": "Supported Postgres Features",
     "searchTitle": "Column Types",
     "sectionTitle": "Column Types",
@@ -2447,7 +2418,7 @@
     "kind": "section"
   },
   {
-    "id": "229-postgres-support#column-defaults",
+    "id": "228-postgres-support#column-defaults",
     "title": "Supported Postgres Features",
     "searchTitle": "Column Defaults",
     "sectionTitle": "Column Defaults",
@@ -2457,17 +2428,17 @@
     "kind": "section"
   },
   {
-    "id": "230-postgres-support#ids",
+    "id": "229-postgres-support#ids",
     "title": "Supported Postgres Features",
     "searchTitle": "IDs",
     "sectionTitle": "IDs",
     "sectionId": "ids",
     "url": "/docs/postgres-support",
-    "content": "It is strongly recommended to use client-generated random strings like uuid, ulid, nanoid, etc for primary keys. This makes optimistic creation and updates much easier. Imagine that the PK of your table is an auto-incrementing integer. If you optimistically create an entity of this type, you will have to give it some ID – the type will require it locally, but also if you want to optimistically create relationships to this row you’ll need an ID. You could sync the highest value seen for that table, but there are race conditions and it is possible for that ID to be taken by the time the creation makes it to the server. Your database can resolve this and assign the next ID, but now the relationships you created optimistically will be against the wrong row. Blech. GUIDs makes a lot more sense in synced applications. If your table has a natural key you can use that and it has less problems. But there is still the chance for a conflict. Imagine you are modeling orgs and you choose domainName as the natural key. It is possible for a race to happen and when the creation gets to the server, somebody has already chosen that domain name. In that case, the best thing to do is reject the write and show the user an error. If you want to have a short auto-incrementing numeric ID for UX reasons (i.e., a bug number), that is possible - see this video.",
+    "content": "It is strongly recommended to use client-generated random strings like crypto.randomUUID(), uuid, ulid, nanoid, etc for primary keys. This makes optimistic creation and updates much easier. Imagine that the PK of your table is an auto-incrementing integer. If you optimistically create an entity of this type, you will have to give it some ID – the type will require it locally, but also if you want to optimistically create relationships to this row you’ll need an ID. You could sync the highest value seen for that table, but there are race conditions and it is possible for that ID to be taken by the time the creation makes it to the server. Your database can resolve this and assign the next ID, but now the relationships you created optimistically will be against the wrong row. Blech. GUIDs makes a lot more sense in synced applications. If your table has a natural key you can use that and it has less problems. But there is still the chance for a conflict. Imagine you are modeling orgs and you choose domainName as the natural key. It is possible for a race to happen and when the creation gets to the server, somebody has already chosen that domain name. In that case, the best thing to do is reject the write and show the user an error. If you want to have a short auto-incrementing numeric ID for UX reasons (i.e., a bug number), that is possible - see this video.",
     "kind": "section"
   },
   {
-    "id": "231-postgres-support#primary-keys",
+    "id": "230-postgres-support#primary-keys",
     "title": "Supported Postgres Features",
     "searchTitle": "Primary Keys",
     "sectionTitle": "Primary Keys",
@@ -2477,7 +2448,7 @@
     "kind": "section"
   },
   {
-    "id": "232-postgres-support#limiting-replication",
+    "id": "231-postgres-support#limiting-replication",
     "title": "Supported Postgres Features",
     "searchTitle": "Limiting Replication",
     "sectionTitle": "Limiting Replication",
@@ -2487,7 +2458,7 @@
     "kind": "section"
   },
   {
-    "id": "233-postgres-support#zero-cache-replication",
+    "id": "232-postgres-support#zero-cache-replication",
     "title": "Supported Postgres Features",
     "searchTitle": "zero-cache replication",
     "sectionTitle": "zero-cache replication",
@@ -2497,7 +2468,7 @@
     "kind": "section"
   },
   {
-    "id": "234-postgres-support#browser-client-replication",
+    "id": "233-postgres-support#browser-client-replication",
     "title": "Supported Postgres Features",
     "searchTitle": "Browser client replication",
     "sectionTitle": "Browser client replication",
@@ -2507,7 +2478,7 @@
     "kind": "section"
   },
   {
-    "id": "235-postgres-support#schema-changes",
+    "id": "234-postgres-support#schema-changes",
     "title": "Supported Postgres Features",
     "searchTitle": "Schema changes",
     "sectionTitle": "Schema changes",
@@ -2521,7 +2492,7 @@
     "title": "Previews",
     "searchTitle": "Previews",
     "url": "/docs/previews",
-    "content": "Most teams deploying to platforms like Vercel use unique hostnames per preview build. Zero supports this directly, and you do not need one zero-cache instance per preview deployment. Overview Preview support has two parts: Configure zero-cache with allowed URL patterns for both query and mutate endpoints. In the browser, pick the concrete queryURL and mutateURL based on the current hostname when constructing Zero. You must do this for both endpoints. Configure Allowed Endpoint Patterns Set ZERO_QUERY_URL and ZERO_MUTATE_URL to include your production URL and your preview URL pattern: ZERO_QUERY_URL=\"https://myapp.com/api/zero/query,https://my-app-*.preview.myapp.com/api/zero/query\" ZERO_MUTATE_URL=\"https://myapp.com/api/zero/mutate,https://my-app-*.preview.myapp.com/api/zero/mutate\" zero-cache will only allow client-selected URLs that match one of the configured values/patterns. Choose Endpoint URLs in the Client When you construct Zero on the client, derive URLs from location.origin and pass both queryURL and mutateURL: function getZeroEndpoints() { const origin = location.origin return { queryURL: `${origin}/api/zero/query`, mutateURL: `${origin}/api/zero/mutate` } } const {queryURL, mutateURL} = getZeroEndpoints() const zero = new Zero({ schema, userID, auth, queryURL, mutateURL }) For full URL pattern syntax details, see Queries URL Patterns. Schema Changes in Previews If a preview includes a schema change, you should implement the schema change first and do it in the same backwards-compatible way documented in Schema Change Process (expand → migrate → contract). After that, implement the rest of the preview behavior. In practice, this means: Apply the compatible schema expansion first. Ship the preview app/API behavior as a preview, using the new schema. Run contract cleanup later, after old clients are gone. If desired, previews can share a single staging database. Neon-style per-preview database branching is not well supported with Zero today, because each upstream database typically needs its own zero-cache.",
+    "content": "Most teams deploying to platforms like Vercel use unique hostnames per preview build. Zero supports this directly, and you do not need one zero-cache instance per preview deployment. Overview Preview support has two parts: Configure zero-cache with allowed URL patterns for both query and mutate endpoints. In the browser, pick the concrete queryURL and mutateURL based on the current hostname when constructing Zero. You must do this for both endpoints. Configure Allowed Endpoint Patterns Set ZERO_QUERY_URL and ZERO_MUTATE_URL to include your production URL and your preview URL pattern: ZERO_QUERY_URL=\"https://myapp.com/api/zero/query,https://my-app-*.preview.myapp.com/api/zero/query\" ZERO_MUTATE_URL=\"https://myapp.com/api/zero/mutate,https://my-app-*.preview.myapp.com/api/zero/mutate\" zero-cache will only allow client-selected URLs that match one of the configured values/patterns. Choose Endpoint URLs in the Client When you construct Zero on the client, derive URLs from location.origin and pass both queryURL and mutateURL: function getZeroEndpoints() { const origin = location.origin return { queryURL: `${origin}/api/zero/query`, mutateURL: `${origin}/api/zero/mutate` } } const {queryURL, mutateURL} = getZeroEndpoints() const zero = new Zero({ schema, userID, auth, queryURL, mutateURL }) For full URL pattern syntax details, see Queries URL Patterns. Schema Changes in Previews If a preview includes a schema change, you should implement the schema change first and do it in the same backwards-compatible way documented in Schema Changes (expand → migrate → contract). After that, implement the rest of the preview behavior. In practice, this means: Apply the compatible schema expansion first. Ship the preview app/API behavior as a preview, using the new schema. Run contract cleanup later, after old clients are gone. If desired, previews can share a single staging database. Neon-style per-preview database branching is not well supported with Zero today, because each upstream database typically needs its own zero-cache.",
     "headings": [
       {
         "text": "Overview",
@@ -2543,7 +2514,7 @@
     "kind": "page"
   },
   {
-    "id": "236-previews#overview",
+    "id": "235-previews#overview",
     "title": "Previews",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -2553,7 +2524,7 @@
     "kind": "section"
   },
   {
-    "id": "237-previews#configure-allowed-endpoint-patterns",
+    "id": "236-previews#configure-allowed-endpoint-patterns",
     "title": "Previews",
     "searchTitle": "Configure Allowed Endpoint Patterns",
     "sectionTitle": "Configure Allowed Endpoint Patterns",
@@ -2563,7 +2534,7 @@
     "kind": "section"
   },
   {
-    "id": "238-previews#choose-endpoint-urls-in-the-client",
+    "id": "237-previews#choose-endpoint-urls-in-the-client",
     "title": "Previews",
     "searchTitle": "Choose Endpoint URLs in the Client",
     "sectionTitle": "Choose Endpoint URLs in the Client",
@@ -2573,13 +2544,13 @@
     "kind": "section"
   },
   {
-    "id": "239-previews#schema-changes-in-previews",
+    "id": "238-previews#schema-changes-in-previews",
     "title": "Previews",
     "searchTitle": "Schema Changes in Previews",
     "sectionTitle": "Schema Changes in Previews",
     "sectionId": "schema-changes-in-previews",
     "url": "/docs/previews",
-    "content": "If a preview includes a schema change, you should implement the schema change first and do it in the same backwards-compatible way documented in Schema Change Process (expand → migrate → contract). After that, implement the rest of the preview behavior. In practice, this means: Apply the compatible schema expansion first. Ship the preview app/API behavior as a preview, using the new schema. Run contract cleanup later, after old clients are gone. If desired, previews can share a single staging database. Neon-style per-preview database branching is not well supported with Zero today, because each upstream database typically needs its own zero-cache.",
+    "content": "If a preview includes a schema change, you should implement the schema change first and do it in the same backwards-compatible way documented in Schema Changes (expand → migrate → contract). After that, implement the rest of the preview behavior. In practice, this means: Apply the compatible schema expansion first. Ship the preview app/API behavior as a preview, using the new schema. Run contract cleanup later, after old clients are gone. If desired, previews can share a single staging database. Neon-style per-preview database branching is not well supported with Zero today, because each upstream database typically needs its own zero-cache.",
     "kind": "section"
   },
   {
@@ -2587,7 +2558,7 @@
     "title": "Queries",
     "searchTitle": "Queries",
     "url": "/docs/queries",
-    "content": "Queries are how you read and sync data with Zero. Here's a simple example: import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from 'schema.ts' export const queries = defineQueries({ postsByAuthor: defineQuery( z.object({authorID: z.string()}), ({args: {authorID}}) => zql.post.where('authorID', authorID) ) }) Architecture A copy of each query exists on both the client and on your server: Often the implementations will be the same, and you can just share their code. This is easy with full-stack frameworks like TanStack Start or Next.js. But the implementations don't have to be the same, or even compute the same result. For example, the server can add extra filters to enforce permissions that the client query does not. Life of a Query When a query is invoked, it initially runs on the client, against the client-side datastore. Any matching data is returned immediately and the user sees instant results. In the background, the name and arguments for the query are sent to zero-cache. Zero-cache calls the queries endpoint on your server to get the ZQL for the query. Your server looks up its implementation of the query, invokes it, and returns the resulting ZQL expression to zero-cache. Zero-cache then runs this ZQL against the server-side data. The initial server result is sent back to the client and the client query updates in response. zero-cache receives updates from Postgres via logical replication. It updates affected queries and sends row changes back to the client, which updates the client query, and the user sees the changes. Defining Queries Basics Create a query using defineQuery. The only required argument is a QueryFn, which must return a ZQL expression: import {zql} from 'schema.ts' const allPostsQueryDef = defineQuery(() => zql.post) Arguments The QueryFn can take a single args parameter. To enable this, pass a validator to defineQuery: import {zql} from 'schema.ts' const postsByAuthor = defineQuery( z.object({authorID: z.string().optional()}), ({args: {authorID}}) => { let q = zql.post if (authorID !== undefined) { q = q.where('authorID', authorID) } return q } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. Zero queries run on both the client and on your server. In the server case, the parameters come from the client and are untrusted. The validator ensures the data passed to your query is of the expected type. Query Registries The result of defineQuery is a QueryDefinition. By itself this isn't super useful. You need to register it using defineQueries: export const queries = defineQueries({ posts: { all: allPostsQueryDef } }) Typically these are done together in one step: export const queries = defineQueries({ posts: { all: defineQuery(() => zql.post) } }) The result of defineQueries is called a QueryRegistry. Each field in the registry is a callable Query that you can use to read data: import {zero} from 'zero.ts' import {queries} from 'queries.ts' const allPosts = await zero.run(queries.posts.all()) Query Names Each Query has a queryName which is computed by defineQueries. This name is later sent to your server to identify the query to run: console.log(queries.posts.all.queryName) // \"posts.all\" Context Query parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero queries also support the concept of a context object. Access your context with the ctx parameter to your query: const myPostsQuery = defineQuery(({ctx: {userID}}) => { // User cannot control context.userID, so this safely // restricts the query to the user's own posts. return zql.post.where('authorID', userID) }) queries.ts By convention, all queries for an application are listed in a central queries.ts file. This allows them to be easily used on both the client and server: import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema.ts' export const queries = defineQueries({ posts: { get: defineQuery(z.string(), id => zql.post.where('id', id) ), byAuthor: defineQuery( z.object({ authorID: z.string(), includeDrafts: z.boolean().optional() }), ({args: {authorID, includeDrafts}}) => { let q = zql.post.where('authorID', authorID) if (!includeDrafts) { q = q.where('isDraft', false) } return q } ) } }) You can use as many levels of nesting as you want to organize your queries. As your application grows, you can move queries to different files to keep them organized: // posts.ts export const postQueries = { get: defineQuery(z.string(), id => zql.post.where('id', id) ) // ... } // users.ts export const userQueries = { byRole: defineQuery(z.string(), role => zql.user.where('role', role) ) // ... } // queries.ts import {postQueries} from './posts.ts' import {userQueries} from './users.ts' export const queries = defineQueries({ posts: postQueries, users: userQueries }) Because defineQueries establishes the full name for each query (i.e., posts.get, users.byRole), it should only be used once at the top level of your queries.ts file. Server Setup In order for queries to sync, you must provide an implementation of the query endpoint on your server. zero-cache calls this endpoint to resolve each query to ZQL that it can run. Registering the Endpoint Use ZERO_QUERY_URL to tell zero-cache where to find your query implementation: export ZERO_QUERY_URL=\"http://localhost:3000/api/zero/query\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleQueryRequest and mustGetQuery functions to implement the endpoint. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' app.post('/api/zero/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) handleQueryRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetQuery looks up the query in the registry and throws an error if not found. The query.fn function is your query implementation wrapped in the validator you provided. These examples have only public queries, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the query handler. See Authentication. Custom Query URL By default, Zero sends queries to the URL specified in the ZERO_QUERY_URL parameter in the zero-cache config. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in ZERO_QUERY_URL: ZERO_QUERY_URL='https://api.example.com/query,https://api.staging.example.com/query' Then choose one of those URLs by passing it to queryURL on the Zero constructor: const zero = new Zero({ schema, queries, queryURL: 'https://api.staging.example.com/query' }) URL Patterns The strings listed in ZERO_QUERY_URL can also be URLPatterns: ZERO_QUERY_URL=\"https://mybranch-*.preview.myapp.com/query\" This queries URL will allow clients to choose URLs like: https://mybranch-aaa.preview.myapp.com/query ✅ https://mybranch-bbb.preview.myapp.com/query ✅ But rejects URLs like: https://preview.myapp.com/query ❌ (missing subdomain) https://malicious.com/query ❌ (different domain) https://mybranch-123.preview.myapp.com/query/extra ❌ (extra path) https://mybranch-123.preview.myapp.com/other ❌ (different path) Because URLPattern is a web standard, you can test them right in your browser: For more information, see the URLPattern docs. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints. Running Queries Reactively The most common way to use queries is with the useQuery reactive hooks from the React or SolidJS bindings (or the equivalent low-level API): import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(queries.posts.get('user123')) return posts.map(post => ( <div key={post.id}>{post.title}</div> )) }import {useQuery} from '@rocicorp/zero/solid' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(() => queries.posts.get('user123') ) return ( <For each={posts()}> {post => <div key={post.id}>{post.title}</div>} </For> ) }import {queries} from 'zero/queries.ts' import {zero} from 'zero.ts' const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) for (let post of postsView.data) { console.log(post.title) } // updates as the underlying data changes postsView.addListener(posts => { console.log('posts', posts) }) These functions allow you to automatically re-render UI when a query changes. Once You usually want to subscribe to a query in a reactive UI, but every so often you'll need to run a query just once. To do this, use zero.run(): const results = await zero.run( queries.issues.byPriority('high') ) By default, run() only returns results that are currently available on the client. That is, it returns the data that would be given for result.type === 'unknown'. If you want to wait for the server to return results, pass {type: 'complete'} to run: const results = await zero.run( queries.issues.byPriority('high'), {type: 'complete'} ) For Preloading Almost all Zero apps will want to preload some data in order to maximize the feel of instantaneous UI transitions. Because preload queries are often much larger than a screenful of UI, Zero provides a special zero.preload() method to avoid the overhead of materializing the result into JS objects: // Preload a large number of the inbox query results. zero.preload( queries.issues.inbox({ sort: 'created', sortDirection: 'desc', limit: 1000 }) ) Missing Data Because Zero returns local results immediately and server results asynchronously, displaying \"not found\" / 404 UI can be slightly tricky. If you just use a simple existence check, you will often see the 404 UI flicker while the server result loads: const [issue] = useQuery(queries.issues.get('some-id')) // ❌ This causes flickering of the UI if (!issue) { return <div>404 Not Found</div> } else { return <div>{issue.title}</div> }const [issue] = useQuery(() => queries.issues.get('some-id') ) return ( <Show when={issue()}> {resolved => ( <Show when={resolved} fallback={<div>404 Not Found</div>} > <div>{resolved.title}</div> </Show> )} </Show> )const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) postsView.addListener(posts => { // ❌ This is updated as data comes in console.log('posts', posts) }) To do this correctly, only display the \"not found\" UI when the result type is complete. This way the 404 page is slow but pages with data are still just as fast: const [issue, issueResult] = useQuery( queries.issues.get('some-id') ) if (!issue && issueResult.type === 'complete') { return <div>404 Not Found</div> } if (!issue) { return null } return <div>{issue.title}</div>const [issue, issueResult] = useQuery(() => queries.issues.get('some-id') ) return ( <Switch fallback={null}> <Match when={issue()}> {resolved => <div>{resolved.title}</div>} </Match> <Match when={issueResult().type === 'complete'}> <div>404 Not Found</div> </Match> </Switch> )const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) postsView.addListener((posts, resultType) => { if (resultType === 'complete') { console.log('posts', posts) } }) Partial Data Zero immediately returns the data for a query it has on the client, then falls back to the server for any missing data. Sometimes it's useful to know the difference between these two types of results. To do so, use the result from useQuery: const [issues, issuesResult] = useQuery( queries.issues.inbox() ) if (issuesResult.type === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') }const [issues, issuesResult] = useQuery(() => queries.issues.inbox() ) if (issuesResult().type === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') }const view = zero.materialize(queries.issues.inbox()) view.addListener((issues, resultType) => { if (resultType === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') } }) The possible values of result.type are currently complete and unknown. The complete value is currently only returned when Zero has received the server result. In the future, Zero will be able to return this result type when it knows that all possible data for this query is already available locally. Additionally, we plan to add a prefix result for when the data is known to be a prefix of the complete result. See Consistency for more information. Handling Errors If the queries endpoint throws an application or parse error, zero-cache will report it to the client using the type and error fields on the query details object: const [posts, postsResult] = useQuery( queries.posts.byAuthorID('user123') ) if (postsResult.type === 'error') { return ( <div> Error loading posts: {postsResult.error.message} </div> ) }const [posts, postsResult] = useQuery(() => queries.posts.byAuthorID('user123') ) return ( <Switch> <Match when={postsResult().type === 'error'}> <div> Error loading posts: {postsResult().error.message} </div> </Match> </Switch> )// Materialize a view of a query const postsView = queries.posts .byAuthorID('user123') .materialize() postsView.addListener((posts, resultType, error) => { if (resultType === 'error') { console.error('Error loading posts', error) } }) See Connection Status for how HTTP or network errors from the queries endpoint are handled. Granular Updates You can use the materialize() method to create a view that you can listen to for changes. However, this will only tell you when the view has changed and give you the complete new result. It won't tell you what changed. To know what changed, you can create your own custom View implementation: // Inside the View class // Instead of storing the change, we invoke some callback push(change: Change): void { switch (change.type) { case 'add': this.#onAdd?.(change) break case 'remove': this.#onRemove?.(change) break case 'edit': this.#onEdit?.(change) break case 'child': this.#onChild?.(change) break default: throw new Error(`Unknown change type: ${change['type']}`) } } For examples, see the View implementations in zero-vue or zero-solid. Query Caching Queries can be either active or cached. An active query is one that is currently being used by the application. Cached queries are not currently in use, but continue syncing in case they are needed again soon. Queries are deactivated according to how they were created: For useQuery(), the UI unmounts the component (which calls destroy() under the covers). For preload(), the UI calls cleanup() on the return value of preload(). For run(), queries are automatically deactivated immediately after the result is returned. For materialize() queries, the UI calls destroy() on the view. Additionally when a Zero instance closes, all active queries are automatically deactivated. This also happens when the containing page or script is unloaded. TTLs Each query has a ttl that controls how long it stays cached. If the user closes all tabs for your app, Zero stops running and the time that elapses doesn't count toward any TTLs. You do not need to account for such time when choosing a TTL – you only need to account for time your app is running without a query. TTL Defaults In most cases, the default TTL should work well: preload() queries default to ttl:'none', meaning they are not cached at all, and will stop syncing immediately when deactivated. But because preload() queries are typically registered at app startup and never shutdown, and because the ttl clock only ticks while Zero is running, this means that preload queries never get unregistered. Other queries have a default ttl of 5m (five minutes). Setting Different TTLs You can override the default TTL with the ttl parameter: const [user] = useQuery( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero.preload(queries.posts.byAuthorID('user123'), { ttl: '5m' })const [user] = useQuery( () => queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero().preload(queries.posts.byAuthorID('user123'), { ttl: '5m' })// run() const user = await zero.run( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // materialize() const view = zero.materialize( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero.preload(queries.posts.byAuthorID('user123'), { ttl: '5m' }) TTLs up to 10m (ten minutes) are currently supported. The following formats are allowed: Why Zero TTLs are Short Zero queries are not free. Just as in any database, queries consume resources on both the client and server. Memory is used to keep metadata about the query, and disk storage is used to keep the query's current state. We do drop this state after we haven't heard from a client for awhile, but this is only a partial improvement. If the client returns, we have to re-run the query to get the latest data. This means that we do not actually want to keep queries active unless there is a good chance they will be needed again soon. The default Zero TTL values might initially seem too short, but they are designed to work well with the way Zero's TTL clock works and strike a good balance between keeping queries alive long enough to be useful, while not keeping them alive so long that they consume resources unnecessarily. Local-Only Queries It can sometimes be useful to run queries only on the client. For example, to implement typeahead search, it really doesn't make sense to register a query with the server for every single keystroke. Zero doesn't yet have a way to run named queries local-only, but you can run ZQL expressions locally by passing them anywhere a query is supported. For example, to subscribe to a local-only query: // Queries the already synced data for issues, // without syncing more data. const [issues] = useQuery( zql.issue.orderBy('created', 'desc').limit(10) )// Queries the already synced data for issues, // without syncing more data. const [issues] = useQuery(() => zql.issue.orderBy('created', 'desc').limit(10) )// Queries the already synced data for issues, // without syncing more data. const view = z.materialize( zql.issue.orderBy('created', 'desc').limit(10) ) view.addListener(issues => { console.log('issues', issues) }) Custom Server Implementation It is possible to implement the ZERO_QUERY_URL endpoint without using Zero's TypeScript libraries, or even in a different language entirely. The endpoint receives a POST request with a JSON body of the form: type QueriesRequestBody = { id: string name: string args: readonly ReadonlyJSONValue[] }[] And responds with: type QueriesResponseBody = ( | { id: string name: string // See https://github.com/rocicorp/mono/blob/main/packages/zero-protocol/src/ast.ts ast: AST } | { error: 'app' id: string name: string details: ReadonlyJSONValue } | { error: 'zero' id: string name: string details: ReadonlyJSONValue } | { error: 'http' id: string name: string status: number details: ReadonlyJSONValue } )[] Consistency Zero always syncs a consistent partial replica of the backend database to the client. This avoids many common consistency issues that come up in classic web applications. But there are still some consistency issues to be aware of when using Zero. For example, imagine that you have a bug database w/ 10k issues. You preload the first 1k issues sorted by created. The user then does a query of issues assigned to themselves, sorted by created. Among the 1k issues that were preloaded imagine 100 are found that match the query. Since the data we preloaded is in the same order as this query, we are guaranteed that any local results found will be a prefix of the server results. The UX that result is nice: the user will see initial results to the query instantly. If more results are found server-side, those results are guaranteed to sort below the local results. There's no shuffling of results when the server response comes in. Now imagine that the user switches the sort to ‘sort by modified’. This new query will run locally, and will again find some local matches. But it is now unlikely that the local results found are a prefix of the server results. When the server result comes in, the user will probably see the results shuffle around. To avoid this annoying effect, what you should do in this example is also preload the first 1k issues sorted by modified desc. In general for any query shape you intend to do, you should preload the first n results for that query shape with no filters, in each sort you intend to use. Zero syncs the union of all active queries' results. You don't have to worry about syncing many sorts of the same query when it's likely the results will overlap heavily. In the future, we will be implementing a consistency model that fixes these issues automatically. We will prevent Zero from returning local data when that data is not known to be a prefix of the server result. Once the consistency model is implemented, preloading can be thought of as purely a performance thing, and not required to avoid unsightly flickering.",
+    "content": "Queries are how you read and sync data with Zero. Here's a simple example: // src/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from 'schema.ts' export const queries = defineQueries({ postsByAuthor: defineQuery( z.object({authorID: z.string()}), ({args: {authorID}}) => zql.post.where('authorID', authorID) ) }) Architecture A copy of each query exists on both the client and on your server: Often the implementations will be the same, and you can just share their code. This is easy with full-stack frameworks like TanStack Start or Next.js. But the implementations don't have to be the same, or even compute the same result. For example, the server can add extra filters to enforce permissions that the client query does not. Life of a Query When a query is invoked, it initially runs on the client, against the client-side datastore. Any matching data is returned immediately and the user sees instant results. In the background, the name and arguments for the query are sent to zero-cache. Zero-cache calls the queries endpoint on your server to get the ZQL for the query. Your server looks up its implementation of the query, invokes it, and returns the resulting ZQL expression to zero-cache. Zero-cache then runs this ZQL against the server-side data. The initial server result is sent back to the client and the client query updates in response. zero-cache receives updates from Postgres via logical replication. It updates affected queries and sends row changes back to the client, which updates the client query, and the user sees the changes. Defining Queries Basics Create a query using defineQuery. The only required argument is a QueryFn, which must return a ZQL expression: import {zql} from 'schema.ts' const allPostsQueryDef = defineQuery(() => zql.post) Arguments The QueryFn can take a single args parameter. To enable this, pass a validator to defineQuery: import {zql} from 'schema.ts' const postsByAuthor = defineQuery( z.object({authorID: z.string().optional()}), ({args: {authorID}}) => { let q = zql.post if (authorID !== undefined) { q = q.where('authorID', authorID) } return q } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. Zero queries run on both the client and on your server. In the server case, the parameters come from the client and are untrusted. The validator ensures the data passed to your query is of the expected type. Query Registries The result of defineQuery is a QueryDefinition. By itself this isn't super useful. You need to register it using defineQueries: export const queries = defineQueries({ posts: { all: allPostsQueryDef } }) Typically these are done together in one step: export const queries = defineQueries({ posts: { all: defineQuery(() => zql.post) } }) The result of defineQueries is called a QueryRegistry. Each field in the registry is a callable Query that you can use to read data: import {zero} from 'zero.ts' import {queries} from 'queries.ts' const allPosts = await zero.run(queries.posts.all()) Query Names Each Query has a queryName which is computed by defineQueries. This name is later sent to your server to identify the query to run: console.log(queries.posts.all.queryName) // \"posts.all\" Context Query parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero queries also support the concept of a context object. Access your context with the ctx parameter to your query: const myPostsQuery = defineQuery(({ctx: {userID}}) => { // User cannot control context.userID, so this safely // restricts the query to the user's own posts. return zql.post.where('authorID', userID) }) If you don't want to register your Context and Schema types globally, you can use defineQueryWithType and defineQueriesWithType: import { defineQueriesWithType, defineQueryWithType } from '@rocicorp/zero' import type {Schema} from 'schema.ts' import type {ZeroContext} from 'context.ts' const defineQuery = defineQueryWithType< Schema, ZeroContext >() const defineQueries = defineQueriesWithType<Schema>() queries.ts By convention, all queries for an application are listed in a central queries.ts file. This allows them to be easily used on both the client and server: import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema.ts' export const queries = defineQueries({ posts: { get: defineQuery(z.string(), id => zql.post.where('id', id) ), byAuthor: defineQuery( z.object({ authorID: z.string(), includeDrafts: z.boolean().optional() }), ({args: {authorID, includeDrafts}}) => { let q = zql.post.where('authorID', authorID) if (!includeDrafts) { q = q.where('isDraft', false) } return q } ) } }) You can use as many levels of nesting as you want to organize your queries. As your application grows, you can move queries to different files to keep them organized: // posts.ts export const postQueries = { get: defineQuery(z.string(), id => zql.post.where('id', id) ) // ... } // users.ts export const userQueries = { byRole: defineQuery(z.string(), role => zql.user.where('role', role) ) // ... } // queries.ts import {postQueries} from './posts.ts' import {userQueries} from './users.ts' export const queries = defineQueries({ posts: postQueries, users: userQueries }) Because defineQueries establishes the full name for each query (i.e., posts.get, users.byRole), it should only be used once at the top level of your queries.ts file. Server Setup In order for queries to sync, you must provide an implementation of the query endpoint on your server. zero-cache calls this endpoint to resolve each query to ZQL that it can run. Registering the Endpoint Use ZERO_QUERY_URL to tell zero-cache where to find your query implementation: export ZERO_QUERY_URL=\"http://localhost:3000/api/zero/query\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleQueryRequest and mustGetQuery functions to implement the endpoint. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' app.post('/api/zero/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) handleQueryRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetQuery looks up the query in the registry and throws an error if not found. The query.fn function is your query implementation wrapped in the validator you provided. These examples have only public queries, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the query handler. See Authentication. Custom Query URL By default, Zero sends queries to the URL specified in the ZERO_QUERY_URL parameter in the zero-cache config. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in ZERO_QUERY_URL: ZERO_QUERY_URL='https://api.example.com/query,https://api.staging.example.com/query' Then choose one of those URLs by passing it to queryURL on the Zero constructor: const zero = new Zero({ schema, queries, queryURL: 'https://api.staging.example.com/query' }) URL Patterns The strings listed in ZERO_QUERY_URL can also be URLPatterns: ZERO_QUERY_URL=\"https://mybranch-*.preview.myapp.com/query\" This queries URL will allow clients to choose URLs like: https://mybranch-aaa.preview.myapp.com/query ✅ https://mybranch-bbb.preview.myapp.com/query ✅ But rejects URLs like: https://preview.myapp.com/query ❌ (missing subdomain) https://malicious.com/query ❌ (different domain) https://mybranch-123.preview.myapp.com/query/extra ❌ (extra path) https://mybranch-123.preview.myapp.com/other ❌ (different path) Because URLPattern is a web standard, you can test them right in your browser: For more information, see the URLPattern docs. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints. Running Queries Reactively The most common way to use queries is with the useQuery reactive hooks from the React or SolidJS bindings (or the equivalent low-level API): import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(queries.posts.get('user123')) return posts.map(post => ( <div key={post.id}>{post.title}</div> )) }import {useQuery} from '@rocicorp/zero/solid' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(() => queries.posts.get('user123') ) return ( <For each={posts()}> {post => <div key={post.id}>{post.title}</div>} </For> ) }import {queries} from 'zero/queries.ts' import {zero} from 'zero.ts' const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) for (let post of postsView.data) { console.log(post.title) } // updates as the underlying data changes postsView.addListener(posts => { console.log('posts', posts) }) These functions allow you to automatically re-render UI when a query changes. Conditionally Sometimes the inputs needed to construct a query are not available on the first render. For example, auth state or a route param might still be loading after a page refresh. Both React and Solid support conditional queries by passing undefined until the query can be constructed: import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function Username({userID}: {userID: string | undefined}) { const [user] = useQuery( userID ? queries.users.getUser({ userID }) : undefined ) return user ? <div>{user.username}</div> : null }import {useQuery} from '@rocicorp/zero/solid' import {Show} from 'solid-js' import {queries} from 'zero/queries.ts' function Username(props: {userID: string | undefined}) { const [user] = useQuery(() => props.userID ? queries.users.getUser({ userID: props.userID }) : undefined ) return ( <Show when={user()}> {user => <div>{user().username}</div>} </Show> ) } Once You usually want to subscribe to a query in a reactive UI, but every so often you'll need to run a query just once. To do this, use zero.run(): const results = await zero.run( queries.issues.byPriority('high') ) By default, run() only returns results that are currently available on the client. That is, it returns the data that would be given for result.type === 'unknown'. If you want to wait for the server to return results, pass {type: 'complete'} to run: const results = await zero.run( queries.issues.byPriority('high'), {type: 'complete'} ) For Preloading Almost all Zero apps will want to preload some data in order to maximize the feel of instantaneous UI transitions. Because preload queries are often much larger than a screenful of UI, Zero provides a special zero.preload() method to avoid the overhead of materializing the result into JS objects: // Preload a large number of the inbox query results. zero.preload( queries.issues.inbox({ sort: 'created', sortDirection: 'desc', limit: 1000 }) ) Missing Data Because Zero returns local results immediately and server results asynchronously, displaying \"not found\" / 404 UI can be slightly tricky. If you just use a simple existence check, you will often see the 404 UI flicker while the server result loads: const [issue] = useQuery(queries.issues.get('some-id')) // ❌ This causes flickering of the UI if (!issue) { return <div>404 Not Found</div> } else { return <div>{issue.title}</div> }const [issue] = useQuery(() => queries.issues.get('some-id') ) return ( <Show when={issue()}> {resolved => ( <Show when={resolved} fallback={<div>404 Not Found</div>} > <div>{resolved.title}</div> </Show> )} </Show> )const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) postsView.addListener(posts => { // ❌ This is updated as data comes in console.log('posts', posts) }) To do this correctly, only display the \"not found\" UI when the result type is complete. This way the 404 page is slow but pages with data are still just as fast: const [issue, issueResult] = useQuery( queries.issues.get('some-id') ) if (!issue && issueResult.type === 'complete') { return <div>404 Not Found</div> } if (!issue) { return null } return <div>{issue.title}</div>const [issue, issueResult] = useQuery(() => queries.issues.get('some-id') ) return ( <Switch fallback={null}> <Match when={issue()}> {resolved => <div>{resolved.title}</div>} </Match> <Match when={issueResult().type === 'complete'}> <div>404 Not Found</div> </Match> </Switch> )const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) postsView.addListener((posts, resultType) => { if (resultType === 'complete') { console.log('posts', posts) } }) Partial Data Zero immediately returns the data for a query it has on the client, then falls back to the server for any missing data. Sometimes it's useful to know the difference between these two types of results. To do so, use the result from useQuery: const [issues, issuesResult] = useQuery( queries.issues.inbox() ) if (issuesResult.type === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') }const [issues, issuesResult] = useQuery(() => queries.issues.inbox() ) if (issuesResult().type === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') }const view = zero.materialize(queries.issues.inbox()) view.addListener((issues, resultType) => { if (resultType === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') } }) The possible values of result.type are currently complete and unknown. The complete value is currently only returned when Zero has received the server result. In the future, Zero will be able to return this result type when it knows that all possible data for this query is already available locally. Additionally, we plan to add a prefix result for when the data is known to be a prefix of the complete result. See Consistency for more information. Handling Errors If the queries endpoint throws an application or parse error, zero-cache will report it to the client using the type and error fields on the query details object: const [posts, postsResult] = useQuery( queries.posts.byAuthorID('user123') ) if (postsResult.type === 'error') { return ( <div> Error loading posts: {postsResult.error.message} </div> ) }const [posts, postsResult] = useQuery(() => queries.posts.byAuthorID('user123') ) return ( <Switch> <Match when={postsResult().type === 'error'}> <div> Error loading posts: {postsResult().error.message} </div> </Match> </Switch> )// Materialize a view of a query const postsView = queries.posts .byAuthorID('user123') .materialize() postsView.addListener((posts, resultType, error) => { if (resultType === 'error') { console.error('Error loading posts', error) } }) See Connection Status for how HTTP or network errors from the queries endpoint are handled. Granular Updates You can use the materialize() method to create a view that you can listen to for changes. However, this will only tell you when the view has changed and give you the complete new result. It won't tell you what changed. To know what changed, you can create your own custom View implementation: // Inside the View class // Instead of storing the change, we invoke some callback push(change: Change): void { switch (change.type) { case 'add': this.#onAdd?.(change) break case 'remove': this.#onRemove?.(change) break case 'edit': this.#onEdit?.(change) break case 'child': this.#onChild?.(change) break default: throw new Error(`Unknown change type: ${change['type']}`) } } For examples, see the View implementations in zero-vue or zero-solid. Query Caching Queries can be either active or cached. An active query is one that is currently being used by the application. Cached queries are not currently in use, but continue syncing in case they are needed again soon. Queries are deactivated according to how they were created: For useQuery(), the UI unmounts the component (which calls destroy() under the covers). For preload(), the UI calls cleanup() on the return value of preload(). For run(), queries are automatically deactivated immediately after the result is returned. For materialize() queries, the UI calls destroy() on the view. Additionally when a Zero instance closes, all active queries are automatically deactivated. This also happens when the containing page or script is unloaded. TTLs Each query has a ttl that controls how long it stays cached. If the user closes all tabs for your app, Zero stops running and the time that elapses doesn't count toward any TTLs. You do not need to account for such time when choosing a TTL – you only need to account for time your app is running without a query. TTL Defaults In most cases, the default TTL should work well: preload() queries default to ttl:'none', meaning they are not cached at all, and will stop syncing immediately when deactivated. But because preload() queries are typically registered at app startup and never shutdown, and because the ttl clock only ticks while Zero is running, this means that preload queries never get unregistered. Other queries have a default ttl of 5m (five minutes). Setting Different TTLs You can override the default TTL with the ttl parameter: const [user] = useQuery( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero.preload(queries.posts.byAuthorID('user123'), { ttl: '5m' })const [user] = useQuery( () => queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero().preload(queries.posts.byAuthorID('user123'), { ttl: '5m' })// run() const user = await zero.run( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // materialize() const view = zero.materialize( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero.preload(queries.posts.byAuthorID('user123'), { ttl: '5m' }) TTLs up to 10m (ten minutes) are currently supported. The following formats are allowed: Why Zero TTLs are Short Zero queries are not free. Just as in any database, queries consume resources on both the client and server. Memory is used to keep metadata about the query, and disk storage is used to keep the query's current state. We do drop this state after we haven't heard from a client for awhile, but this is only a partial improvement. If the client returns, we have to re-run the query to get the latest data. This means that we do not actually want to keep queries active unless there is a good chance they will be needed again soon. The default Zero TTL values might initially seem too short, but they are designed to work well with the way Zero's TTL clock works and strike a good balance between keeping queries alive long enough to be useful, while not keeping them alive so long that they consume resources unnecessarily. Local-Only Queries It can sometimes be useful to run queries only on the client. For example, to implement typeahead search, it really doesn't make sense to register a query with the server for every single keystroke. Zero doesn't yet have a way to run named queries local-only, but you can run ZQL expressions locally by passing them anywhere a query is supported. For example, to subscribe to a local-only query: // Queries the already synced data for issues, // without syncing more data. const [issues] = useQuery( zql.issue.orderBy('created', 'desc').limit(10) )// Queries the already synced data for issues, // without syncing more data. const [issues] = useQuery(() => zql.issue.orderBy('created', 'desc').limit(10) )// Queries the already synced data for issues, // without syncing more data. const view = z.materialize( zql.issue.orderBy('created', 'desc').limit(10) ) view.addListener(issues => { console.log('issues', issues) }) Custom Server Implementation It is possible to implement the ZERO_QUERY_URL endpoint without using Zero's TypeScript libraries, or even in a different language entirely. The endpoint receives a POST request with a JSON body of the form: type QueriesRequestBody = { id: string name: string args: readonly ReadonlyJSONValue[] }[] And responds with: type QueriesResponseBody = ( | { id: string name: string // See https://github.com/rocicorp/mono/blob/main/packages/zero-protocol/src/ast.ts ast: AST } | { error: 'app' id: string name: string details: ReadonlyJSONValue } | { error: 'zero' id: string name: string details: ReadonlyJSONValue } | { error: 'http' id: string name: string status: number details: ReadonlyJSONValue } )[] Consistency Zero always syncs a consistent partial replica of the backend database to the client. This avoids many common consistency issues that come up in classic web applications. But there are still some consistency issues to be aware of when using Zero. For example, imagine that you have a bug database w/ 10k issues. You preload the first 1k issues sorted by created. The user then does a query of issues assigned to themselves, sorted by created. Among the 1k issues that were preloaded imagine 100 are found that match the query. Since the data we preloaded is in the same order as this query, we are guaranteed that any local results found will be a prefix of the server results. The UX that result is nice: the user will see initial results to the query instantly. If more results are found server-side, those results are guaranteed to sort below the local results. There's no shuffling of results when the server response comes in. Now imagine that the user switches the sort to ‘sort by modified’. This new query will run locally, and will again find some local matches. But it is now unlikely that the local results found are a prefix of the server results. When the server result comes in, the user will probably see the results shuffle around. To avoid this annoying effect, what you should do in this example is also preload the first 1k issues sorted by modified desc. In general for any query shape you intend to do, you should preload the first n results for that query shape with no filters, in each sort you intend to use. Zero syncs the union of all active queries' results. You don't have to worry about syncing many sorts of the same query when it's likely the results will overlap heavily. In the future, we will be implementing a consistency model that fixes these issues automatically. We will prevent Zero from returning local data when that data is not known to be a prefix of the server result. Once the consistency model is implemented, preloading can be thought of as purely a performance thing, and not required to avoid unsightly flickering.",
     "headings": [
       {
         "text": "Architecture",
@@ -2654,6 +2625,10 @@
         "id": "reactively"
       },
       {
+        "text": "Conditionally",
+        "id": "conditionally"
+      },
+      {
         "text": "Once",
         "id": "once"
       },
@@ -2713,7 +2688,7 @@
     "kind": "page"
   },
   {
-    "id": "240-queries#architecture",
+    "id": "239-queries#architecture",
     "title": "Queries",
     "searchTitle": "Architecture",
     "sectionTitle": "Architecture",
@@ -2723,7 +2698,7 @@
     "kind": "section"
   },
   {
-    "id": "241-queries#life-of-a-query",
+    "id": "240-queries#life-of-a-query",
     "title": "Queries",
     "searchTitle": "Life of a Query",
     "sectionTitle": "Life of a Query",
@@ -2733,17 +2708,17 @@
     "kind": "section"
   },
   {
-    "id": "242-queries#defining-queries",
+    "id": "241-queries#defining-queries",
     "title": "Queries",
     "searchTitle": "Defining Queries",
     "sectionTitle": "Defining Queries",
     "sectionId": "defining-queries",
     "url": "/docs/queries",
-    "content": "Basics Create a query using defineQuery. The only required argument is a QueryFn, which must return a ZQL expression: import {zql} from 'schema.ts' const allPostsQueryDef = defineQuery(() => zql.post) Arguments The QueryFn can take a single args parameter. To enable this, pass a validator to defineQuery: import {zql} from 'schema.ts' const postsByAuthor = defineQuery( z.object({authorID: z.string().optional()}), ({args: {authorID}}) => { let q = zql.post if (authorID !== undefined) { q = q.where('authorID', authorID) } return q } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. Zero queries run on both the client and on your server. In the server case, the parameters come from the client and are untrusted. The validator ensures the data passed to your query is of the expected type. Query Registries The result of defineQuery is a QueryDefinition. By itself this isn't super useful. You need to register it using defineQueries: export const queries = defineQueries({ posts: { all: allPostsQueryDef } }) Typically these are done together in one step: export const queries = defineQueries({ posts: { all: defineQuery(() => zql.post) } }) The result of defineQueries is called a QueryRegistry. Each field in the registry is a callable Query that you can use to read data: import {zero} from 'zero.ts' import {queries} from 'queries.ts' const allPosts = await zero.run(queries.posts.all()) Query Names Each Query has a queryName which is computed by defineQueries. This name is later sent to your server to identify the query to run: console.log(queries.posts.all.queryName) // \"posts.all\" Context Query parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero queries also support the concept of a context object. Access your context with the ctx parameter to your query: const myPostsQuery = defineQuery(({ctx: {userID}}) => { // User cannot control context.userID, so this safely // restricts the query to the user's own posts. return zql.post.where('authorID', userID) }) queries.ts By convention, all queries for an application are listed in a central queries.ts file. This allows them to be easily used on both the client and server: import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema.ts' export const queries = defineQueries({ posts: { get: defineQuery(z.string(), id => zql.post.where('id', id) ), byAuthor: defineQuery( z.object({ authorID: z.string(), includeDrafts: z.boolean().optional() }), ({args: {authorID, includeDrafts}}) => { let q = zql.post.where('authorID', authorID) if (!includeDrafts) { q = q.where('isDraft', false) } return q } ) } }) You can use as many levels of nesting as you want to organize your queries. As your application grows, you can move queries to different files to keep them organized: // posts.ts export const postQueries = { get: defineQuery(z.string(), id => zql.post.where('id', id) ) // ... } // users.ts export const userQueries = { byRole: defineQuery(z.string(), role => zql.user.where('role', role) ) // ... } // queries.ts import {postQueries} from './posts.ts' import {userQueries} from './users.ts' export const queries = defineQueries({ posts: postQueries, users: userQueries }) Because defineQueries establishes the full name for each query (i.e., posts.get, users.byRole), it should only be used once at the top level of your queries.ts file.",
+    "content": "Basics Create a query using defineQuery. The only required argument is a QueryFn, which must return a ZQL expression: import {zql} from 'schema.ts' const allPostsQueryDef = defineQuery(() => zql.post) Arguments The QueryFn can take a single args parameter. To enable this, pass a validator to defineQuery: import {zql} from 'schema.ts' const postsByAuthor = defineQuery( z.object({authorID: z.string().optional()}), ({args: {authorID}}) => { let q = zql.post if (authorID !== undefined) { q = q.where('authorID', authorID) } return q } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. Zero queries run on both the client and on your server. In the server case, the parameters come from the client and are untrusted. The validator ensures the data passed to your query is of the expected type. Query Registries The result of defineQuery is a QueryDefinition. By itself this isn't super useful. You need to register it using defineQueries: export const queries = defineQueries({ posts: { all: allPostsQueryDef } }) Typically these are done together in one step: export const queries = defineQueries({ posts: { all: defineQuery(() => zql.post) } }) The result of defineQueries is called a QueryRegistry. Each field in the registry is a callable Query that you can use to read data: import {zero} from 'zero.ts' import {queries} from 'queries.ts' const allPosts = await zero.run(queries.posts.all()) Query Names Each Query has a queryName which is computed by defineQueries. This name is later sent to your server to identify the query to run: console.log(queries.posts.all.queryName) // \"posts.all\" Context Query parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero queries also support the concept of a context object. Access your context with the ctx parameter to your query: const myPostsQuery = defineQuery(({ctx: {userID}}) => { // User cannot control context.userID, so this safely // restricts the query to the user's own posts. return zql.post.where('authorID', userID) }) If you don't want to register your Context and Schema types globally, you can use defineQueryWithType and defineQueriesWithType: import { defineQueriesWithType, defineQueryWithType } from '@rocicorp/zero' import type {Schema} from 'schema.ts' import type {ZeroContext} from 'context.ts' const defineQuery = defineQueryWithType< Schema, ZeroContext >() const defineQueries = defineQueriesWithType<Schema>() queries.ts By convention, all queries for an application are listed in a central queries.ts file. This allows them to be easily used on both the client and server: import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema.ts' export const queries = defineQueries({ posts: { get: defineQuery(z.string(), id => zql.post.where('id', id) ), byAuthor: defineQuery( z.object({ authorID: z.string(), includeDrafts: z.boolean().optional() }), ({args: {authorID, includeDrafts}}) => { let q = zql.post.where('authorID', authorID) if (!includeDrafts) { q = q.where('isDraft', false) } return q } ) } }) You can use as many levels of nesting as you want to organize your queries. As your application grows, you can move queries to different files to keep them organized: // posts.ts export const postQueries = { get: defineQuery(z.string(), id => zql.post.where('id', id) ) // ... } // users.ts export const userQueries = { byRole: defineQuery(z.string(), role => zql.user.where('role', role) ) // ... } // queries.ts import {postQueries} from './posts.ts' import {userQueries} from './users.ts' export const queries = defineQueries({ posts: postQueries, users: userQueries }) Because defineQueries establishes the full name for each query (i.e., posts.get, users.byRole), it should only be used once at the top level of your queries.ts file.",
     "kind": "section"
   },
   {
-    "id": "243-queries#basics",
+    "id": "242-queries#basics",
     "title": "Queries",
     "searchTitle": "Basics",
     "sectionTitle": "Basics",
@@ -2753,7 +2728,7 @@
     "kind": "section"
   },
   {
-    "id": "244-queries#arguments",
+    "id": "243-queries#arguments",
     "title": "Queries",
     "searchTitle": "Arguments",
     "sectionTitle": "Arguments",
@@ -2763,7 +2738,7 @@
     "kind": "section"
   },
   {
-    "id": "245-queries#query-registries",
+    "id": "244-queries#query-registries",
     "title": "Queries",
     "searchTitle": "Query Registries",
     "sectionTitle": "Query Registries",
@@ -2773,7 +2748,7 @@
     "kind": "section"
   },
   {
-    "id": "246-queries#query-names",
+    "id": "245-queries#query-names",
     "title": "Queries",
     "searchTitle": "Query Names",
     "sectionTitle": "Query Names",
@@ -2783,17 +2758,17 @@
     "kind": "section"
   },
   {
-    "id": "247-queries#context",
+    "id": "246-queries#context",
     "title": "Queries",
     "searchTitle": "Context",
     "sectionTitle": "Context",
     "sectionId": "context",
     "url": "/docs/queries",
-    "content": "Query parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero queries also support the concept of a context object. Access your context with the ctx parameter to your query: const myPostsQuery = defineQuery(({ctx: {userID}}) => { // User cannot control context.userID, so this safely // restricts the query to the user's own posts. return zql.post.where('authorID', userID) })",
+    "content": "Query parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero queries also support the concept of a context object. Access your context with the ctx parameter to your query: const myPostsQuery = defineQuery(({ctx: {userID}}) => { // User cannot control context.userID, so this safely // restricts the query to the user's own posts. return zql.post.where('authorID', userID) }) If you don't want to register your Context and Schema types globally, you can use defineQueryWithType and defineQueriesWithType: import { defineQueriesWithType, defineQueryWithType } from '@rocicorp/zero' import type {Schema} from 'schema.ts' import type {ZeroContext} from 'context.ts' const defineQuery = defineQueryWithType< Schema, ZeroContext >() const defineQueries = defineQueriesWithType<Schema>()",
     "kind": "section"
   },
   {
-    "id": "248-queries#queriests",
+    "id": "247-queries#queriests",
     "title": "Queries",
     "searchTitle": "queries.ts",
     "sectionTitle": "queries.ts",
@@ -2803,7 +2778,7 @@
     "kind": "section"
   },
   {
-    "id": "249-queries#server-setup",
+    "id": "248-queries#server-setup",
     "title": "Queries",
     "searchTitle": "Server Setup",
     "sectionTitle": "Server Setup",
@@ -2813,7 +2788,7 @@
     "kind": "section"
   },
   {
-    "id": "250-queries#registering-the-endpoint",
+    "id": "249-queries#registering-the-endpoint",
     "title": "Queries",
     "searchTitle": "Registering the Endpoint",
     "sectionTitle": "Registering the Endpoint",
@@ -2823,7 +2798,7 @@
     "kind": "section"
   },
   {
-    "id": "251-queries#implementing-the-endpoint",
+    "id": "250-queries#implementing-the-endpoint",
     "title": "Queries",
     "searchTitle": "Implementing the Endpoint",
     "sectionTitle": "Implementing the Endpoint",
@@ -2833,7 +2808,7 @@
     "kind": "section"
   },
   {
-    "id": "252-queries#custom-query-url",
+    "id": "251-queries#custom-query-url",
     "title": "Queries",
     "searchTitle": "Custom Query URL",
     "sectionTitle": "Custom Query URL",
@@ -2843,7 +2818,7 @@
     "kind": "section"
   },
   {
-    "id": "253-queries#url-patterns",
+    "id": "252-queries#url-patterns",
     "title": "Queries",
     "searchTitle": "URL Patterns",
     "sectionTitle": "URL Patterns",
@@ -2853,23 +2828,33 @@
     "kind": "section"
   },
   {
-    "id": "254-queries#running-queries",
+    "id": "253-queries#running-queries",
     "title": "Queries",
     "searchTitle": "Running Queries",
     "sectionTitle": "Running Queries",
     "sectionId": "running-queries",
     "url": "/docs/queries",
-    "content": "Reactively The most common way to use queries is with the useQuery reactive hooks from the React or SolidJS bindings (or the equivalent low-level API): import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(queries.posts.get('user123')) return posts.map(post => ( <div key={post.id}>{post.title}</div> )) }import {useQuery} from '@rocicorp/zero/solid' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(() => queries.posts.get('user123') ) return ( <For each={posts()}> {post => <div key={post.id}>{post.title}</div>} </For> ) }import {queries} from 'zero/queries.ts' import {zero} from 'zero.ts' const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) for (let post of postsView.data) { console.log(post.title) } // updates as the underlying data changes postsView.addListener(posts => { console.log('posts', posts) }) These functions allow you to automatically re-render UI when a query changes. Once You usually want to subscribe to a query in a reactive UI, but every so often you'll need to run a query just once. To do this, use zero.run(): const results = await zero.run( queries.issues.byPriority('high') ) By default, run() only returns results that are currently available on the client. That is, it returns the data that would be given for result.type === 'unknown'. If you want to wait for the server to return results, pass {type: 'complete'} to run: const results = await zero.run( queries.issues.byPriority('high'), {type: 'complete'} ) For Preloading Almost all Zero apps will want to preload some data in order to maximize the feel of instantaneous UI transitions. Because preload queries are often much larger than a screenful of UI, Zero provides a special zero.preload() method to avoid the overhead of materializing the result into JS objects: // Preload a large number of the inbox query results. zero.preload( queries.issues.inbox({ sort: 'created', sortDirection: 'desc', limit: 1000 }) )",
+    "content": "Reactively The most common way to use queries is with the useQuery reactive hooks from the React or SolidJS bindings (or the equivalent low-level API): import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(queries.posts.get('user123')) return posts.map(post => ( <div key={post.id}>{post.title}</div> )) }import {useQuery} from '@rocicorp/zero/solid' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(() => queries.posts.get('user123') ) return ( <For each={posts()}> {post => <div key={post.id}>{post.title}</div>} </For> ) }import {queries} from 'zero/queries.ts' import {zero} from 'zero.ts' const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) for (let post of postsView.data) { console.log(post.title) } // updates as the underlying data changes postsView.addListener(posts => { console.log('posts', posts) }) These functions allow you to automatically re-render UI when a query changes. Conditionally Sometimes the inputs needed to construct a query are not available on the first render. For example, auth state or a route param might still be loading after a page refresh. Both React and Solid support conditional queries by passing undefined until the query can be constructed: import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function Username({userID}: {userID: string | undefined}) { const [user] = useQuery( userID ? queries.users.getUser({ userID }) : undefined ) return user ? <div>{user.username}</div> : null }import {useQuery} from '@rocicorp/zero/solid' import {Show} from 'solid-js' import {queries} from 'zero/queries.ts' function Username(props: {userID: string | undefined}) { const [user] = useQuery(() => props.userID ? queries.users.getUser({ userID: props.userID }) : undefined ) return ( <Show when={user()}> {user => <div>{user().username}</div>} </Show> ) } Once You usually want to subscribe to a query in a reactive UI, but every so often you'll need to run a query just once. To do this, use zero.run(): const results = await zero.run( queries.issues.byPriority('high') ) By default, run() only returns results that are currently available on the client. That is, it returns the data that would be given for result.type === 'unknown'. If you want to wait for the server to return results, pass {type: 'complete'} to run: const results = await zero.run( queries.issues.byPriority('high'), {type: 'complete'} ) For Preloading Almost all Zero apps will want to preload some data in order to maximize the feel of instantaneous UI transitions. Because preload queries are often much larger than a screenful of UI, Zero provides a special zero.preload() method to avoid the overhead of materializing the result into JS objects: // Preload a large number of the inbox query results. zero.preload( queries.issues.inbox({ sort: 'created', sortDirection: 'desc', limit: 1000 }) )",
     "kind": "section"
   },
   {
-    "id": "255-queries#reactively",
+    "id": "254-queries#reactively",
     "title": "Queries",
     "searchTitle": "Reactively",
     "sectionTitle": "Reactively",
     "sectionId": "reactively",
     "url": "/docs/queries",
     "content": "The most common way to use queries is with the useQuery reactive hooks from the React or SolidJS bindings (or the equivalent low-level API): import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(queries.posts.get('user123')) return posts.map(post => ( <div key={post.id}>{post.title}</div> )) }import {useQuery} from '@rocicorp/zero/solid' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(() => queries.posts.get('user123') ) return ( <For each={posts()}> {post => <div key={post.id}>{post.title}</div>} </For> ) }import {queries} from 'zero/queries.ts' import {zero} from 'zero.ts' const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) for (let post of postsView.data) { console.log(post.title) } // updates as the underlying data changes postsView.addListener(posts => { console.log('posts', posts) }) These functions allow you to automatically re-render UI when a query changes.",
+    "kind": "section"
+  },
+  {
+    "id": "255-queries#conditionally",
+    "title": "Queries",
+    "searchTitle": "Conditionally",
+    "sectionTitle": "Conditionally",
+    "sectionId": "conditionally",
+    "url": "/docs/queries",
+    "content": "Sometimes the inputs needed to construct a query are not available on the first render. For example, auth state or a route param might still be loading after a page refresh. Both React and Solid support conditional queries by passing undefined until the query can be constructed: import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function Username({userID}: {userID: string | undefined}) { const [user] = useQuery( userID ? queries.users.getUser({ userID }) : undefined ) return user ? <div>{user.username}</div> : null }import {useQuery} from '@rocicorp/zero/solid' import {Show} from 'solid-js' import {queries} from 'zero/queries.ts' function Username(props: {userID: string | undefined}) { const [user] = useQuery(() => props.userID ? queries.users.getUser({ userID: props.userID }) : undefined ) return ( <Show when={user()}> {user => <div>{user().username}</div>} </Show> ) }",
     "kind": "section"
   },
   {
@@ -3014,10 +2999,10 @@
   },
   {
     "id": "23-quickstart",
-    "title": "Quickstarts",
-    "searchTitle": "Quickstarts",
+    "title": "Quickstart",
+    "searchTitle": "Quickstart",
     "url": "/docs/quickstart",
-    "content": "Minimal starter apps for Zero with a variety of stacks. hello-zero-solid Simple quickstart for Zero/SolidJS. Stack: Vite/Hono/SolidJS Source: https://github.com/rocicorp/hello-zero-solid Features: Instant reads and writes, realtime updates hello-zero-cf Shows how to use the Zero in a Cloudflare Worker environment. This sample runs Zero in a React/Hono app, within the Cloudflare worker environment. It uses Hono to implement authentication and Zero's API endpoints. It also runs zero-client within a Durable Object and monitors changes to a Zero query. This can be used to do things like send notifications, update external services, etc. Stack: pnpm/Vite/Hono/React/Cloudflare Workers Source: https://github.com/rocicorp/hello-zero-cf hello-zero Quickstart for Zero/React. Stack: Vite/Hono/React Source: https://github.com/rocicorp/hello-zero Docs: Quickstart Features: Instant reads and writes, realtime updates.",
+    "content": "Minimal starter apps for Zero with a variety of stacks. If you want the guided tutorial instead, see Tutorial. hello-zero-solid Simple starter for Zero and SolidJS. Stack: Vite/Hono/SolidJS Source: https://github.com/rocicorp/hello-zero-solid Features: Instant reads and writes, realtime updates hello-zero-cf Shows how to use Zero in a Cloudflare Worker environment. This starter runs Zero in a React/Hono app within the Cloudflare worker environment. It uses Hono to implement authentication and Zero's API endpoints. It also runs zero-client within a Durable Object and monitors changes to a Zero query. This can be used to do things like send notifications, update external services, and trigger other background work. Stack: pnpm/Vite/Hono/React/Cloudflare Workers Source: https://github.com/rocicorp/hello-zero-cf hello-zero Simple starter for Zero and React. Stack: Vite/Hono/React Source: https://github.com/rocicorp/hello-zero Features: Instant reads and writes, realtime updates.",
     "headings": [
       {
         "text": "hello-zero-solid",
@@ -3036,32 +3021,32 @@
   },
   {
     "id": "270-quickstart#hello-zero-solid",
-    "title": "Quickstarts",
+    "title": "Quickstart",
     "searchTitle": "hello-zero-solid",
     "sectionTitle": "hello-zero-solid",
     "sectionId": "hello-zero-solid",
     "url": "/docs/quickstart",
-    "content": "Simple quickstart for Zero/SolidJS. Stack: Vite/Hono/SolidJS Source: https://github.com/rocicorp/hello-zero-solid Features: Instant reads and writes, realtime updates",
+    "content": "Simple starter for Zero and SolidJS. Stack: Vite/Hono/SolidJS Source: https://github.com/rocicorp/hello-zero-solid Features: Instant reads and writes, realtime updates",
     "kind": "section"
   },
   {
     "id": "271-quickstart#hello-zero-cf",
-    "title": "Quickstarts",
+    "title": "Quickstart",
     "searchTitle": "hello-zero-cf",
     "sectionTitle": "hello-zero-cf",
     "sectionId": "hello-zero-cf",
     "url": "/docs/quickstart",
-    "content": "Shows how to use the Zero in a Cloudflare Worker environment. This sample runs Zero in a React/Hono app, within the Cloudflare worker environment. It uses Hono to implement authentication and Zero's API endpoints. It also runs zero-client within a Durable Object and monitors changes to a Zero query. This can be used to do things like send notifications, update external services, etc. Stack: pnpm/Vite/Hono/React/Cloudflare Workers Source: https://github.com/rocicorp/hello-zero-cf",
+    "content": "Shows how to use Zero in a Cloudflare Worker environment. This starter runs Zero in a React/Hono app within the Cloudflare worker environment. It uses Hono to implement authentication and Zero's API endpoints. It also runs zero-client within a Durable Object and monitors changes to a Zero query. This can be used to do things like send notifications, update external services, and trigger other background work. Stack: pnpm/Vite/Hono/React/Cloudflare Workers Source: https://github.com/rocicorp/hello-zero-cf",
     "kind": "section"
   },
   {
     "id": "272-quickstart#hello-zero",
-    "title": "Quickstarts",
+    "title": "Quickstart",
     "searchTitle": "hello-zero",
     "sectionTitle": "hello-zero",
     "sectionId": "hello-zero",
     "url": "/docs/quickstart",
-    "content": "Quickstart for Zero/React. Stack: Vite/Hono/React Source: https://github.com/rocicorp/hello-zero Docs: Quickstart Features: Instant reads and writes, realtime updates.",
+    "content": "Simple starter for Zero and React. Stack: Vite/Hono/React Source: https://github.com/rocicorp/hello-zero Features: Instant reads and writes, realtime updates.",
     "kind": "section"
   },
   {
@@ -3078,7 +3063,7 @@
     "title": "React",
     "searchTitle": "React",
     "url": "/docs/react",
-    "content": "Zero has built-in support for React. Here's what basic usage looks like. Setup Use the ZeroProvider component to setup Zero. It takes care of creating and destroying Zero instances reactively: import {createRoot} from 'react-dom/client' import {ZeroProvider} from '@rocicorp/zero/react' import {useSession} from 'my-session-provider' import App from './App.tsx' import {schema} from 'schema.ts' import {mutators} from 'mutators.ts' const cacheURL = import.meta.env.VITE_PUBLIC_ZERO_CACHE_URL! export default function Root() { const session = useSession() const userID = session?.userID const auth = session?.accessToken const context = userID ? {userID} : undefined return ( <ZeroProvider {...{ userID, auth, context, cacheURL, schema, mutators }} > <App /> </ZeroProvider> ) } If you use token auth, pass it with auth={session?.jwt}. If you use cookie auth, omit the parameter entirely. When auth changes from one string to another, ZeroProvider refreshes auth in place with zero.connection.connect({auth}). When auth is added or removed, or userID changes, it recreates the Zero instance. When the user is logged out, omit the userID entirely. You can also pass a Zero instance to the ZeroProvider if you want to control the lifecycle of the Zero instance yourself: // ZeroProvider just sets up the context, it doesn't manage // the lifecycle of the Zero instance. <ZeroProvider zero={zero}> <App /> </ZeroProvider> When you pass zero={zero}, ZeroProvider only provides React Context. It does not manage auth updates for that instance, so if you are using token auth, call zero.connection.connect({auth: newToken}) yourself or recreate the instance when the user changes. Usage Use useQuery to run queries: import {useQuery} from '@rocicorp/zero/react' import {queries} from 'queries.ts' function Posts() { const [posts] = useQuery( queries.posts.byStatus({status: 'draft'}) ) return ( <> {posts.map(p => ( <div key={p.id}> {p.title} ({p.comments.length} comments) </div> ))} </> ) } Use useZero to get access to the Zero instance, for example to run mutators: import {useZero} from '@rocicorp/zero/react' import {mutators} from 'mutators.ts' function CompleteButton({issueID}: {issueID: string}) { const zero = useZero() const onClick = () => { zero.mutate(mutators.issues.complete({id: issueID})) } return <button onClick={onClick}>Complete Issue</button> } Suspense The useSuspenseQuery hook is exactly like useQuery, except it supports React Suspense. const [issues] = useSuspenseQuery(issueQuery, { suspendUntil: 'complete' // 'partial' or 'complete' }) Use the suspendUntil parameter to control how long to suspend for. The value complete suspends until authoritative results from the server are received. The partial value suspends until any non-empty data is received, or for a empty result that is complete. Examples See the sample directory for more complete React examples.",
+    "content": "Zero has built-in support for React. Here's what basic usage looks like. Setup Use the ZeroProvider component to setup Zero. It takes care of creating and destroying Zero instances reactively: import {createRoot} from 'react-dom/client' import {ZeroProvider} from '@rocicorp/zero/react' import {useSession} from 'my-session-provider' import App from './App.tsx' import {schema} from 'schema.ts' import {mutators} from 'mutators.ts' const cacheURL = import.meta.env.VITE_PUBLIC_ZERO_CACHE_URL! export default function Root() { const session = useSession() const userID = session?.userID const auth = session?.accessToken const context = userID ? {userID} : undefined return ( <ZeroProvider {...{ userID, auth, context, cacheURL, schema, mutators }} > <App /> </ZeroProvider> ) } If you use token auth, pass it with auth={session?.jwt}. If you use cookie auth, omit the parameter entirely. When auth changes from one string to another, ZeroProvider refreshes auth in place with zero.connection.connect({auth}). When auth is added or removed, or userID changes, it recreates the Zero instance. When the user is logged out, omit the userID entirely. You can also pass a Zero instance to the ZeroProvider if you want to control the lifecycle of the Zero instance yourself: // ZeroProvider just sets up the context, it doesn't manage // the lifecycle of the Zero instance. <ZeroProvider zero={zero}> <App /> </ZeroProvider> When you pass zero={zero}, ZeroProvider only provides React Context. It does not manage auth updates for that instance, so if you are using token auth, call zero.connection.connect({auth: newToken}) yourself or recreate the instance when the user changes. Usage Use useQuery to run queries: import {useQuery} from '@rocicorp/zero/react' import {queries} from 'queries.ts' function Posts() { const [posts] = useQuery( queries.posts.byStatus({status: 'draft'}) ) return ( <> {posts.map(p => ( <div key={p.id}> {p.title} ({p.comments.length} comments) </div> ))} </> ) } For conditional queries, such as queries that depend on auth state or route params that may not be loaded yet, see Conditional Queries. Use useZero to get access to the Zero instance, for example to run mutators: import {useZero} from '@rocicorp/zero/react' import {mutators} from 'mutators.ts' function CompleteButton({issueID}: {issueID: string}) { const zero = useZero() const onClick = () => { zero.mutate(mutators.issues.complete({id: issueID})) } return <button onClick={onClick}>Complete Issue</button> } Suspense The useSuspenseQuery hook is exactly like useQuery, except it supports React Suspense. const [issues] = useSuspenseQuery(issueQuery, { suspendUntil: 'complete' // 'partial' or 'complete' }) Use the suspendUntil parameter to control how long to suspend for. The value complete suspends until authoritative results from the server are received. The partial value suspends until any non-empty data is received, or for a empty result that is complete. Examples See the sample directory for more complete React examples.",
     "headings": [
       {
         "text": "Setup",
@@ -3116,7 +3101,7 @@
     "sectionTitle": "Usage",
     "sectionId": "usage",
     "url": "/docs/react",
-    "content": "Use useQuery to run queries: import {useQuery} from '@rocicorp/zero/react' import {queries} from 'queries.ts' function Posts() { const [posts] = useQuery( queries.posts.byStatus({status: 'draft'}) ) return ( <> {posts.map(p => ( <div key={p.id}> {p.title} ({p.comments.length} comments) </div> ))} </> ) } Use useZero to get access to the Zero instance, for example to run mutators: import {useZero} from '@rocicorp/zero/react' import {mutators} from 'mutators.ts' function CompleteButton({issueID}: {issueID: string}) { const zero = useZero() const onClick = () => { zero.mutate(mutators.issues.complete({id: issueID})) } return <button onClick={onClick}>Complete Issue</button> }",
+    "content": "Use useQuery to run queries: import {useQuery} from '@rocicorp/zero/react' import {queries} from 'queries.ts' function Posts() { const [posts] = useQuery( queries.posts.byStatus({status: 'draft'}) ) return ( <> {posts.map(p => ( <div key={p.id}> {p.title} ({p.comments.length} comments) </div> ))} </> ) } For conditional queries, such as queries that depend on auth state or route params that may not be loaded yet, see Conditional Queries. Use useZero to get access to the Zero instance, for example to run mutators: import {useZero} from '@rocicorp/zero/react' import {mutators} from 'mutators.ts' function CompleteButton({issueID}: {issueID: string}) { const zero = useZero() const onClick = () => { zero.mutate(mutators.issues.complete({id: issueID})) } return <button onClick={onClick}>Complete Issue</button> }",
     "kind": "section"
   },
   {
@@ -4584,7 +4569,7 @@
     "title": "Zero 0.26",
     "searchTitle": "Zero 0.26",
     "url": "/docs/release-notes/0.26",
-    "content": "Installation npm install @rocicorp/zero@0.26 Features Schema Backfill: Zero now natively supports adding columns with non-constant defaults, or adding existing columns to a custom publication. There is no longer a need to touch every row in the database to backfill data manually. Scalar Subqueries: Added a new optional optimization for exists queries that filter by related data with a one-to-one relationship. This can improve query performance significantly for cases where the subquery result changes rarely. Virtual Scroll: Added zero-virtual library for efficient infinite scrolling in React. Support for time and timetz columns: Added support for time and timetz columns (thanks GRBurst). Comparing to undefined: Added a new convenience for comparing to undefined. This is useful for filtering by nullable fields. zero.delete(): Added a more convenient way to delete all data from the browser's IndexedDB database. Fixes Updating auth tokens no cycles connection Add configurable back-pressure limit for change streamer Surface replication LSN at /statz?replication Generalize all statz output to be machine-readable Fix unique constraint violations during sync Fix zero-sqlite3 install script to work with bun Warn when mutations are rejected due to offline/error/closed state Fix queries being dropped when other queries with same hash expire Fix incorrect query results when filtering by undefined values Fix connection.connect() being ignored when in error/auth state Extra table name validation Redact sensitive info from logs Do not log mutation args Allow validation of JWT issuer and audience claims Protect against admin password timing attacks Forward origin header to API server Escape publication names Prevent denial of service attacks Fix race condition in notification handling Fix custom kvStoreProvider being ignored in React Native (thanks @kvnkusch!) Allow hybrid permissions with new queries in zero-cache-dev Fix unnecessary reconnection attempts after auth errors Fix \"database connection is not open\" error during shutdown Fix view-syncer crash from stale WebSocket messages Forward fresh auth token with each push message (thanks @jbingen!) Prevent IDB collection from deleting active databases Fix statz double close and ensure sqlite db handles are closed Fix OOM crashes when replicating databases with large rows Fix parsing of json[] and jsonb[] types Fix slow queries on tables with nullable unique columns Fix replication crash from closed WebSocket (thanks @utkarsh-611!) Fix notifications not working in background browser tabs Log WebSocket close code 1006 as info, not error (thanks @jbingen!) Fix replication deadlock on Storer crash (thanks @utkarsh-611!) Downgrade IDBNotFoundError to info log level (thanks @jbingen!) Fix type safety for default context/schema types Fix watermark errors when restoring from litestream backups Fix replica metadata being deleted during non-disruptive resync Fix occasional server crash when Postgres goes down Set idle transaction timeout to prevent hung transactions Fix lock errors under high CDC load Retry on change-db connection errors Detect publication differences during initial sync Prevent concurrent schema migrations from racing Fix stale destroy timers on query resubscribe (thanks @alpkaravil!) Add missing @types/ws dependency (thanks @YevheniiKotyrlo!) Fix constraints not detected when definition changes but name stays same Fix duplicate mutations when retry transaction succeeds Fix analyze-query crash with scalar subqueries Detect tables moved out of published schema Breaking Changes Just two very minor breaking changes this time, that are unlikely to affect most users: If you send custom headers to query or mutate endpoints, you must now allowlist them via ZERO_MUTATE_ALLOWED_CLIENT_HEADERS or ZERO_QUERY_ALLOWED_CLIENT_HEADERS. By default, no client-provided headers are forwarded. If you have very large mutations, note that WebSocket messages are now limited to 10MB by default. Increase ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES if needed.",
+    "content": "Installation npm install @rocicorp/zero@0.26 Features Schema Backfill: Zero now natively supports adding columns with non-constant defaults, or adding existing columns to a custom publication. There is no longer a need to touch every row in the database to backfill data manually. Scalar Subqueries: Added a new optional optimization for exists queries that filter by related data with a one-to-one relationship. This can improve query performance significantly for cases where the subquery result changes rarely. Virtual Scroll: Added zero-virtual library for efficient infinite scrolling in React. Support for time and timetz columns: Added support for time and timetz columns (thanks GRBurst). Comparing to undefined: Added a new convenience for comparing to undefined. This is useful for filtering by nullable fields. zero.delete(): Added a more convenient way to delete all data from the browser's IndexedDB database. Fixes Updating auth tokens no cycles connection Add configurable back-pressure limit for change streamer Surface replication LSN at /statz?replication Generalize all statz output to be machine-readable Fix unique constraint violations during sync Fix zero-sqlite3 install script to work with bun Warn when mutations are rejected due to offline/error/closed state Fix queries being dropped when other queries with same hash expire Fix incorrect query results when filtering by undefined values Fix connection.connect() being ignored when in error/auth state Extra table name validation Redact sensitive info from logs Do not log mutation args Allow validation of JWT issuer and audience claims Protect against admin password timing attacks Forward origin header to API server Escape publication names Prevent denial of service attacks Fix race condition in notification handling Fix custom kvStoreProvider being ignored in React Native (thanks @kvnkusch!) Allow hybrid permissions with new queries in zero-cache-dev Fix unnecessary reconnection attempts after auth errors Fix \"database connection is not open\" error during shutdown Fix view-syncer crash from stale WebSocket messages Forward fresh auth token with each push message (thanks @jbingen!) Prevent IDB collection from deleting active databases Fix statz double close and ensure sqlite db handles are closed Fix OOM crashes when replicating databases with large rows Fix parsing of json[] and jsonb[] types Fix slow queries on tables with nullable unique columns Fix replication crash from closed WebSocket (thanks @utkarsh-611!) Fix notifications not working in background browser tabs Log WebSocket close code 1006 as info, not error (thanks @jbingen!) Fix replication deadlock on Storer crash (thanks @utkarsh-611!) Downgrade IDBNotFoundError to info log level (thanks @jbingen!) Fix type safety for default context/schema types Fix watermark errors when restoring from litestream backups Fix replica metadata being deleted during non-disruptive resync Fix occasional server crash when Postgres goes down Set idle transaction timeout to prevent hung transactions Fix lock errors under high CDC load Retry on change-db connection errors Detect publication differences during initial sync Prevent concurrent schema migrations from racing Fix stale destroy timers on query resubscribe (thanks @Karavil!) Add missing @types/ws dependency (thanks @YevheniiKotyrlo!) Fix constraints not detected when definition changes but name stays same Fix duplicate mutations when retry transaction succeeds Fix analyze-query crash with scalar subqueries Detect tables moved out of published schema Breaking Changes Just two very minor breaking changes this time, that are unlikely to affect most users: If you send custom headers to query or mutate endpoints, you must now allowlist them via ZERO_MUTATE_ALLOWED_CLIENT_HEADERS or ZERO_QUERY_ALLOWED_CLIENT_HEADERS. By default, no client-provided headers are forwarded. If you have very large mutations, note that WebSocket messages are now limited to 10MB by default. Increase ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES if needed.",
     "headings": [
       {
         "text": "Installation",
@@ -4632,7 +4617,7 @@
     "sectionTitle": "Fixes",
     "sectionId": "fixes",
     "url": "/docs/release-notes/0.26",
-    "content": "Updating auth tokens no cycles connection Add configurable back-pressure limit for change streamer Surface replication LSN at /statz?replication Generalize all statz output to be machine-readable Fix unique constraint violations during sync Fix zero-sqlite3 install script to work with bun Warn when mutations are rejected due to offline/error/closed state Fix queries being dropped when other queries with same hash expire Fix incorrect query results when filtering by undefined values Fix connection.connect() being ignored when in error/auth state Extra table name validation Redact sensitive info from logs Do not log mutation args Allow validation of JWT issuer and audience claims Protect against admin password timing attacks Forward origin header to API server Escape publication names Prevent denial of service attacks Fix race condition in notification handling Fix custom kvStoreProvider being ignored in React Native (thanks @kvnkusch!) Allow hybrid permissions with new queries in zero-cache-dev Fix unnecessary reconnection attempts after auth errors Fix \"database connection is not open\" error during shutdown Fix view-syncer crash from stale WebSocket messages Forward fresh auth token with each push message (thanks @jbingen!) Prevent IDB collection from deleting active databases Fix statz double close and ensure sqlite db handles are closed Fix OOM crashes when replicating databases with large rows Fix parsing of json[] and jsonb[] types Fix slow queries on tables with nullable unique columns Fix replication crash from closed WebSocket (thanks @utkarsh-611!) Fix notifications not working in background browser tabs Log WebSocket close code 1006 as info, not error (thanks @jbingen!) Fix replication deadlock on Storer crash (thanks @utkarsh-611!) Downgrade IDBNotFoundError to info log level (thanks @jbingen!) Fix type safety for default context/schema types Fix watermark errors when restoring from litestream backups Fix replica metadata being deleted during non-disruptive resync Fix occasional server crash when Postgres goes down Set idle transaction timeout to prevent hung transactions Fix lock errors under high CDC load Retry on change-db connection errors Detect publication differences during initial sync Prevent concurrent schema migrations from racing Fix stale destroy timers on query resubscribe (thanks @alpkaravil!) Add missing @types/ws dependency (thanks @YevheniiKotyrlo!) Fix constraints not detected when definition changes but name stays same Fix duplicate mutations when retry transaction succeeds Fix analyze-query crash with scalar subqueries Detect tables moved out of published schema",
+    "content": "Updating auth tokens no cycles connection Add configurable back-pressure limit for change streamer Surface replication LSN at /statz?replication Generalize all statz output to be machine-readable Fix unique constraint violations during sync Fix zero-sqlite3 install script to work with bun Warn when mutations are rejected due to offline/error/closed state Fix queries being dropped when other queries with same hash expire Fix incorrect query results when filtering by undefined values Fix connection.connect() being ignored when in error/auth state Extra table name validation Redact sensitive info from logs Do not log mutation args Allow validation of JWT issuer and audience claims Protect against admin password timing attacks Forward origin header to API server Escape publication names Prevent denial of service attacks Fix race condition in notification handling Fix custom kvStoreProvider being ignored in React Native (thanks @kvnkusch!) Allow hybrid permissions with new queries in zero-cache-dev Fix unnecessary reconnection attempts after auth errors Fix \"database connection is not open\" error during shutdown Fix view-syncer crash from stale WebSocket messages Forward fresh auth token with each push message (thanks @jbingen!) Prevent IDB collection from deleting active databases Fix statz double close and ensure sqlite db handles are closed Fix OOM crashes when replicating databases with large rows Fix parsing of json[] and jsonb[] types Fix slow queries on tables with nullable unique columns Fix replication crash from closed WebSocket (thanks @utkarsh-611!) Fix notifications not working in background browser tabs Log WebSocket close code 1006 as info, not error (thanks @jbingen!) Fix replication deadlock on Storer crash (thanks @utkarsh-611!) Downgrade IDBNotFoundError to info log level (thanks @jbingen!) Fix type safety for default context/schema types Fix watermark errors when restoring from litestream backups Fix replica metadata being deleted during non-disruptive resync Fix occasional server crash when Postgres goes down Set idle transaction timeout to prevent hung transactions Fix lock errors under high CDC load Retry on change-db connection errors Detect publication differences during initial sync Prevent concurrent schema migrations from racing Fix stale destroy timers on query resubscribe (thanks @Karavil!) Add missing @types/ws dependency (thanks @YevheniiKotyrlo!) Fix constraints not detected when definition changes but name stays same Fix duplicate mutations when retry transaction succeeds Fix analyze-query crash with scalar subqueries Detect tables moved out of published schema",
     "kind": "section"
   },
   {
@@ -5775,7 +5760,7 @@
     "title": "Samples",
     "searchTitle": "Samples",
     "url": "/docs/samples",
-    "content": "Gigabugs A complete Linear-style bug tracker, populated with 1.2 million bugs, totalling over 1GB of sample data. This demo shows off Zero's support for large datasets and partial sync, loading from cold start in < 2s yet providing instant UI for almost all interactions. But it's not just a demo. We also use a different instance of this app everyday as our actual bug tracker to continuously dogfood Zero. Demo: https://gigabugs.rocicorp.dev/ Stack: Vite/Fastify/React/AWS Source: https://github.com/rocicorp/mono/tree/latest/apps/zbugs Features: Instant reads and writes, realtime updates, Github auth, write permissions, read permissions, complex filters, unread indicators, basic text search, emojis, short numeric bug IDs, notifications, and more. ztunes An ecommerce store built with Zero, TanStack, Drizzle, and PlanetScale for Postgres. Demo: https://ztunes.rocicorp.dev/ Stack: TanStack/Drizzle/Better Auth/Fly.io Source: https://github.com/rocicorp/ztunes Features: 88k artists, 200k albums, single-command dev, full drizzle integration, text search, read permissions, write permissions. zslack Simple Slack-like app built with Expo/React Native. Stack: Expo/Hono/Drizzle/Bun Source: https://github.com/rocicorp/zslack Features: Native iOS/Android, instant reads and writes, realtime updates.",
+    "content": "Gigabugs A complete Linear-style bug tracker, populated with 1.2 million bugs, totalling over 1GB of sample data. This demo shows off Zero's support for large datasets and partial sync, loading from cold start in < 2s yet providing instant UI for almost all interactions. But it's not just a demo. We also use a different instance of this app everyday as our actual bug tracker to continuously dogfood Zero. Demo: https://gigabugs.rocicorp.dev/ Stack: Vite/Fastify/React/AWS Source: https://github.com/rocicorp/mono/tree/latest/apps/zbugs Features: Instant reads and writes, realtime updates, Github auth, write permissions, read permissions, complex filters, unread indicators, basic text search, emojis, short numeric bug IDs, notifications, and more. ztunes An ecommerce store built with Zero, TanStack, Drizzle, and PlanetScale for Postgres. Demo: https://ztunes.rocicorp.dev/ Stack: TanStack/Drizzle/Better Auth/Fly.io Source: https://github.com/rocicorp/ztunes Features: 88k artists, 200k albums, single-command dev, full drizzle integration, text search, read permissions, write permissions. zslack Simple Slack-like app built with Expo/React Native. Stack: Expo/Hono/Drizzle/Bun Source: https://github.com/rocicorp/zslack Features: Native iOS/Android, instant reads and writes, realtime updates. onboarding Barebones music-themed app, using Zero/Tanstack Start/Drizzle. Stack: Tanstack/Drizzle/Bun Source: https://github.com/rocicorp/onboarding Features: Barebones app, optimistic reads and writes, realtime sync.",
     "headings": [
       {
         "text": "Gigabugs",
@@ -5788,6 +5773,10 @@
       {
         "text": "zslack",
         "id": "zslack"
+      },
+      {
+        "text": "onboarding",
+        "id": "onboarding"
       }
     ],
     "kind": "page"
@@ -5823,11 +5812,21 @@
     "kind": "section"
   },
   {
+    "id": "443-samples#onboarding",
+    "title": "Samples",
+    "searchTitle": "onboarding",
+    "sectionTitle": "onboarding",
+    "sectionId": "onboarding",
+    "url": "/docs/samples",
+    "content": "Barebones music-themed app, using Zero/Tanstack Start/Drizzle. Stack: Tanstack/Drizzle/Bun Source: https://github.com/rocicorp/onboarding Features: Barebones app, optimistic reads and writes, realtime sync.",
+    "kind": "section"
+  },
+  {
     "id": "62-schema",
     "title": "Zero Schema",
     "searchTitle": "Zero Schema",
     "url": "/docs/schema",
-    "content": "Zero applications have both a database schema (the normal backend schema all web apps have) and a Zero schema. The Zero schema is conventionally located in schema.ts in your app's source code. The Zero schema serves two purposes: Provide typesafety for ZQL queries Define first-class relationships between tables The Zero schema is usually generated from your backend schema, but can be defined by hand for more control. Generating from Database If you use Drizzle or Prisma ORM, you can generate schema.ts with drizzle-zero or prisma-zero: npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate We'd love more! See the source for drizzle-zero and prisma-zero as a guide, or reach out on Discord with questions. Writing by Hand You can also write Zero schemas by hand for full control. Table Schemas Use the table function to define each table in your Zero schema: import {table, string, boolean} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), partner: boolean() }) .primaryKey('id') Column types are defined with the boolean(), number(), string(), json(), and enumeration() helpers. See Column Types for how database types are mapped to these types. Name Mapping Use from() to map a TypeScript table or column name to a different database name: const userPref = table('userPref') // Map TS \"userPref\" to DB name \"user_pref\" .from('user_pref') .columns({ id: string(), // Map TS \"orgID\" to DB name \"org_id\" orgID: string().from('org_id') }) Multiple Schemas You can also use from() to access other Postgres schemas: // Sync the \"event\" table from the \"analytics\" schema. const event = table('event').from('analytics.event') Optional Columns Columns can be marked optional. This corresponds to the SQL concept nullable. const user = table('user') .columns({ id: string(), name: string(), nickName: string().optional() }) .primaryKey('id') An optional column can store a value of the specified type or null to mean no value. Note that null and undefined mean different things when working with Zero rows. When reading, if a column is optional, Zero can return null for that field. undefined is not used at all when Reading from Zero. When writing, you can specify null for an optional field to explicitly write null to the datastore, unsetting any previous value. For create and upsert you can set optional fields to undefined (or leave the field off completely) to take the default value as specified by backend schema for that column. For update you can set any non-PK field to undefined to leave the previous value unmodified. Enumerations Use the enumeration helper to define a column that can only take on a specific set of values. This is most often used alongside an enum Postgres column type. import {table, string, enumeration} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), mood: enumeration<'happy' | 'sad' | 'taco'>() }) .primaryKey('id') Custom JSON Types Use the json helper to define a column that stores a JSON-compatible value: import {table, string, json} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), settings: json<{theme: 'light' | 'dark'}>() }) .primaryKey('id') Compound Primary Keys Pass multiple columns to primaryKey to define a compound primary key: const user = table('user') .columns({ orgID: string(), userID: string(), name: string() }) .primaryKey('orgID', 'userID') Relationships Use the relationships function to define relationships between tables. Use the one and many helpers to define singular and plural relationships, respectively: const messageRelationships = relationships( message, ({one, many}) => ({ sender: one({ sourceField: ['senderID'], destField: ['id'], destSchema: user }), replies: many({ sourceField: ['id'], destSchema: message, destField: ['parentMessageID'] }) }) ) This creates \"sender\" and \"replies\" relationships that can later be queried with the related ZQL clause: const messagesWithSenderAndReplies = z.query.messages .related('sender') .related('replies') This will return an object for each message row. Each message will have a sender field that is a single User object or null, and a replies field that is an array of Message objects. Many-to-Many Relationships You can create many-to-many relationships by chaining the relationship definitions. Assuming issue and label tables, along with an issueLabel junction table, you can define a labels relationship like this: const issueRelationships = relationships( issue, ({many}) => ({ labels: many( { sourceField: ['id'], destSchema: issueLabel, destField: ['issueID'] }, { sourceField: ['labelID'], destSchema: label, destField: ['id'] } ) }) ) See https://bugs.rocicorp.dev/issue/3454. Compound Keys Relationships Relationships can traverse compound keys. Imagine a user table with a compound primary key of orgID and userID, and a message table with a related senderOrgID and senderUserID. This can be represented in your schema with: const messageRelationships = relationships( message, ({one}) => ({ sender: one({ sourceField: ['senderOrgID', 'senderUserID'], destSchema: user, destField: ['orgID', 'userID'] }) }) ) Circular Relationships Circular relationships are fully supported: const commentRelationships = relationships( comment, ({one}) => ({ parent: one({ sourceField: ['parentID'], destSchema: comment, destField: ['id'] }) }) ) Database Schemas Use createSchema to define the entire Zero schema: import {createSchema} from '@rocicorp/zero' export const schema = createSchema({ tables: [user, medium, message], relationships: [ userRelationships, mediumRelationships, messageRelationships ] }) Default Type Parameter Use DefaultTypes to register the your Schema type with Zero: declare module '@rocicorp/zero' { interface DefaultTypes { schema: Schema } } This prevents having to pass Schema manually to every Zero API. Schema Changes Zero applications have three components that interact with the database schema: Postgres, the API server (query/mutate endpoints), and the client. Development During development, you can make changes to all three components in any order: Change the Postgres schema Update the API server to use the new schema Update client code to use the new schema If the Zero client ever detects that its schema is incompatible with the server, it disconnects and fires the onUpdateNeeded event. If the API server ever detects that it has an incompatible schema, it will fail with an error. Simply reloading the app fixes both issues. Production Zero also supports downtime-free schema changes for use in production. To achieve this, the order you deploy in matters: Expand (adding things): Deploy providers before consumers. DB → API → Client. Contract (removing things): Deploy consumers before providers. Client → API → DB. For production apps, we strongly recommend testing schema changes on a staging environment that has a production-like dataset before deploying to production. Expand Changes When you're adding a column, table, or new mutator/query: Deploy the database change and wait for it to replicate through zero-cache. In Cloud Zero, you can see replication status in the dashboard. In self-hosted zero-cache, check the logs. If there's backfill, wait for that to complete. Deploy the API server. Deploy the client. If you use a custom publication with Supabase, you need to manually notify zero-cache of changes to your publication. For full-stack frameworks where the API and client deploy together, steps 2 and 3 are combined. If your change doesn't affect the Postgres schema (for example, just adding a mutator that uses existing columns), skip step 1. If your change doesn't affect the API server, skip step 2. If you deploy the API server before the schema change has replicated, mutators and/or queries will fail because they will refer to non-existent columns. If you deploy the client before the API change, the client will call mutators/queries that don't exist yet. Both these issues will cause Zero to go into an error state. The user can manually reload to recover from this as soon as the depended-upon component has been deployed. Contract Changes When you're removing a column, table, or mutator/query: Deploy the client (stop using the thing being removed). Deploy the API server (stop providing the thing being removed). Deploy the database change. When a client connects to zero-cache, it sends the schema it was built against. If that schema is incompatible with what zero-cache has (for example if server has just contracted), the client receives an error and calls onUpdateNeeded: new Zero({ // Optional. By default calls location.reload() onUpdateNeeded: reason => { if (reason.type === 'SchemaVersionNotSupported') { // Show a banner prompting the user to update } } }) By default onUpdateNeeded calls location.reload() if available. On the web, this will reload the page and the user will get the new code. For native apps or web apps that want a smoother experience, provide a custom onUpdateNeeded callback. Compound Changes Some changes are both expand and contract—like renaming a column or changing a mutator's interface. For these, you run both patterns in sequence: Expand: Add the new column/mutator. Optionally backfill data and add a trigger to keep the old column in sync. Contract: Remove the old column/mutator. Examples Adding a Column Add a bio column to the users table: Add column to database ALTER TABLE users ADD COLUMN bio TEXT; Wait for replication. Deploy API server Add bio to schema.ts Add any new queries that read bio Add any new mutators that write to bio Deploy Deploy client Update app code to display/edit bio Deploy For full-stack frameworks, steps 2 and 3 are a single deploy. Even when the API server and client are separate, they can be deployed in sequence by CI using a single PR. The client just can't be deployed until the API server is complete. Removing a Column Remove the bio column from the users table: Deploy client Remove bio from app code Deploy Deploy API server Remove mutators that write to bio Remove queries that read bio Remove bio from schema.ts Deploy Remove column from database ALTER TABLE users DROP COLUMN bio; Renaming a Column Rename nickname to displayName: Add new column with trigger ALTER TABLE users ADD COLUMN display_name TEXT; UPDATE users SET display_name = nickname; CREATE FUNCTION sync_display_name() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN -- On insert, sync whichever column was provided IF NEW.display_name IS NULL AND NEW.nickname IS NOT NULL THEN NEW.display_name := NEW.nickname; ELSIF NEW.nickname IS NULL AND NEW.display_name IS NOT NULL THEN NEW.nickname := NEW.display_name; END IF; ELSE -- UPDATE -- Sync whichever column changed IF NEW.display_name IS DISTINCT FROM OLD.display_name AND NEW.nickname IS NOT DISTINCT FROM OLD.nickname THEN NEW.nickname := NEW.display_name; ELSIF NEW.nickname IS DISTINCT FROM OLD.nickname AND NEW.display_name IS NOT DISTINCT FROM OLD.display_name THEN NEW.display_name := NEW.nickname; END IF; END IF; RETURN NEW; END; $$ LANGUAGE plpgsql; CREATE TRIGGER sync_display_name_trigger BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE FUNCTION sync_display_name(); Wait for replication. Deploy app using new column Add displayName to schema.ts Update app code to read/write displayName Update queries to read/write displayName Update mutators to use displayName Deploy API → Client Remove old column Remove nickname from schema.ts Deploy Client → API Drop trigger and old column: DROP TRIGGER sync_display_name_trigger ON users; DROP FUNCTION sync_display_name(); ALTER TABLE users DROP COLUMN nickname; Making a Column Optional Change nickname from required to optional: The safest approach is to treat this like a rename—create a new nullable column: Add new nullable column with trigger ALTER TABLE users ADD COLUMN nickname_v2 TEXT; -- nullable UPDATE users SET nickname_v2 = nickname; CREATE FUNCTION sync_nickname() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN -- On insert, sync whichever column was provided IF NEW.nickname_v2 IS NULL AND NEW.nickname IS NOT NULL THEN NEW.nickname_v2 := NEW.nickname; ELSIF NEW.nickname IS NULL AND NEW.nickname_v2 IS NOT NULL THEN NEW.nickname := COALESCE(NEW.nickname_v2, ''); -- default for old clients END IF; ELSE -- UPDATE -- Sync whichever column changed IF NEW.nickname_v2 IS DISTINCT FROM OLD.nickname_v2 AND NEW.nickname IS NOT DISTINCT FROM OLD.nickname THEN NEW.nickname := COALESCE(NEW.nickname_v2, ''); -- default for old clients ELSIF NEW.nickname IS DISTINCT FROM OLD.nickname AND NEW.nickname_v2 IS NOT DISTINCT FROM OLD.nickname_v2 THEN NEW.nickname_v2 := NEW.nickname; END IF; END IF; RETURN NEW; END; $$ LANGUAGE plpgsql; CREATE TRIGGER sync_nickname_trigger BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE FUNCTION sync_nickname(); Wait for replication. Deploy app using new column Add nicknameV2 to schema.ts as optional() Update app code to handle nulls Deploy API → Client Remove old column Remove nickname from schema.ts Rename nickname_v2 to nickname if desired (another rename cycle), or keep the new name Deploy Client → API Drop trigger and old column Quick Reference Backfill When you add a new column or table to your schema, initial data (from e.g., GENERATED, DEFAULT, CURRENT_TIMESTAMP, etc.) needs to be replicated to zero-cache and synced to clients. Similarly, when adding an existing column to a custom publication, that column's existing data needs to be replicated. Zero handles both these cases through a process called backfilling. Zero backfills existing data to the replica in the background after detecting a new column. The new column is not exposed to the client until all data has been backfilled, which may take some time depending on the amount of data. Monitoring Backfill Progress To track backfill progress, check your zero-cache logs for messages about backfilling status. If you're using Cloud Zero, backfill progress is displayed directly in the dashboard.",
+    "content": "Zero applications have both a database schema (the normal backend schema all web apps have) and a Zero schema. The Zero schema is conventionally located in schema.ts in your app's source code. The Zero schema serves two purposes: Provide typesafety for ZQL queries Define first-class relationships between tables The Zero schema is usually generated from your backend schema, but can be defined by hand for more control. Generating from Database If you use Drizzle or Prisma ORM, you can generate schema.ts with drizzle-zero or prisma-zero: npm install -D drizzle-zero npx drizzle-zero generatepnpm add -D drizzle-zero pnpm dlx drizzle-zero generatebun add -D drizzle-zero bunx drizzle-zero generateyarn add -D drizzle-zero yarn dlx drizzle-zero generatenpm install -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to your prisma schema: # generator zero { # provider = \"prisma-zero\" # } yarn prisma generate We'd love more! See the source for drizzle-zero and prisma-zero as a guide, or reach out on Discord with questions. Writing by Hand You can also write Zero schemas by hand for full control. Table Schemas Use the table function to define each table in your Zero schema: import {table, string, boolean} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), partner: boolean() }) .primaryKey('id') Column types are defined with the boolean(), number(), string(), json(), and enumeration() helpers. See Column Types for how database types are mapped to these types. Name Mapping Use from() to map a TypeScript table or column name to a different database name: const userPref = table('userPref') // Map TS \"userPref\" to DB name \"user_pref\" .from('user_pref') .columns({ id: string(), // Map TS \"orgID\" to DB name \"org_id\" orgID: string().from('org_id') }) Multiple Schemas You can also use from() to access other Postgres schemas: // Sync the \"event\" table from the \"analytics\" schema. const event = table('event').from('analytics.event') Optional Columns Columns can be marked optional. This corresponds to the SQL concept nullable. const user = table('user') .columns({ id: string(), name: string(), nickName: string().optional() }) .primaryKey('id') An optional column can store a value of the specified type or null to mean no value. Note that null and undefined mean different things when working with Zero rows. When reading, if a column is optional, Zero can return null for that field. undefined is not used at all when Reading from Zero. When writing, you can specify null for an optional field to explicitly write null to the datastore, unsetting any previous value. For create and upsert you can set optional fields to undefined (or leave the field off completely) to take the default value as specified by backend schema for that column. For update you can set any non-PK field to undefined to leave the previous value unmodified. Enumerations Use the enumeration helper to define a column that can only take on a specific set of values. This is most often used alongside an enum Postgres column type. import {table, string, enumeration} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), mood: enumeration<'happy' | 'sad' | 'taco'>() }) .primaryKey('id') Custom JSON Types Use the json helper to define a column that stores a JSON-compatible value: import {table, string, json} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), settings: json<{theme: 'light' | 'dark'}>() }) .primaryKey('id') Compound Primary Keys Pass multiple columns to primaryKey to define a compound primary key: const user = table('user') .columns({ orgID: string(), userID: string(), name: string() }) .primaryKey('orgID', 'userID') Relationships Use the relationships function to define relationships between tables. Use the one and many helpers to define singular and plural relationships, respectively: const messageRelationships = relationships( message, ({one, many}) => ({ sender: one({ sourceField: ['senderID'], destField: ['id'], destSchema: user }), replies: many({ sourceField: ['id'], destSchema: message, destField: ['parentMessageID'] }) }) ) This creates \"sender\" and \"replies\" relationships that can later be queried with the related ZQL clause: const messagesWithSenderAndReplies = z.query.messages .related('sender') .related('replies') This will return an object for each message row. Each message will have a sender field that is a single User object or null, and a replies field that is an array of Message objects. Many-to-Many Relationships You can create many-to-many relationships by chaining the relationship definitions. Assuming issue and label tables, along with an issueLabel junction table, you can define a labels relationship like this: const issueRelationships = relationships( issue, ({many}) => ({ labels: many( { sourceField: ['id'], destSchema: issueLabel, destField: ['issueID'] }, { sourceField: ['labelID'], destSchema: label, destField: ['id'] } ) }) ) See https://bugs.rocicorp.dev/issue/3454. Compound Keys Relationships Relationships can traverse compound keys. Imagine a user table with a compound primary key of orgID and userID, and a message table with a related senderOrgID and senderUserID. This can be represented in your schema with: const messageRelationships = relationships( message, ({one}) => ({ sender: one({ sourceField: ['senderOrgID', 'senderUserID'], destSchema: user, destField: ['orgID', 'userID'] }) }) ) Circular Relationships Circular relationships are fully supported: const commentRelationships = relationships( comment, ({one}) => ({ parent: one({ sourceField: ['parentID'], destSchema: comment, destField: ['id'] }) }) ) Database Schemas Use createSchema to define the entire Zero schema: import {createSchema} from '@rocicorp/zero' export const schema = createSchema({ tables: [user, medium, message], relationships: [ userRelationships, mediumRelationships, messageRelationships ] }) Register Schema Type Use DefaultTypes to register the your Schema type with Zero: declare module '@rocicorp/zero' { interface DefaultTypes { schema: Schema } } This prevents having to pass Schema manually to every Zero API. Schema Changes Zero applications have three components that interact with the database schema: Postgres, the API server (query/mutate endpoints), and the client. Development During development, you can make changes to all three components in any order: Change the Postgres schema Update the API server to use the new schema Update client code to use the new schema If the Zero client ever detects that its schema is incompatible with the server, it disconnects and fires the onUpdateNeeded event. If the API server ever detects that it has an incompatible schema, it will fail with an error. Simply reloading the app fixes both issues. Production Zero also supports downtime-free schema changes for use in production. To achieve this, the order you deploy in matters: Expand (adding things): Deploy providers before consumers. DB → API → Client. Contract (removing things): Deploy consumers before providers. Client → API → DB. For production apps, we strongly recommend testing schema changes on a staging environment that has a production-like dataset before deploying to production. Expand Changes When you're adding a column, table, or new mutator/query: Deploy the database change and wait for it to replicate through zero-cache. In Cloud Zero, you can see replication status in the dashboard. In self-hosted zero-cache, check the logs. If there's backfill, wait for that to complete. Deploy the API server. Deploy the client. If you use a custom publication with Supabase, you need to manually notify zero-cache of changes to your publication. For full-stack frameworks where the API and client deploy together, steps 2 and 3 are combined. If your change doesn't affect the Postgres schema (for example, just adding a mutator that uses existing columns), skip step 1. If your change doesn't affect the API server, skip step 2. If you deploy the API server before the schema change has replicated, mutators and/or queries will fail because they will refer to non-existent columns. If you deploy the client before the API change, the client will call mutators/queries that don't exist yet. Both these issues will cause Zero to go into an error state. The user can manually reload to recover from this as soon as the depended-upon component has been deployed. Contract Changes When you're removing a column, table, or mutator/query: Deploy the client (stop using the thing being removed). Deploy the API server (stop providing the thing being removed). Deploy the database change. When a client connects to zero-cache, it sends the schema it was built against. If that schema is incompatible with what zero-cache has (for example if server has just contracted), the client receives an error and calls onUpdateNeeded: new Zero({ // Optional. By default calls location.reload() onUpdateNeeded: reason => { if (reason.type === 'SchemaVersionNotSupported') { // Show a banner prompting the user to update } } }) By default onUpdateNeeded calls location.reload() if available. On the web, this will reload the page and the user will get the new code. For native apps or web apps that want a smoother experience, provide a custom onUpdateNeeded callback. Compound Changes Some changes are both expand and contract—like renaming a column or changing a mutator's interface. For these, you run both patterns in sequence: Expand: Add the new column/mutator. Optionally backfill data and add a trigger to keep the old column in sync. Contract: Remove the old column/mutator. Examples Adding a Column Add a bio column to the users table: Add column to database ALTER TABLE users ADD COLUMN bio TEXT; Wait for replication. Deploy API server Add bio to schema.ts Add any new queries that read bio Add any new mutators that write to bio Deploy Deploy client Update app code to display/edit bio Deploy For full-stack frameworks, steps 2 and 3 are a single deploy. Even when the API server and client are separate, they can be deployed in sequence by CI using a single PR. The client just can't be deployed until the API server is complete. Removing a Column Remove the bio column from the users table: Deploy client Remove bio from app code Deploy Deploy API server Remove mutators that write to bio Remove queries that read bio Remove bio from schema.ts Deploy Remove column from database ALTER TABLE users DROP COLUMN bio; Renaming a Column Rename nickname to displayName: Add new column with trigger ALTER TABLE users ADD COLUMN display_name TEXT; UPDATE users SET display_name = nickname; CREATE FUNCTION sync_display_name() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN -- On insert, sync whichever column was provided IF NEW.display_name IS NULL AND NEW.nickname IS NOT NULL THEN NEW.display_name := NEW.nickname; ELSIF NEW.nickname IS NULL AND NEW.display_name IS NOT NULL THEN NEW.nickname := NEW.display_name; END IF; ELSE -- UPDATE -- Sync whichever column changed IF NEW.display_name IS DISTINCT FROM OLD.display_name AND NEW.nickname IS NOT DISTINCT FROM OLD.nickname THEN NEW.nickname := NEW.display_name; ELSIF NEW.nickname IS DISTINCT FROM OLD.nickname AND NEW.display_name IS NOT DISTINCT FROM OLD.display_name THEN NEW.display_name := NEW.nickname; END IF; END IF; RETURN NEW; END; $$ LANGUAGE plpgsql; CREATE TRIGGER sync_display_name_trigger BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE FUNCTION sync_display_name(); Wait for replication. Deploy app using new column Add displayName to schema.ts Update app code to read/write displayName Update queries to read/write displayName Update mutators to use displayName Deploy API → Client Remove old column Remove nickname from schema.ts Deploy Client → API Drop trigger and old column: DROP TRIGGER sync_display_name_trigger ON users; DROP FUNCTION sync_display_name(); ALTER TABLE users DROP COLUMN nickname; Making a Column Optional Change nickname from required to optional: The safest approach is to treat this like a rename—create a new nullable column: Add new nullable column with trigger ALTER TABLE users ADD COLUMN nickname_v2 TEXT; -- nullable UPDATE users SET nickname_v2 = nickname; CREATE FUNCTION sync_nickname() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN -- On insert, sync whichever column was provided IF NEW.nickname_v2 IS NULL AND NEW.nickname IS NOT NULL THEN NEW.nickname_v2 := NEW.nickname; ELSIF NEW.nickname IS NULL AND NEW.nickname_v2 IS NOT NULL THEN NEW.nickname := COALESCE(NEW.nickname_v2, ''); -- default for old clients END IF; ELSE -- UPDATE -- Sync whichever column changed IF NEW.nickname_v2 IS DISTINCT FROM OLD.nickname_v2 AND NEW.nickname IS NOT DISTINCT FROM OLD.nickname THEN NEW.nickname := COALESCE(NEW.nickname_v2, ''); -- default for old clients ELSIF NEW.nickname IS DISTINCT FROM OLD.nickname AND NEW.nickname_v2 IS NOT DISTINCT FROM OLD.nickname_v2 THEN NEW.nickname_v2 := NEW.nickname; END IF; END IF; RETURN NEW; END; $$ LANGUAGE plpgsql; CREATE TRIGGER sync_nickname_trigger BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE FUNCTION sync_nickname(); Wait for replication. Deploy app using new column Add nicknameV2 to schema.ts as optional() Update app code to handle nulls Deploy API → Client Remove old column Remove nickname from schema.ts Rename nickname_v2 to nickname if desired (another rename cycle), or keep the new name Deploy Client → API Drop trigger and old column Quick Reference Backfill When you add a new column or table to your schema, initial data (from e.g., GENERATED, DEFAULT, CURRENT_TIMESTAMP, etc.) needs to be replicated to zero-cache and synced to clients. Similarly, when adding an existing column to a custom publication, that column's existing data needs to be replicated. Zero handles both these cases through a process called backfilling. Zero backfills existing data to the replica in the background after detecting a new column. The new column is not exposed to the client until all data has been backfilled, which may take some time depending on the amount of data. Monitoring Backfill Progress To track backfill progress, check your zero-cache logs for messages about backfilling status. If you're using Cloud Zero, backfill progress is displayed directly in the dashboard.",
     "headings": [
       {
         "text": "Generating from Database",
@@ -5886,8 +5885,8 @@
         "id": "database-schemas"
       },
       {
-        "text": "Default Type Parameter",
-        "id": "default-type-parameter"
+        "text": "Register Schema Type",
+        "id": "register-schema-type"
       },
       {
         "text": "Schema Changes",
@@ -5949,7 +5948,7 @@
     "kind": "page"
   },
   {
-    "id": "443-schema#generating-from-database",
+    "id": "444-schema#generating-from-database",
     "title": "Zero Schema",
     "searchTitle": "Generating from Database",
     "sectionTitle": "Generating from Database",
@@ -5959,17 +5958,17 @@
     "kind": "section"
   },
   {
-    "id": "444-schema#writing-by-hand",
+    "id": "445-schema#writing-by-hand",
     "title": "Zero Schema",
     "searchTitle": "Writing by Hand",
     "sectionTitle": "Writing by Hand",
     "sectionId": "writing-by-hand",
     "url": "/docs/schema",
-    "content": "You can also write Zero schemas by hand for full control. Table Schemas Use the table function to define each table in your Zero schema: import {table, string, boolean} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), partner: boolean() }) .primaryKey('id') Column types are defined with the boolean(), number(), string(), json(), and enumeration() helpers. See Column Types for how database types are mapped to these types. Name Mapping Use from() to map a TypeScript table or column name to a different database name: const userPref = table('userPref') // Map TS \"userPref\" to DB name \"user_pref\" .from('user_pref') .columns({ id: string(), // Map TS \"orgID\" to DB name \"org_id\" orgID: string().from('org_id') }) Multiple Schemas You can also use from() to access other Postgres schemas: // Sync the \"event\" table from the \"analytics\" schema. const event = table('event').from('analytics.event') Optional Columns Columns can be marked optional. This corresponds to the SQL concept nullable. const user = table('user') .columns({ id: string(), name: string(), nickName: string().optional() }) .primaryKey('id') An optional column can store a value of the specified type or null to mean no value. Note that null and undefined mean different things when working with Zero rows. When reading, if a column is optional, Zero can return null for that field. undefined is not used at all when Reading from Zero. When writing, you can specify null for an optional field to explicitly write null to the datastore, unsetting any previous value. For create and upsert you can set optional fields to undefined (or leave the field off completely) to take the default value as specified by backend schema for that column. For update you can set any non-PK field to undefined to leave the previous value unmodified. Enumerations Use the enumeration helper to define a column that can only take on a specific set of values. This is most often used alongside an enum Postgres column type. import {table, string, enumeration} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), mood: enumeration<'happy' | 'sad' | 'taco'>() }) .primaryKey('id') Custom JSON Types Use the json helper to define a column that stores a JSON-compatible value: import {table, string, json} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), settings: json<{theme: 'light' | 'dark'}>() }) .primaryKey('id') Compound Primary Keys Pass multiple columns to primaryKey to define a compound primary key: const user = table('user') .columns({ orgID: string(), userID: string(), name: string() }) .primaryKey('orgID', 'userID') Relationships Use the relationships function to define relationships between tables. Use the one and many helpers to define singular and plural relationships, respectively: const messageRelationships = relationships( message, ({one, many}) => ({ sender: one({ sourceField: ['senderID'], destField: ['id'], destSchema: user }), replies: many({ sourceField: ['id'], destSchema: message, destField: ['parentMessageID'] }) }) ) This creates \"sender\" and \"replies\" relationships that can later be queried with the related ZQL clause: const messagesWithSenderAndReplies = z.query.messages .related('sender') .related('replies') This will return an object for each message row. Each message will have a sender field that is a single User object or null, and a replies field that is an array of Message objects. Many-to-Many Relationships You can create many-to-many relationships by chaining the relationship definitions. Assuming issue and label tables, along with an issueLabel junction table, you can define a labels relationship like this: const issueRelationships = relationships( issue, ({many}) => ({ labels: many( { sourceField: ['id'], destSchema: issueLabel, destField: ['issueID'] }, { sourceField: ['labelID'], destSchema: label, destField: ['id'] } ) }) ) See https://bugs.rocicorp.dev/issue/3454. Compound Keys Relationships Relationships can traverse compound keys. Imagine a user table with a compound primary key of orgID and userID, and a message table with a related senderOrgID and senderUserID. This can be represented in your schema with: const messageRelationships = relationships( message, ({one}) => ({ sender: one({ sourceField: ['senderOrgID', 'senderUserID'], destSchema: user, destField: ['orgID', 'userID'] }) }) ) Circular Relationships Circular relationships are fully supported: const commentRelationships = relationships( comment, ({one}) => ({ parent: one({ sourceField: ['parentID'], destSchema: comment, destField: ['id'] }) }) ) Database Schemas Use createSchema to define the entire Zero schema: import {createSchema} from '@rocicorp/zero' export const schema = createSchema({ tables: [user, medium, message], relationships: [ userRelationships, mediumRelationships, messageRelationships ] }) Default Type Parameter Use DefaultTypes to register the your Schema type with Zero: declare module '@rocicorp/zero' { interface DefaultTypes { schema: Schema } } This prevents having to pass Schema manually to every Zero API.",
+    "content": "You can also write Zero schemas by hand for full control. Table Schemas Use the table function to define each table in your Zero schema: import {table, string, boolean} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), partner: boolean() }) .primaryKey('id') Column types are defined with the boolean(), number(), string(), json(), and enumeration() helpers. See Column Types for how database types are mapped to these types. Name Mapping Use from() to map a TypeScript table or column name to a different database name: const userPref = table('userPref') // Map TS \"userPref\" to DB name \"user_pref\" .from('user_pref') .columns({ id: string(), // Map TS \"orgID\" to DB name \"org_id\" orgID: string().from('org_id') }) Multiple Schemas You can also use from() to access other Postgres schemas: // Sync the \"event\" table from the \"analytics\" schema. const event = table('event').from('analytics.event') Optional Columns Columns can be marked optional. This corresponds to the SQL concept nullable. const user = table('user') .columns({ id: string(), name: string(), nickName: string().optional() }) .primaryKey('id') An optional column can store a value of the specified type or null to mean no value. Note that null and undefined mean different things when working with Zero rows. When reading, if a column is optional, Zero can return null for that field. undefined is not used at all when Reading from Zero. When writing, you can specify null for an optional field to explicitly write null to the datastore, unsetting any previous value. For create and upsert you can set optional fields to undefined (or leave the field off completely) to take the default value as specified by backend schema for that column. For update you can set any non-PK field to undefined to leave the previous value unmodified. Enumerations Use the enumeration helper to define a column that can only take on a specific set of values. This is most often used alongside an enum Postgres column type. import {table, string, enumeration} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), mood: enumeration<'happy' | 'sad' | 'taco'>() }) .primaryKey('id') Custom JSON Types Use the json helper to define a column that stores a JSON-compatible value: import {table, string, json} from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), settings: json<{theme: 'light' | 'dark'}>() }) .primaryKey('id') Compound Primary Keys Pass multiple columns to primaryKey to define a compound primary key: const user = table('user') .columns({ orgID: string(), userID: string(), name: string() }) .primaryKey('orgID', 'userID') Relationships Use the relationships function to define relationships between tables. Use the one and many helpers to define singular and plural relationships, respectively: const messageRelationships = relationships( message, ({one, many}) => ({ sender: one({ sourceField: ['senderID'], destField: ['id'], destSchema: user }), replies: many({ sourceField: ['id'], destSchema: message, destField: ['parentMessageID'] }) }) ) This creates \"sender\" and \"replies\" relationships that can later be queried with the related ZQL clause: const messagesWithSenderAndReplies = z.query.messages .related('sender') .related('replies') This will return an object for each message row. Each message will have a sender field that is a single User object or null, and a replies field that is an array of Message objects. Many-to-Many Relationships You can create many-to-many relationships by chaining the relationship definitions. Assuming issue and label tables, along with an issueLabel junction table, you can define a labels relationship like this: const issueRelationships = relationships( issue, ({many}) => ({ labels: many( { sourceField: ['id'], destSchema: issueLabel, destField: ['issueID'] }, { sourceField: ['labelID'], destSchema: label, destField: ['id'] } ) }) ) See https://bugs.rocicorp.dev/issue/3454. Compound Keys Relationships Relationships can traverse compound keys. Imagine a user table with a compound primary key of orgID and userID, and a message table with a related senderOrgID and senderUserID. This can be represented in your schema with: const messageRelationships = relationships( message, ({one}) => ({ sender: one({ sourceField: ['senderOrgID', 'senderUserID'], destSchema: user, destField: ['orgID', 'userID'] }) }) ) Circular Relationships Circular relationships are fully supported: const commentRelationships = relationships( comment, ({one}) => ({ parent: one({ sourceField: ['parentID'], destSchema: comment, destField: ['id'] }) }) ) Database Schemas Use createSchema to define the entire Zero schema: import {createSchema} from '@rocicorp/zero' export const schema = createSchema({ tables: [user, medium, message], relationships: [ userRelationships, mediumRelationships, messageRelationships ] }) Register Schema Type Use DefaultTypes to register the your Schema type with Zero: declare module '@rocicorp/zero' { interface DefaultTypes { schema: Schema } } This prevents having to pass Schema manually to every Zero API.",
     "kind": "section"
   },
   {
-    "id": "445-schema#table-schemas",
+    "id": "446-schema#table-schemas",
     "title": "Zero Schema",
     "searchTitle": "Table Schemas",
     "sectionTitle": "Table Schemas",
@@ -5979,7 +5978,7 @@
     "kind": "section"
   },
   {
-    "id": "446-schema#name-mapping",
+    "id": "447-schema#name-mapping",
     "title": "Zero Schema",
     "searchTitle": "Name Mapping",
     "sectionTitle": "Name Mapping",
@@ -5989,7 +5988,7 @@
     "kind": "section"
   },
   {
-    "id": "447-schema#multiple-schemas",
+    "id": "448-schema#multiple-schemas",
     "title": "Zero Schema",
     "searchTitle": "Multiple Schemas",
     "sectionTitle": "Multiple Schemas",
@@ -5999,7 +5998,7 @@
     "kind": "section"
   },
   {
-    "id": "448-schema#optional-columns",
+    "id": "449-schema#optional-columns",
     "title": "Zero Schema",
     "searchTitle": "Optional Columns",
     "sectionTitle": "Optional Columns",
@@ -6009,7 +6008,7 @@
     "kind": "section"
   },
   {
-    "id": "449-schema#enumerations",
+    "id": "450-schema#enumerations",
     "title": "Zero Schema",
     "searchTitle": "Enumerations",
     "sectionTitle": "Enumerations",
@@ -6019,7 +6018,7 @@
     "kind": "section"
   },
   {
-    "id": "450-schema#custom-json-types",
+    "id": "451-schema#custom-json-types",
     "title": "Zero Schema",
     "searchTitle": "Custom JSON Types",
     "sectionTitle": "Custom JSON Types",
@@ -6029,7 +6028,7 @@
     "kind": "section"
   },
   {
-    "id": "451-schema#compound-primary-keys",
+    "id": "452-schema#compound-primary-keys",
     "title": "Zero Schema",
     "searchTitle": "Compound Primary Keys",
     "sectionTitle": "Compound Primary Keys",
@@ -6039,7 +6038,7 @@
     "kind": "section"
   },
   {
-    "id": "452-schema#relationships",
+    "id": "453-schema#relationships",
     "title": "Zero Schema",
     "searchTitle": "Relationships",
     "sectionTitle": "Relationships",
@@ -6049,7 +6048,7 @@
     "kind": "section"
   },
   {
-    "id": "453-schema#many-to-many-relationships",
+    "id": "454-schema#many-to-many-relationships",
     "title": "Zero Schema",
     "searchTitle": "Many-to-Many Relationships",
     "sectionTitle": "Many-to-Many Relationships",
@@ -6059,7 +6058,7 @@
     "kind": "section"
   },
   {
-    "id": "454-schema#compound-keys-relationships",
+    "id": "455-schema#compound-keys-relationships",
     "title": "Zero Schema",
     "searchTitle": "Compound Keys Relationships",
     "sectionTitle": "Compound Keys Relationships",
@@ -6069,7 +6068,7 @@
     "kind": "section"
   },
   {
-    "id": "455-schema#circular-relationships",
+    "id": "456-schema#circular-relationships",
     "title": "Zero Schema",
     "searchTitle": "Circular Relationships",
     "sectionTitle": "Circular Relationships",
@@ -6079,7 +6078,7 @@
     "kind": "section"
   },
   {
-    "id": "456-schema#database-schemas",
+    "id": "457-schema#database-schemas",
     "title": "Zero Schema",
     "searchTitle": "Database Schemas",
     "sectionTitle": "Database Schemas",
@@ -6089,17 +6088,17 @@
     "kind": "section"
   },
   {
-    "id": "457-schema#default-type-parameter",
+    "id": "458-schema#register-schema-type",
     "title": "Zero Schema",
-    "searchTitle": "Default Type Parameter",
-    "sectionTitle": "Default Type Parameter",
-    "sectionId": "default-type-parameter",
+    "searchTitle": "Register Schema Type",
+    "sectionTitle": "Register Schema Type",
+    "sectionId": "register-schema-type",
     "url": "/docs/schema",
     "content": "Use DefaultTypes to register the your Schema type with Zero: declare module '@rocicorp/zero' { interface DefaultTypes { schema: Schema } } This prevents having to pass Schema manually to every Zero API.",
     "kind": "section"
   },
   {
-    "id": "458-schema#schema-changes",
+    "id": "459-schema#schema-changes",
     "title": "Zero Schema",
     "searchTitle": "Schema Changes",
     "sectionTitle": "Schema Changes",
@@ -6109,7 +6108,7 @@
     "kind": "section"
   },
   {
-    "id": "459-schema#development",
+    "id": "460-schema#development",
     "title": "Zero Schema",
     "searchTitle": "Development",
     "sectionTitle": "Development",
@@ -6119,7 +6118,7 @@
     "kind": "section"
   },
   {
-    "id": "460-schema#production",
+    "id": "461-schema#production",
     "title": "Zero Schema",
     "searchTitle": "Production",
     "sectionTitle": "Production",
@@ -6129,7 +6128,7 @@
     "kind": "section"
   },
   {
-    "id": "461-schema#expand-changes",
+    "id": "462-schema#expand-changes",
     "title": "Zero Schema",
     "searchTitle": "Expand Changes",
     "sectionTitle": "Expand Changes",
@@ -6139,7 +6138,7 @@
     "kind": "section"
   },
   {
-    "id": "462-schema#contract-changes",
+    "id": "463-schema#contract-changes",
     "title": "Zero Schema",
     "searchTitle": "Contract Changes",
     "sectionTitle": "Contract Changes",
@@ -6149,7 +6148,7 @@
     "kind": "section"
   },
   {
-    "id": "463-schema#compound-changes",
+    "id": "464-schema#compound-changes",
     "title": "Zero Schema",
     "searchTitle": "Compound Changes",
     "sectionTitle": "Compound Changes",
@@ -6159,7 +6158,7 @@
     "kind": "section"
   },
   {
-    "id": "464-schema#examples",
+    "id": "465-schema#examples",
     "title": "Zero Schema",
     "searchTitle": "Examples",
     "sectionTitle": "Examples",
@@ -6169,7 +6168,7 @@
     "kind": "section"
   },
   {
-    "id": "465-schema#adding-a-column",
+    "id": "466-schema#adding-a-column",
     "title": "Zero Schema",
     "searchTitle": "Adding a Column",
     "sectionTitle": "Adding a Column",
@@ -6179,7 +6178,7 @@
     "kind": "section"
   },
   {
-    "id": "466-schema#removing-a-column",
+    "id": "467-schema#removing-a-column",
     "title": "Zero Schema",
     "searchTitle": "Removing a Column",
     "sectionTitle": "Removing a Column",
@@ -6189,7 +6188,7 @@
     "kind": "section"
   },
   {
-    "id": "467-schema#renaming-a-column",
+    "id": "468-schema#renaming-a-column",
     "title": "Zero Schema",
     "searchTitle": "Renaming a Column",
     "sectionTitle": "Renaming a Column",
@@ -6199,7 +6198,7 @@
     "kind": "section"
   },
   {
-    "id": "468-schema#making-a-column-optional",
+    "id": "469-schema#making-a-column-optional",
     "title": "Zero Schema",
     "searchTitle": "Making a Column Optional",
     "sectionTitle": "Making a Column Optional",
@@ -6209,7 +6208,7 @@
     "kind": "section"
   },
   {
-    "id": "469-schema#quick-reference",
+    "id": "470-schema#quick-reference",
     "title": "Zero Schema",
     "searchTitle": "Quick Reference",
     "sectionTitle": "Quick Reference",
@@ -6219,7 +6218,7 @@
     "kind": "section"
   },
   {
-    "id": "470-schema#backfill",
+    "id": "471-schema#backfill",
     "title": "Zero Schema",
     "searchTitle": "Backfill",
     "sectionTitle": "Backfill",
@@ -6229,7 +6228,7 @@
     "kind": "section"
   },
   {
-    "id": "471-schema#monitoring-backfill-progress",
+    "id": "472-schema#monitoring-backfill-progress",
     "title": "Zero Schema",
     "searchTitle": "Monitoring Backfill Progress",
     "sectionTitle": "Monitoring Backfill Progress",
@@ -6297,7 +6296,7 @@
     "kind": "page"
   },
   {
-    "id": "472-self-host#minimum-viable-strategy",
+    "id": "473-self-host#minimum-viable-strategy",
     "title": "Self-Hosting Zero",
     "searchTitle": "Minimum Viable Strategy",
     "sectionTitle": "Minimum Viable Strategy",
@@ -6307,7 +6306,7 @@
     "kind": "section"
   },
   {
-    "id": "473-self-host#maximal-strategy",
+    "id": "474-self-host#maximal-strategy",
     "title": "Self-Hosting Zero",
     "searchTitle": "Maximal Strategy",
     "sectionTitle": "Maximal Strategy",
@@ -6317,7 +6316,7 @@
     "kind": "section"
   },
   {
-    "id": "474-self-host#replica-lifecycle",
+    "id": "475-self-host#replica-lifecycle",
     "title": "Self-Hosting Zero",
     "searchTitle": "Replica Lifecycle",
     "sectionTitle": "Replica Lifecycle",
@@ -6327,7 +6326,7 @@
     "kind": "section"
   },
   {
-    "id": "475-self-host#performance",
+    "id": "476-self-host#performance",
     "title": "Self-Hosting Zero",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
@@ -6337,7 +6336,7 @@
     "kind": "section"
   },
   {
-    "id": "476-self-host#hydration",
+    "id": "477-self-host#hydration",
     "title": "Self-Hosting Zero",
     "searchTitle": "Hydration",
     "sectionTitle": "Hydration",
@@ -6347,7 +6346,7 @@
     "kind": "section"
   },
   {
-    "id": "477-self-host#ivm-advancement",
+    "id": "478-self-host#ivm-advancement",
     "title": "Self-Hosting Zero",
     "searchTitle": "IVM advancement",
     "sectionTitle": "IVM advancement",
@@ -6357,7 +6356,7 @@
     "kind": "section"
   },
   {
-    "id": "478-self-host#system-level",
+    "id": "479-self-host#system-level",
     "title": "Self-Hosting Zero",
     "searchTitle": "System-level",
     "sectionTitle": "System-level",
@@ -6367,7 +6366,7 @@
     "kind": "section"
   },
   {
-    "id": "479-self-host#networking",
+    "id": "480-self-host#networking",
     "title": "Self-Hosting Zero",
     "searchTitle": "Networking",
     "sectionTitle": "Networking",
@@ -6377,7 +6376,7 @@
     "kind": "section"
   },
   {
-    "id": "480-self-host#sticky-sessions",
+    "id": "481-self-host#sticky-sessions",
     "title": "Self-Hosting Zero",
     "searchTitle": "Sticky Sessions",
     "sectionTitle": "Sticky Sessions",
@@ -6387,7 +6386,7 @@
     "kind": "section"
   },
   {
-    "id": "481-self-host#rolling-updates",
+    "id": "482-self-host#rolling-updates",
     "title": "Self-Hosting Zero",
     "searchTitle": "Rolling Updates",
     "sectionTitle": "Rolling Updates",
@@ -6397,7 +6396,7 @@
     "kind": "section"
   },
   {
-    "id": "482-self-host#clientserver-version-compatibility",
+    "id": "483-self-host#clientserver-version-compatibility",
     "title": "Self-Hosting Zero",
     "searchTitle": "Client/Server Version Compatibility",
     "sectionTitle": "Client/Server Version Compatibility",
@@ -6407,7 +6406,7 @@
     "kind": "section"
   },
   {
-    "id": "483-self-host#configuration",
+    "id": "484-self-host#configuration",
     "title": "Self-Hosting Zero",
     "searchTitle": "Configuration",
     "sectionTitle": "Configuration",
@@ -6421,7 +6420,7 @@
     "title": "ZQL on the Server",
     "searchTitle": "ZQL on the Server",
     "url": "/docs/server-zql",
-    "content": "The Zero package includes utilities to run ZQL on the server directly against your upstream Postgres database. This is useful for many reasons: It allows mutators to read data using ZQL to check permissions or invariants. You can use ZQL to implement standard REST endpoints, allowing you to share code with mutators. In the future (but not yet implemented), this can support server-side rendering. ZQLDatabase currently does a read of your postgres schema before every transaction. This is fine for most usages, but for high scale it may become a problem. Let us know if you need a fix for this. Creating a Database To run ZQL on the database, you will create a ZQLDatabase instance. Zero ships with several built-in factories for popular Postgres libraries and ORMs. // app/api/mutate/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' interface Database { user: { id: string name: string | null status: 'active' | 'inactive' } } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // You can also pass a client instead of a pool: // // const client = new Client({ // connectionString: process.env.ZERO_UPSTREAM_DB! // }) // await client.connect() // export const dbProvider = zeroNodePg(schema, client) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Within your mutators, you can access the underlying transaction via tx.dbTransaction.wrappedTransaction: // mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction .insert(drizzleSchema.user) .values({id, name}) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction .insertInto('user') .values({id, name, status: 'active'}) .execute() } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction.user.create( { data: { id, name, status: 'active' } } ) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction.query( 'insert into \"user\" (id, name) values ($1, $2) returning *', [id, name] ) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction< {id: string; name: string}[] >`insert into \"user\" (id, name) values (${id}, ${name}) returning *` } } ) }) Custom Database To implement support for some other Postgres bindings library, you will implement the DBConnection interface. See the implementations for the existing adapters for examples. Running ZQL Once you have an instance of ZQLDatabase, use the transaction() method to run ZQL: await dbProvider.transaction(async tx => { // await tx.mutate... // await tx.query... // await myMutator.fn({tx, ctx, args}) }) SSR Zero doesn't yet have the wiring setup in its bindings layers to really nicely support server-side rendering (patches welcome though!). For now, we don't recommend using Zero with SSR. Use your framework's recommended pattern to prevent SSR execution: import {lazy} from 'react' // Use React lazy to defer loading the ZeroProvider const ZeroProvider = lazy(() => import('@rocicorp/zero/react').then(mod => ({ default: mod.ZeroProvider })) ) function Root() { return ( <ZeroProvider> <App /> </ZeroProvider> ) }// Mark client-only components 'use client' import {ZeroProvider} from '@rocicorp/zero/react' export default function Root() { return ( <ZeroProvider> <App /> </ZeroProvider> ) }import {clientOnly} from '@solidjs/start' const ZeroProvider = clientOnly(async () => { // Optionally dynamic import to code-split return import('@rocicorp/zero/solid').then(mod => ({ default: mod.ZeroProvider })) }) export default function Root() { return ( <ZeroProvider> <App /> </ZeroProvider> ) }",
+    "content": "The Zero package includes utilities to run ZQL on the server directly against your upstream Postgres database. This is useful for many reasons: It allows mutators to read data using ZQL to check permissions or invariants. You can use ZQL to implement standard REST endpoints, allowing you to share code with mutators. In the future (but not yet implemented), this can support server-side rendering. ZQLDatabase currently does a read of your postgres schema before every transaction. This is fine for most usages, but for high scale it may become a problem. Let us know if you need a fix for this. Creating a Database To run ZQL on the server, you will create a ZQLDatabase instance. Zero ships with several built-in factories for popular Postgres libraries and ORMs. // app/api/mutate/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' interface Database { user: { id: string name: string | null status: 'active' | 'inactive' } } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // You can also pass a client instead of a pool: // // const client = new Client({ // connectionString: process.env.ZERO_UPSTREAM_DB! // }) // await client.connect() // export const dbProvider = zeroNodePg(schema, client) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Within your mutators, you can access the underlying transaction via tx.dbTransaction.wrappedTransaction: // mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction .insert(drizzleSchema.user) .values({id, name}) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction .insertInto('user') .values({id, name, status: 'active'}) .execute() } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction.user.create( { data: { id, name, status: 'active' } } ) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction.query( 'insert into \"user\" (id, name) values ($1, $2) returning *', [id, name] ) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction< {id: string; name: string}[] >`insert into \"user\" (id, name) values (${id}, ${name}) returning *` } } ) }) Custom Database To implement support for some other Postgres bindings library, you will implement the DBConnection interface. See the implementations for the existing adapters for examples. Running ZQL Once you have an instance of ZQLDatabase, use the transaction() method to run ZQL: await dbProvider.transaction(async tx => { // await tx.mutate... // await tx.query... // await myMutator.fn({tx, ctx, args}) }) SSR Zero doesn't yet have the wiring setup in its bindings layers to really nicely support server-side rendering (patches welcome though!). For now, we don't recommend using Zero with SSR. Use your framework's recommended pattern to prevent SSR execution: import {lazy} from 'react' // Use React lazy to defer loading the ZeroProvider const ZeroProvider = lazy(() => import('@rocicorp/zero/react').then(mod => ({ default: mod.ZeroProvider })) ) function Root() { return ( <ZeroProvider> <App /> </ZeroProvider> ) }// Mark client-only components 'use client' import {ZeroProvider} from '@rocicorp/zero/react' export default function Root() { return ( <ZeroProvider> <App /> </ZeroProvider> ) }import {clientOnly} from '@solidjs/start' const ZeroProvider = clientOnly(async () => { // Optionally dynamic import to code-split return import('@rocicorp/zero/solid').then(mod => ({ default: mod.ZeroProvider })) }) export default function Root() { return ( <ZeroProvider> <App /> </ZeroProvider> ) }",
     "headings": [
       {
         "text": "Creating a Database",
@@ -6443,17 +6442,17 @@
     "kind": "page"
   },
   {
-    "id": "484-server-zql#creating-a-database",
+    "id": "485-server-zql#creating-a-database",
     "title": "ZQL on the Server",
     "searchTitle": "Creating a Database",
     "sectionTitle": "Creating a Database",
     "sectionId": "creating-a-database",
     "url": "/docs/server-zql",
-    "content": "To run ZQL on the database, you will create a ZQLDatabase instance. Zero ships with several built-in factories for popular Postgres libraries and ORMs. // app/api/mutate/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' interface Database { user: { id: string name: string | null status: 'active' | 'inactive' } } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // You can also pass a client instead of a pool: // // const client = new Client({ // connectionString: process.env.ZERO_UPSTREAM_DB! // }) // await client.connect() // export const dbProvider = zeroNodePg(schema, client) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Within your mutators, you can access the underlying transaction via tx.dbTransaction.wrappedTransaction: // mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction .insert(drizzleSchema.user) .values({id, name}) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction .insertInto('user') .values({id, name, status: 'active'}) .execute() } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction.user.create( { data: { id, name, status: 'active' } } ) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction.query( 'insert into \"user\" (id, name) values ($1, $2) returning *', [id, name] ) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction< {id: string; name: string}[] >`insert into \"user\" (id, name) values (${id}, ${name}) returning *` } } ) }) Custom Database To implement support for some other Postgres bindings library, you will implement the DBConnection interface. See the implementations for the existing adapters for examples.",
+    "content": "To run ZQL on the server, you will create a ZQLDatabase instance. Zero ships with several built-in factories for popular Postgres libraries and ORMs. // app/api/mutate/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {schema} from '../../zero/schema.ts' import * as drizzleSchema from '../../drizzle/schema.ts' // pass a drizzle client instance. for example: export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' interface Database { user: { id: string name: string | null status: 'active' | 'inactive' } } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from '../../zero/schema.ts' const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: process.env.ZERO_UPSTREAM_DB! }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from '../../zero/schema.ts' const pool = new Pool({ connectionString: process.env.ZERO_UPSTREAM_DB! }) export const dbProvider = zeroNodePg(schema, pool) // You can also pass a client instead of a pool: // // const client = new Client({ // connectionString: process.env.ZERO_UPSTREAM_DB! // }) // await client.connect() // export const dbProvider = zeroNodePg(schema, client) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// app/api/mutate/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from '../../zero/schema.ts' const sql = postgres(process.env.ZERO_UPSTREAM_DB!) export const dbProvider = zeroPostgresJS(schema, sql) // Register the database provider for type safety declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Within your mutators, you can access the underlying transaction via tx.dbTransaction.wrappedTransaction: // mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction .insert(drizzleSchema.user) .values({id, name}) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction .insertInto('user') .values({id, name, status: 'active'}) .execute() } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction.user.create( { data: { id, name, status: 'active' } } ) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction.query( 'insert into \"user\" (id, name) values ($1, $2) returning *', [id, name] ) } } ) })// mutators.ts export const mutators = defineMutators({ createUser: defineMutator( z.object({id: z.string(), name: z.string()}), async ({tx, args: {id, name}}) => { if (tx.location === 'server') { await tx.dbTransaction.wrappedTransaction< {id: string; name: string}[] >`insert into \"user\" (id, name) values (${id}, ${name}) returning *` } } ) }) Custom Database To implement support for some other Postgres bindings library, you will implement the DBConnection interface. See the implementations for the existing adapters for examples.",
     "kind": "section"
   },
   {
-    "id": "485-server-zql#custom-database",
+    "id": "486-server-zql#custom-database",
     "title": "ZQL on the Server",
     "searchTitle": "Custom Database",
     "sectionTitle": "Custom Database",
@@ -6463,7 +6462,7 @@
     "kind": "section"
   },
   {
-    "id": "486-server-zql#running-zql",
+    "id": "487-server-zql#running-zql",
     "title": "ZQL on the Server",
     "searchTitle": "Running ZQL",
     "sectionTitle": "Running ZQL",
@@ -6473,7 +6472,7 @@
     "kind": "section"
   },
   {
-    "id": "487-server-zql#ssr",
+    "id": "488-server-zql#ssr",
     "title": "ZQL on the Server",
     "searchTitle": "SSR",
     "sectionTitle": "SSR",
@@ -6505,7 +6504,7 @@
     "kind": "page"
   },
   {
-    "id": "488-solidjs#setup",
+    "id": "489-solidjs#setup",
     "title": "SolidJS",
     "searchTitle": "Setup",
     "sectionTitle": "Setup",
@@ -6515,7 +6514,7 @@
     "kind": "section"
   },
   {
-    "id": "489-solidjs#usage",
+    "id": "490-solidjs#usage",
     "title": "SolidJS",
     "searchTitle": "Usage",
     "sectionTitle": "Usage",
@@ -6525,7 +6524,7 @@
     "kind": "section"
   },
   {
-    "id": "490-solidjs#examples",
+    "id": "491-solidjs#examples",
     "title": "SolidJS",
     "searchTitle": "Examples",
     "sectionTitle": "Examples",
@@ -6561,7 +6560,7 @@
     "kind": "page"
   },
   {
-    "id": "491-status#breaking-changes",
+    "id": "492-status#breaking-changes",
     "title": "Project Status",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -6571,7 +6570,7 @@
     "kind": "section"
   },
   {
-    "id": "492-status#roadmap",
+    "id": "493-status#roadmap",
     "title": "Project Status",
     "searchTitle": "Roadmap",
     "sectionTitle": "Roadmap",
@@ -6581,7 +6580,7 @@
     "kind": "section"
   },
   {
-    "id": "493-status#2026",
+    "id": "494-status#2026",
     "title": "Project Status",
     "searchTitle": "2026",
     "sectionTitle": "2026",
@@ -6591,7 +6590,7 @@
     "kind": "section"
   },
   {
-    "id": "494-status#soon",
+    "id": "495-status#soon",
     "title": "Project Status",
     "searchTitle": "Soon",
     "sectionTitle": "Soon",
@@ -6623,7 +6622,7 @@
     "kind": "page"
   },
   {
-    "id": "495-sync#problem",
+    "id": "496-sync#problem",
     "title": "What is Sync?",
     "searchTitle": "Problem",
     "sectionTitle": "Problem",
@@ -6633,7 +6632,7 @@
     "kind": "section"
   },
   {
-    "id": "496-sync#solution",
+    "id": "497-sync#solution",
     "title": "What is Sync?",
     "searchTitle": "Solution",
     "sectionTitle": "Solution",
@@ -6643,7 +6642,7 @@
     "kind": "section"
   },
   {
-    "id": "497-sync#history-of-sync",
+    "id": "498-sync#history-of-sync",
     "title": "What is Sync?",
     "searchTitle": "History of Sync",
     "sectionTitle": "History of Sync",
@@ -6653,7 +6652,213 @@
     "kind": "section"
   },
   {
-    "id": "68-when-to-use",
+    "id": "68-tutorial",
+    "title": "Tutorial",
+    "searchTitle": "Tutorial",
+    "url": "/docs/tutorial",
+    "content": "This guide builds a small music app with Zero from scratch. It's a nice way to get a feel for how Zero works and takes about 15 minutes to complete. You will seed a Postgres database with artists and albums, run zero-cache, add a query and a mutator, and watch data sync across clients in realtime. If you want to wire Zero into your own app, see Installation. Integrate Zero Create a Project Start with a TypeScript frontend framework: npx @tanstack/cli@latest create zero-music \\ --package-manager npm --yes --no-intent cd zero-musicpnpm dlx @tanstack/cli@latest create zero-music \\ --package-manager pnpm --yes --no-intent cd zero-musicbunx @tanstack/cli@latest create zero-music \\ --package-manager bun --yes --no-intent cd zero-musicnpx create-next-app@latest zero-music --yes --use-npm cd zero-musicpnpm create next-app zero-music --yes --use-pnpm cd zero-musicnpx create-next-app@latest zero-music --yes --use-bun cd zero-musicnpm init solid -- zero-music basic --solidstart --ts --v2 cd zero-music npm installpnpm create solid zero-music basic --solidstart --ts --v2 cd zero-music pnpm installbun create solid zero-music basic --solidstart --ts --v2 cd zero-music bun install Set Up Your Database You'll need a Postgres database with logical replication enabled. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Connecting to Postgres and make sure wal_level is logical. Then, create some music-themed tables and seed them with data (this step uses psql if you don't already have it). # Creates new albums, artists, fans, # and favorites tables with sample music data curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \\ | psql postgres://postgres:pass@localhost:5432/zero Create a .env file so your app server and zero-cache-dev use the same Postgres connection: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install and Run Zero-Cache Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\" Set Up Your Zero Schema Zero uses a schema.ts file to provide a type-safe query API on the client. Download the music-app schema: mkdir -p src/zero curl https://raw.githubusercontent.com/rocicorp/zero-music/1-install/packages/zero/src/schema.ts \\ -o src/zero/schema.ts This quickstart uses a premade schema.ts so you can stay focused on how Zero works. In a real app, you would usually generate schema.ts from your own Drizzle or Prisma schema, or manually add it alongside your application schema. See Installation and Zero Schema. Set Up the Zero Client Zero has first-class support for React and SolidJS. There is also a low-level API you can use in any TypeScript-based project. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero Music</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero} Sync Data Define Query Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev Invoke Query Use the seeded data to fetch albums for The Beatles under artist_1. // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export default function Page() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery} from '@rocicorp/zero/solid' import {queries} from '../zero/queries' export default function Home() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {queries} from './zero/queries' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) This query will run against the zero-cache replica and return Abbey Road and Revolver. The client will update its local datastore with these new albums, and future queries will run optimistically against the local data. Also, Zero queries are reactive, so if you edit data in Postgres directly, you will see it replicate to the Zero replica and the UI: Mutate Data Define Mutators Now let's add a write path that inserts a new album: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. Mutations are written directly to Postgres and replicated to the client. Your other code that writes to the same tables will also sync instantly to the client. First, create a dbProvider with node-postgres: // src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Add the mutate endpoint itself: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) } Restart zero-cache with ZERO_MUTATE_URL configured: ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-dev Invoke Mutators Now add a button to create an album: // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Page() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery, useZero} from '@rocicorp/zero/solid' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Home() { const zero = useZero() const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero().mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {mutators} from './zero/mutators' import {queries} from './zero/queries' const client = await zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log( 'albums', albums.map(album => album.title) ) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Please Please Me will appear in the album list immediately. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients: That's it! You now have a simple, Zero-powered music app. Try opening multiple browser windows to see the realtime sync in action!",
+    "headings": [
+      {
+        "text": "Integrate Zero",
+        "id": "integrate-zero"
+      },
+      {
+        "text": "Create a Project",
+        "id": "create-a-project"
+      },
+      {
+        "text": "Set Up Your Database",
+        "id": "set-up-your-database"
+      },
+      {
+        "text": "Install and Run Zero-Cache",
+        "id": "install-and-run-zero-cache"
+      },
+      {
+        "text": "Set Up Your Zero Schema",
+        "id": "set-up-your-zero-schema"
+      },
+      {
+        "text": "Set Up the Zero Client",
+        "id": "set-up-the-zero-client"
+      },
+      {
+        "text": "Sync Data",
+        "id": "sync-data"
+      },
+      {
+        "text": "Define Query",
+        "id": "define-query"
+      },
+      {
+        "text": "Add Query Endpoint",
+        "id": "add-query-endpoint"
+      },
+      {
+        "text": "Invoke Query",
+        "id": "invoke-query"
+      },
+      {
+        "text": "Mutate Data",
+        "id": "mutate-data"
+      },
+      {
+        "text": "Define Mutators",
+        "id": "define-mutators"
+      },
+      {
+        "text": "Add Mutate Endpoint",
+        "id": "add-mutate-endpoint"
+      },
+      {
+        "text": "Invoke Mutators",
+        "id": "invoke-mutators"
+      }
+    ],
+    "kind": "page"
+  },
+  {
+    "id": "499-tutorial#integrate-zero",
+    "title": "Tutorial",
+    "searchTitle": "Integrate Zero",
+    "sectionTitle": "Integrate Zero",
+    "sectionId": "integrate-zero",
+    "url": "/docs/tutorial",
+    "content": "Create a Project Start with a TypeScript frontend framework: npx @tanstack/cli@latest create zero-music \\ --package-manager npm --yes --no-intent cd zero-musicpnpm dlx @tanstack/cli@latest create zero-music \\ --package-manager pnpm --yes --no-intent cd zero-musicbunx @tanstack/cli@latest create zero-music \\ --package-manager bun --yes --no-intent cd zero-musicnpx create-next-app@latest zero-music --yes --use-npm cd zero-musicpnpm create next-app zero-music --yes --use-pnpm cd zero-musicnpx create-next-app@latest zero-music --yes --use-bun cd zero-musicnpm init solid -- zero-music basic --solidstart --ts --v2 cd zero-music npm installpnpm create solid zero-music basic --solidstart --ts --v2 cd zero-music pnpm installbun create solid zero-music basic --solidstart --ts --v2 cd zero-music bun install Set Up Your Database You'll need a Postgres database with logical replication enabled. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Connecting to Postgres and make sure wal_level is logical. Then, create some music-themed tables and seed them with data (this step uses psql if you don't already have it). # Creates new albums, artists, fans, # and favorites tables with sample music data curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \\ | psql postgres://postgres:pass@localhost:5432/zero Create a .env file so your app server and zero-cache-dev use the same Postgres connection: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install and Run Zero-Cache Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\" Set Up Your Zero Schema Zero uses a schema.ts file to provide a type-safe query API on the client. Download the music-app schema: mkdir -p src/zero curl https://raw.githubusercontent.com/rocicorp/zero-music/1-install/packages/zero/src/schema.ts \\ -o src/zero/schema.ts This quickstart uses a premade schema.ts so you can stay focused on how Zero works. In a real app, you would usually generate schema.ts from your own Drizzle or Prisma schema, or manually add it alongside your application schema. See Installation and Zero Schema. Set Up the Zero Client Zero has first-class support for React and SolidJS. There is also a low-level API you can use in any TypeScript-based project. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero Music</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero}",
+    "kind": "section"
+  },
+  {
+    "id": "500-tutorial#create-a-project",
+    "title": "Tutorial",
+    "searchTitle": "Create a Project",
+    "sectionTitle": "Create a Project",
+    "sectionId": "create-a-project",
+    "url": "/docs/tutorial",
+    "content": "Start with a TypeScript frontend framework: npx @tanstack/cli@latest create zero-music \\ --package-manager npm --yes --no-intent cd zero-musicpnpm dlx @tanstack/cli@latest create zero-music \\ --package-manager pnpm --yes --no-intent cd zero-musicbunx @tanstack/cli@latest create zero-music \\ --package-manager bun --yes --no-intent cd zero-musicnpx create-next-app@latest zero-music --yes --use-npm cd zero-musicpnpm create next-app zero-music --yes --use-pnpm cd zero-musicnpx create-next-app@latest zero-music --yes --use-bun cd zero-musicnpm init solid -- zero-music basic --solidstart --ts --v2 cd zero-music npm installpnpm create solid zero-music basic --solidstart --ts --v2 cd zero-music pnpm installbun create solid zero-music basic --solidstart --ts --v2 cd zero-music bun install",
+    "kind": "section"
+  },
+  {
+    "id": "501-tutorial#set-up-your-database",
+    "title": "Tutorial",
+    "searchTitle": "Set Up Your Database",
+    "sectionTitle": "Set Up Your Database",
+    "sectionId": "set-up-your-database",
+    "url": "/docs/tutorial",
+    "content": "You'll need a Postgres database with logical replication enabled. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Connecting to Postgres and make sure wal_level is logical. Then, create some music-themed tables and seed them with data (this step uses psql if you don't already have it). # Creates new albums, artists, fans, # and favorites tables with sample music data curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \\ | psql postgres://postgres:pass@localhost:5432/zero Create a .env file so your app server and zero-cache-dev use the same Postgres connection: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\"",
+    "kind": "section"
+  },
+  {
+    "id": "502-tutorial#install-and-run-zero-cache",
+    "title": "Tutorial",
+    "searchTitle": "Install and Run Zero-Cache",
+    "sectionTitle": "Install and Run Zero-Cache",
+    "sectionId": "install-and-run-zero-cache",
+    "url": "/docs/tutorial",
+    "content": "Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\"",
+    "kind": "section"
+  },
+  {
+    "id": "503-tutorial#set-up-your-zero-schema",
+    "title": "Tutorial",
+    "searchTitle": "Set Up Your Zero Schema",
+    "sectionTitle": "Set Up Your Zero Schema",
+    "sectionId": "set-up-your-zero-schema",
+    "url": "/docs/tutorial",
+    "content": "Zero uses a schema.ts file to provide a type-safe query API on the client. Download the music-app schema: mkdir -p src/zero curl https://raw.githubusercontent.com/rocicorp/zero-music/1-install/packages/zero/src/schema.ts \\ -o src/zero/schema.ts This quickstart uses a premade schema.ts so you can stay focused on how Zero works. In a real app, you would usually generate schema.ts from your own Drizzle or Prisma schema, or manually add it alongside your application schema. See Installation and Zero Schema.",
+    "kind": "section"
+  },
+  {
+    "id": "504-tutorial#set-up-the-zero-client",
+    "title": "Tutorial",
+    "searchTitle": "Set Up the Zero Client",
+    "sectionTitle": "Set Up the Zero Client",
+    "sectionId": "set-up-the-zero-client",
+    "url": "/docs/tutorial",
+    "content": "Zero has first-class support for React and SolidJS. There is also a low-level API you can use in any TypeScript-based project. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero Music</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero}",
+    "kind": "section"
+  },
+  {
+    "id": "505-tutorial#sync-data",
+    "title": "Tutorial",
+    "searchTitle": "Sync Data",
+    "sectionTitle": "Sync Data",
+    "sectionId": "sync-data",
+    "url": "/docs/tutorial",
+    "content": "Define Query Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev Invoke Query Use the seeded data to fetch albums for The Beatles under artist_1. // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export default function Page() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery} from '@rocicorp/zero/solid' import {queries} from '../zero/queries' export default function Home() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {queries} from './zero/queries' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) This query will run against the zero-cache replica and return Abbey Road and Revolver. The client will update its local datastore with these new albums, and future queries will run optimistically against the local data. Also, Zero queries are reactive, so if you edit data in Postgres directly, you will see it replicate to the Zero replica and the UI:",
+    "kind": "section"
+  },
+  {
+    "id": "506-tutorial#define-query",
+    "title": "Tutorial",
+    "searchTitle": "Define Query",
+    "sectionTitle": "Define Query",
+    "sectionId": "define-query",
+    "url": "/docs/tutorial",
+    "content": "Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more:",
+    "kind": "section"
+  },
+  {
+    "id": "507-tutorial#add-query-endpoint",
+    "title": "Tutorial",
+    "searchTitle": "Add Query Endpoint",
+    "sectionTitle": "Add Query Endpoint",
+    "sectionId": "add-query-endpoint",
+    "url": "/docs/tutorial",
+    "content": "Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev",
+    "kind": "section"
+  },
+  {
+    "id": "508-tutorial#invoke-query",
+    "title": "Tutorial",
+    "searchTitle": "Invoke Query",
+    "sectionTitle": "Invoke Query",
+    "sectionId": "invoke-query",
+    "url": "/docs/tutorial",
+    "content": "Use the seeded data to fetch albums for The Beatles under artist_1. // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export default function Page() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery} from '@rocicorp/zero/solid' import {queries} from '../zero/queries' export default function Home() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {queries} from './zero/queries' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) This query will run against the zero-cache replica and return Abbey Road and Revolver. The client will update its local datastore with these new albums, and future queries will run optimistically against the local data. Also, Zero queries are reactive, so if you edit data in Postgres directly, you will see it replicate to the Zero replica and the UI:",
+    "kind": "section"
+  },
+  {
+    "id": "509-tutorial#mutate-data",
+    "title": "Tutorial",
+    "searchTitle": "Mutate Data",
+    "sectionTitle": "Mutate Data",
+    "sectionId": "mutate-data",
+    "url": "/docs/tutorial",
+    "content": "Define Mutators Now let's add a write path that inserts a new album: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. Mutations are written directly to Postgres and replicated to the client. Your other code that writes to the same tables will also sync instantly to the client. First, create a dbProvider with node-postgres: // src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Add the mutate endpoint itself: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) } Restart zero-cache with ZERO_MUTATE_URL configured: ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-dev Invoke Mutators Now add a button to create an album: // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Page() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery, useZero} from '@rocicorp/zero/solid' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Home() { const zero = useZero() const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero().mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {mutators} from './zero/mutators' import {queries} from './zero/queries' const client = await zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log( 'albums', albums.map(album => album.title) ) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Please Please Me will appear in the album list immediately. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients: That's it! You now have a simple, Zero-powered music app. Try opening multiple browser windows to see the realtime sync in action!",
+    "kind": "section"
+  },
+  {
+    "id": "510-tutorial#define-mutators",
+    "title": "Tutorial",
+    "searchTitle": "Define Mutators",
+    "sectionTitle": "Define Mutators",
+    "sectionId": "define-mutators",
+    "url": "/docs/tutorial",
+    "content": "Now let's add a write path that inserts a new album: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }",
+    "kind": "section"
+  },
+  {
+    "id": "511-tutorial#add-mutate-endpoint",
+    "title": "Tutorial",
+    "searchTitle": "Add Mutate Endpoint",
+    "sectionTitle": "Add Mutate Endpoint",
+    "sectionId": "add-mutate-endpoint",
+    "url": "/docs/tutorial",
+    "content": "Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. Mutations are written directly to Postgres and replicated to the client. Your other code that writes to the same tables will also sync instantly to the client. First, create a dbProvider with node-postgres: // src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Add the mutate endpoint itself: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) } Restart zero-cache with ZERO_MUTATE_URL configured: ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-dev",
+    "kind": "section"
+  },
+  {
+    "id": "512-tutorial#invoke-mutators",
+    "title": "Tutorial",
+    "searchTitle": "Invoke Mutators",
+    "sectionTitle": "Invoke Mutators",
+    "sectionId": "invoke-mutators",
+    "url": "/docs/tutorial",
+    "content": "Now add a button to create an album: // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Page() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery, useZero} from '@rocicorp/zero/solid' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Home() { const zero = useZero() const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero().mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {mutators} from './zero/mutators' import {queries} from './zero/queries' const client = await zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log( 'albums', albums.map(album => album.title) ) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Please Please Me will appear in the album list immediately. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients: That's it! You now have a simple, Zero-powered music app. Try opening multiple browser windows to see the realtime sync in action!",
+    "kind": "section"
+  },
+  {
+    "id": "69-when-to-use",
     "title": "When To Use Zero",
     "searchTitle": "When To Use Zero",
     "url": "/docs/when-to-use",
@@ -6719,7 +6924,7 @@
     "kind": "page"
   },
   {
-    "id": "498-when-to-use#zero-might-be-a-good-fit",
+    "id": "513-when-to-use#zero-might-be-a-good-fit",
     "title": "When To Use Zero",
     "searchTitle": "Zero Might be a Good Fit",
     "sectionTitle": "Zero Might be a Good Fit",
@@ -6729,7 +6934,7 @@
     "kind": "section"
   },
   {
-    "id": "499-when-to-use#you-want-to-sync-only-a-small-subset-of-data-to-client",
+    "id": "514-when-to-use#you-want-to-sync-only-a-small-subset-of-data-to-client",
     "title": "When To Use Zero",
     "searchTitle": "You want to sync only a small subset of data to client",
     "sectionTitle": "You want to sync only a small subset of data to client",
@@ -6739,7 +6944,7 @@
     "kind": "section"
   },
   {
-    "id": "500-when-to-use#you-need-fine-grained-read-or-write-permissions",
+    "id": "515-when-to-use#you-need-fine-grained-read-or-write-permissions",
     "title": "When To Use Zero",
     "searchTitle": "You need fine-grained read or write permissions",
     "sectionTitle": "You need fine-grained read or write permissions",
@@ -6749,7 +6954,7 @@
     "kind": "section"
   },
   {
-    "id": "501-when-to-use#you-are-building-a-traditional-client-server-web-app",
+    "id": "516-when-to-use#you-are-building-a-traditional-client-server-web-app",
     "title": "When To Use Zero",
     "searchTitle": "You are building a traditional client-server web app",
     "sectionTitle": "You are building a traditional client-server web app",
@@ -6759,7 +6964,7 @@
     "kind": "section"
   },
   {
-    "id": "502-when-to-use#you-use-postgresql",
+    "id": "517-when-to-use#you-use-postgresql",
     "title": "When To Use Zero",
     "searchTitle": "You use PostgreSQL",
     "sectionTitle": "You use PostgreSQL",
@@ -6769,7 +6974,7 @@
     "kind": "section"
   },
   {
-    "id": "503-when-to-use#your-app-is-broadly-like-linear",
+    "id": "518-when-to-use#your-app-is-broadly-like-linear",
     "title": "When To Use Zero",
     "searchTitle": "Your app is broadly \"like Linear\"",
     "sectionTitle": "Your app is broadly \"like Linear\"",
@@ -6779,7 +6984,7 @@
     "kind": "section"
   },
   {
-    "id": "504-when-to-use#interaction-performance-is-very-important-to-you",
+    "id": "519-when-to-use#interaction-performance-is-very-important-to-you",
     "title": "When To Use Zero",
     "searchTitle": "Interaction performance is very important to you",
     "sectionTitle": "Interaction performance is very important to you",
@@ -6789,7 +6994,7 @@
     "kind": "section"
   },
   {
-    "id": "505-when-to-use#zero-might-not-be-a-good-fit",
+    "id": "520-when-to-use#zero-might-not-be-a-good-fit",
     "title": "When To Use Zero",
     "searchTitle": "Zero Might Not be a Good Fit",
     "sectionTitle": "Zero Might Not be a Good Fit",
@@ -6799,7 +7004,7 @@
     "kind": "section"
   },
   {
-    "id": "506-when-to-use#you-need-the-privacy-or-data-ownership-benefits-of-local-first",
+    "id": "521-when-to-use#you-need-the-privacy-or-data-ownership-benefits-of-local-first",
     "title": "When To Use Zero",
     "searchTitle": "You need the privacy or data ownership benefits of local-first",
     "sectionTitle": "You need the privacy or data ownership benefits of local-first",
@@ -6809,7 +7014,7 @@
     "kind": "section"
   },
   {
-    "id": "507-when-to-use#you-need-to-support-offline-writes-or-long-periods-offline",
+    "id": "522-when-to-use#you-need-to-support-offline-writes-or-long-periods-offline",
     "title": "When To Use Zero",
     "searchTitle": "You need to support offline writes or long periods offline",
     "sectionTitle": "You need to support offline writes or long periods offline",
@@ -6819,7 +7024,7 @@
     "kind": "section"
   },
   {
-    "id": "508-when-to-use#you-are-building-a-native-mobile-app",
+    "id": "523-when-to-use#you-are-building-a-native-mobile-app",
     "title": "When To Use Zero",
     "searchTitle": "You are building a native mobile app",
     "sectionTitle": "You are building a native mobile app",
@@ -6829,7 +7034,7 @@
     "kind": "section"
   },
   {
-    "id": "509-when-to-use#the-total-backend-dataset-is--100gb",
+    "id": "524-when-to-use#the-total-backend-dataset-is--100gb",
     "title": "When To Use Zero",
     "searchTitle": "The total backend dataset is > ~100GB",
     "sectionTitle": "The total backend dataset is > ~100GB",
@@ -6839,7 +7044,7 @@
     "kind": "section"
   },
   {
-    "id": "510-when-to-use#zero-might-not-be-a-good-fit-yet",
+    "id": "525-when-to-use#zero-might-not-be-a-good-fit-yet",
     "title": "When To Use Zero",
     "searchTitle": "Zero Might Not be a Good Fit Yet",
     "sectionTitle": "Zero Might Not be a Good Fit Yet",
@@ -6849,7 +7054,7 @@
     "kind": "section"
   },
   {
-    "id": "511-when-to-use#alternatives",
+    "id": "526-when-to-use#alternatives",
     "title": "When To Use Zero",
     "searchTitle": "Alternatives",
     "sectionTitle": "Alternatives",
@@ -6859,7 +7064,7 @@
     "kind": "section"
   },
   {
-    "id": "69-zero-cache-config",
+    "id": "70-zero-cache-config",
     "title": "zero-cache Config",
     "searchTitle": "zero-cache Config",
     "url": "/docs/zero-cache-config",
@@ -7185,7 +7390,7 @@
     "kind": "page"
   },
   {
-    "id": "512-zero-cache-config#required-flags",
+    "id": "527-zero-cache-config#required-flags",
     "title": "zero-cache Config",
     "searchTitle": "Required Flags",
     "sectionTitle": "Required Flags",
@@ -7195,7 +7400,7 @@
     "kind": "section"
   },
   {
-    "id": "513-zero-cache-config#upstream-db",
+    "id": "528-zero-cache-config#upstream-db",
     "title": "zero-cache Config",
     "searchTitle": "Upstream DB",
     "sectionTitle": "Upstream DB",
@@ -7205,7 +7410,7 @@
     "kind": "section"
   },
   {
-    "id": "514-zero-cache-config#admin-password",
+    "id": "529-zero-cache-config#admin-password",
     "title": "zero-cache Config",
     "searchTitle": "Admin Password",
     "sectionTitle": "Admin Password",
@@ -7215,7 +7420,7 @@
     "kind": "section"
   },
   {
-    "id": "515-zero-cache-config#optional-flags",
+    "id": "530-zero-cache-config#optional-flags",
     "title": "zero-cache Config",
     "searchTitle": "Optional Flags",
     "sectionTitle": "Optional Flags",
@@ -7225,7 +7430,7 @@
     "kind": "section"
   },
   {
-    "id": "516-zero-cache-config#app-id",
+    "id": "531-zero-cache-config#app-id",
     "title": "zero-cache Config",
     "searchTitle": "App ID",
     "sectionTitle": "App ID",
@@ -7235,7 +7440,7 @@
     "kind": "section"
   },
   {
-    "id": "517-zero-cache-config#app-publications",
+    "id": "532-zero-cache-config#app-publications",
     "title": "zero-cache Config",
     "searchTitle": "App Publications",
     "sectionTitle": "App Publications",
@@ -7245,7 +7450,7 @@
     "kind": "section"
   },
   {
-    "id": "518-zero-cache-config#auth-revalidate-interval-seconds",
+    "id": "533-zero-cache-config#auth-revalidate-interval-seconds",
     "title": "zero-cache Config",
     "searchTitle": "Auth Revalidate Interval Seconds",
     "sectionTitle": "Auth Revalidate Interval Seconds",
@@ -7255,7 +7460,7 @@
     "kind": "section"
   },
   {
-    "id": "519-zero-cache-config#auth-retransform-interval-seconds",
+    "id": "534-zero-cache-config#auth-retransform-interval-seconds",
     "title": "zero-cache Config",
     "searchTitle": "Auth Retransform Interval Seconds",
     "sectionTitle": "Auth Retransform Interval Seconds",
@@ -7265,7 +7470,7 @@
     "kind": "section"
   },
   {
-    "id": "520-zero-cache-config#auto-reset",
+    "id": "535-zero-cache-config#auto-reset",
     "title": "zero-cache Config",
     "searchTitle": "Auto Reset",
     "sectionTitle": "Auto Reset",
@@ -7275,7 +7480,7 @@
     "kind": "section"
   },
   {
-    "id": "521-zero-cache-config#change-db",
+    "id": "536-zero-cache-config#change-db",
     "title": "zero-cache Config",
     "searchTitle": "Change DB",
     "sectionTitle": "Change DB",
@@ -7285,7 +7490,7 @@
     "kind": "section"
   },
   {
-    "id": "522-zero-cache-config#change-max-connections",
+    "id": "537-zero-cache-config#change-max-connections",
     "title": "zero-cache Config",
     "searchTitle": "Change Max Connections",
     "sectionTitle": "Change Max Connections",
@@ -7295,7 +7500,7 @@
     "kind": "section"
   },
   {
-    "id": "523-zero-cache-config#change-streamer-back-pressure-limit-heap-proportion",
+    "id": "538-zero-cache-config#change-streamer-back-pressure-limit-heap-proportion",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Back Pressure Limit Heap Proportion",
     "sectionTitle": "Change Streamer Back Pressure Limit Heap Proportion",
@@ -7305,7 +7510,7 @@
     "kind": "section"
   },
   {
-    "id": "524-zero-cache-config#change-streamer-flow-control-consensus-padding-seconds",
+    "id": "539-zero-cache-config#change-streamer-flow-control-consensus-padding-seconds",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Flow Control Consensus Padding Seconds",
     "sectionTitle": "Change Streamer Flow Control Consensus Padding Seconds",
@@ -7315,7 +7520,7 @@
     "kind": "section"
   },
   {
-    "id": "525-zero-cache-config#change-streamer-mode",
+    "id": "540-zero-cache-config#change-streamer-mode",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Mode",
     "sectionTitle": "Change Streamer Mode",
@@ -7325,7 +7530,7 @@
     "kind": "section"
   },
   {
-    "id": "526-zero-cache-config#change-streamer-port",
+    "id": "541-zero-cache-config#change-streamer-port",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Port",
     "sectionTitle": "Change Streamer Port",
@@ -7335,7 +7540,7 @@
     "kind": "section"
   },
   {
-    "id": "527-zero-cache-config#change-streamer-startup-delay-ms",
+    "id": "542-zero-cache-config#change-streamer-startup-delay-ms",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Startup Delay (ms)",
     "sectionTitle": "Change Streamer Startup Delay (ms)",
@@ -7345,7 +7550,7 @@
     "kind": "section"
   },
   {
-    "id": "528-zero-cache-config#change-streamer-uri",
+    "id": "543-zero-cache-config#change-streamer-uri",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer URI",
     "sectionTitle": "Change Streamer URI",
@@ -7355,7 +7560,7 @@
     "kind": "section"
   },
   {
-    "id": "529-zero-cache-config#cvr-db",
+    "id": "544-zero-cache-config#cvr-db",
     "title": "zero-cache Config",
     "searchTitle": "CVR DB",
     "sectionTitle": "CVR DB",
@@ -7365,7 +7570,7 @@
     "kind": "section"
   },
   {
-    "id": "530-zero-cache-config#cvr-garbage-collection-inactivity-threshold-hours",
+    "id": "545-zero-cache-config#cvr-garbage-collection-inactivity-threshold-hours",
     "title": "zero-cache Config",
     "searchTitle": "CVR Garbage Collection Inactivity Threshold Hours",
     "sectionTitle": "CVR Garbage Collection Inactivity Threshold Hours",
@@ -7375,7 +7580,7 @@
     "kind": "section"
   },
   {
-    "id": "531-zero-cache-config#cvr-garbage-collection-initial-batch-size",
+    "id": "546-zero-cache-config#cvr-garbage-collection-initial-batch-size",
     "title": "zero-cache Config",
     "searchTitle": "CVR Garbage Collection Initial Batch Size",
     "sectionTitle": "CVR Garbage Collection Initial Batch Size",
@@ -7385,7 +7590,7 @@
     "kind": "section"
   },
   {
-    "id": "532-zero-cache-config#cvr-garbage-collection-initial-interval-seconds",
+    "id": "547-zero-cache-config#cvr-garbage-collection-initial-interval-seconds",
     "title": "zero-cache Config",
     "searchTitle": "CVR Garbage Collection Initial Interval Seconds",
     "sectionTitle": "CVR Garbage Collection Initial Interval Seconds",
@@ -7395,7 +7600,7 @@
     "kind": "section"
   },
   {
-    "id": "533-zero-cache-config#cvr-max-connections",
+    "id": "548-zero-cache-config#cvr-max-connections",
     "title": "zero-cache Config",
     "searchTitle": "CVR Max Connections",
     "sectionTitle": "CVR Max Connections",
@@ -7405,7 +7610,7 @@
     "kind": "section"
   },
   {
-    "id": "534-zero-cache-config#enable-query-planner",
+    "id": "549-zero-cache-config#enable-query-planner",
     "title": "zero-cache Config",
     "searchTitle": "Enable Query Planner",
     "sectionTitle": "Enable Query Planner",
@@ -7415,7 +7620,7 @@
     "kind": "section"
   },
   {
-    "id": "535-zero-cache-config#enable-crud-mutations",
+    "id": "550-zero-cache-config#enable-crud-mutations",
     "title": "zero-cache Config",
     "searchTitle": "Enable CRUD Mutations",
     "sectionTitle": "Enable CRUD Mutations",
@@ -7425,7 +7630,7 @@
     "kind": "section"
   },
   {
-    "id": "536-zero-cache-config#enable-telemetry",
+    "id": "551-zero-cache-config#enable-telemetry",
     "title": "zero-cache Config",
     "searchTitle": "Enable Telemetry",
     "sectionTitle": "Enable Telemetry",
@@ -7435,7 +7640,7 @@
     "kind": "section"
   },
   {
-    "id": "537-zero-cache-config#initial-sync-table-copy-workers",
+    "id": "552-zero-cache-config#initial-sync-table-copy-workers",
     "title": "zero-cache Config",
     "searchTitle": "Initial Sync Table Copy Workers",
     "sectionTitle": "Initial Sync Table Copy Workers",
@@ -7445,7 +7650,7 @@
     "kind": "section"
   },
   {
-    "id": "538-zero-cache-config#lazy-startup",
+    "id": "553-zero-cache-config#lazy-startup",
     "title": "zero-cache Config",
     "searchTitle": "Lazy Startup",
     "sectionTitle": "Lazy Startup",
@@ -7455,7 +7660,7 @@
     "kind": "section"
   },
   {
-    "id": "539-zero-cache-config#litestream-backup-url",
+    "id": "554-zero-cache-config#litestream-backup-url",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Backup URL",
     "sectionTitle": "Litestream Backup URL",
@@ -7465,7 +7670,7 @@
     "kind": "section"
   },
   {
-    "id": "540-zero-cache-config#litestream-endpoint",
+    "id": "555-zero-cache-config#litestream-endpoint",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Endpoint",
     "sectionTitle": "Litestream Endpoint",
@@ -7475,7 +7680,7 @@
     "kind": "section"
   },
   {
-    "id": "541-zero-cache-config#litestream-checkpoint-threshold-mb",
+    "id": "556-zero-cache-config#litestream-checkpoint-threshold-mb",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Checkpoint Threshold MB",
     "sectionTitle": "Litestream Checkpoint Threshold MB",
@@ -7485,7 +7690,7 @@
     "kind": "section"
   },
   {
-    "id": "542-zero-cache-config#litestream-config-path",
+    "id": "557-zero-cache-config#litestream-config-path",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Config Path",
     "sectionTitle": "Litestream Config Path",
@@ -7495,7 +7700,7 @@
     "kind": "section"
   },
   {
-    "id": "543-zero-cache-config#litestream-executable",
+    "id": "558-zero-cache-config#litestream-executable",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Executable",
     "sectionTitle": "Litestream Executable",
@@ -7505,7 +7710,7 @@
     "kind": "section"
   },
   {
-    "id": "544-zero-cache-config#litestream-incremental-backup-interval-minutes",
+    "id": "559-zero-cache-config#litestream-incremental-backup-interval-minutes",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Incremental Backup Interval Minutes",
     "sectionTitle": "Litestream Incremental Backup Interval Minutes",
@@ -7515,7 +7720,7 @@
     "kind": "section"
   },
   {
-    "id": "545-zero-cache-config#litestream-maximum-checkpoint-page-count",
+    "id": "560-zero-cache-config#litestream-maximum-checkpoint-page-count",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Maximum Checkpoint Page Count",
     "sectionTitle": "Litestream Maximum Checkpoint Page Count",
@@ -7525,7 +7730,7 @@
     "kind": "section"
   },
   {
-    "id": "546-zero-cache-config#litestream-minimum-checkpoint-page-count",
+    "id": "561-zero-cache-config#litestream-minimum-checkpoint-page-count",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Minimum Checkpoint Page Count",
     "sectionTitle": "Litestream Minimum Checkpoint Page Count",
@@ -7535,7 +7740,7 @@
     "kind": "section"
   },
   {
-    "id": "547-zero-cache-config#litestream-multipart-concurrency",
+    "id": "562-zero-cache-config#litestream-multipart-concurrency",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Multipart Concurrency",
     "sectionTitle": "Litestream Multipart Concurrency",
@@ -7545,7 +7750,7 @@
     "kind": "section"
   },
   {
-    "id": "548-zero-cache-config#litestream-multipart-size",
+    "id": "563-zero-cache-config#litestream-multipart-size",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Multipart Size",
     "sectionTitle": "Litestream Multipart Size",
@@ -7555,7 +7760,7 @@
     "kind": "section"
   },
   {
-    "id": "549-zero-cache-config#litestream-log-level",
+    "id": "564-zero-cache-config#litestream-log-level",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Log Level",
     "sectionTitle": "Litestream Log Level",
@@ -7565,7 +7770,7 @@
     "kind": "section"
   },
   {
-    "id": "550-zero-cache-config#litestream-port",
+    "id": "565-zero-cache-config#litestream-port",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Port",
     "sectionTitle": "Litestream Port",
@@ -7575,7 +7780,7 @@
     "kind": "section"
   },
   {
-    "id": "551-zero-cache-config#litestream-restore-parallelism",
+    "id": "566-zero-cache-config#litestream-restore-parallelism",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Restore Parallelism",
     "sectionTitle": "Litestream Restore Parallelism",
@@ -7585,7 +7790,7 @@
     "kind": "section"
   },
   {
-    "id": "552-zero-cache-config#litestream-snapshot-backup-interval-hours",
+    "id": "567-zero-cache-config#litestream-snapshot-backup-interval-hours",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Snapshot Backup Interval Hours",
     "sectionTitle": "Litestream Snapshot Backup Interval Hours",
@@ -7595,7 +7800,7 @@
     "kind": "section"
   },
   {
-    "id": "553-zero-cache-config#log-format",
+    "id": "568-zero-cache-config#log-format",
     "title": "zero-cache Config",
     "searchTitle": "Log Format",
     "sectionTitle": "Log Format",
@@ -7605,7 +7810,7 @@
     "kind": "section"
   },
   {
-    "id": "554-zero-cache-config#log-ivm-sampling",
+    "id": "569-zero-cache-config#log-ivm-sampling",
     "title": "zero-cache Config",
     "searchTitle": "Log IVM Sampling",
     "sectionTitle": "Log IVM Sampling",
@@ -7615,7 +7820,7 @@
     "kind": "section"
   },
   {
-    "id": "555-zero-cache-config#log-level",
+    "id": "570-zero-cache-config#log-level",
     "title": "zero-cache Config",
     "searchTitle": "Log Level",
     "sectionTitle": "Log Level",
@@ -7625,7 +7830,7 @@
     "kind": "section"
   },
   {
-    "id": "556-zero-cache-config#log-slow-hydrate-threshold",
+    "id": "571-zero-cache-config#log-slow-hydrate-threshold",
     "title": "zero-cache Config",
     "searchTitle": "Log Slow Hydrate Threshold",
     "sectionTitle": "Log Slow Hydrate Threshold",
@@ -7635,7 +7840,7 @@
     "kind": "section"
   },
   {
-    "id": "557-zero-cache-config#log-slow-row-threshold",
+    "id": "572-zero-cache-config#log-slow-row-threshold",
     "title": "zero-cache Config",
     "searchTitle": "Log Slow Row Threshold",
     "sectionTitle": "Log Slow Row Threshold",
@@ -7645,7 +7850,7 @@
     "kind": "section"
   },
   {
-    "id": "558-zero-cache-config#mutate-api-key",
+    "id": "573-zero-cache-config#mutate-api-key",
     "title": "zero-cache Config",
     "searchTitle": "Mutate API Key",
     "sectionTitle": "Mutate API Key",
@@ -7655,7 +7860,7 @@
     "kind": "section"
   },
   {
-    "id": "559-zero-cache-config#mutate-allowed-client-headers",
+    "id": "574-zero-cache-config#mutate-allowed-client-headers",
     "title": "zero-cache Config",
     "searchTitle": "Mutate Allowed Client Headers",
     "sectionTitle": "Mutate Allowed Client Headers",
@@ -7665,7 +7870,7 @@
     "kind": "section"
   },
   {
-    "id": "560-zero-cache-config#mutate-forward-cookies",
+    "id": "575-zero-cache-config#mutate-forward-cookies",
     "title": "zero-cache Config",
     "searchTitle": "Mutate Forward Cookies",
     "sectionTitle": "Mutate Forward Cookies",
@@ -7675,7 +7880,7 @@
     "kind": "section"
   },
   {
-    "id": "561-zero-cache-config#mutate-url",
+    "id": "576-zero-cache-config#mutate-url",
     "title": "zero-cache Config",
     "searchTitle": "Mutate URL",
     "sectionTitle": "Mutate URL",
@@ -7685,7 +7890,7 @@
     "kind": "section"
   },
   {
-    "id": "562-zero-cache-config#number-of-sync-workers",
+    "id": "577-zero-cache-config#number-of-sync-workers",
     "title": "zero-cache Config",
     "searchTitle": "Number of Sync Workers",
     "sectionTitle": "Number of Sync Workers",
@@ -7695,7 +7900,7 @@
     "kind": "section"
   },
   {
-    "id": "563-zero-cache-config#per-user-mutation-limit-max",
+    "id": "578-zero-cache-config#per-user-mutation-limit-max",
     "title": "zero-cache Config",
     "searchTitle": "Per User Mutation Limit Max",
     "sectionTitle": "Per User Mutation Limit Max",
@@ -7705,7 +7910,7 @@
     "kind": "section"
   },
   {
-    "id": "564-zero-cache-config#per-user-mutation-limit-window-ms",
+    "id": "579-zero-cache-config#per-user-mutation-limit-window-ms",
     "title": "zero-cache Config",
     "searchTitle": "Per User Mutation Limit Window (ms)",
     "sectionTitle": "Per User Mutation Limit Window (ms)",
@@ -7715,7 +7920,7 @@
     "kind": "section"
   },
   {
-    "id": "565-zero-cache-config#port",
+    "id": "580-zero-cache-config#port",
     "title": "zero-cache Config",
     "searchTitle": "Port",
     "sectionTitle": "Port",
@@ -7725,7 +7930,7 @@
     "kind": "section"
   },
   {
-    "id": "566-zero-cache-config#query-api-key",
+    "id": "581-zero-cache-config#query-api-key",
     "title": "zero-cache Config",
     "searchTitle": "Query API Key",
     "sectionTitle": "Query API Key",
@@ -7735,7 +7940,7 @@
     "kind": "section"
   },
   {
-    "id": "567-zero-cache-config#query-allowed-client-headers",
+    "id": "582-zero-cache-config#query-allowed-client-headers",
     "title": "zero-cache Config",
     "searchTitle": "Query Allowed Client Headers",
     "sectionTitle": "Query Allowed Client Headers",
@@ -7745,7 +7950,7 @@
     "kind": "section"
   },
   {
-    "id": "568-zero-cache-config#query-forward-cookies",
+    "id": "583-zero-cache-config#query-forward-cookies",
     "title": "zero-cache Config",
     "searchTitle": "Query Forward Cookies",
     "sectionTitle": "Query Forward Cookies",
@@ -7755,7 +7960,7 @@
     "kind": "section"
   },
   {
-    "id": "569-zero-cache-config#query-hydration-stats",
+    "id": "584-zero-cache-config#query-hydration-stats",
     "title": "zero-cache Config",
     "searchTitle": "Query Hydration Stats",
     "sectionTitle": "Query Hydration Stats",
@@ -7765,7 +7970,7 @@
     "kind": "section"
   },
   {
-    "id": "570-zero-cache-config#query-url",
+    "id": "585-zero-cache-config#query-url",
     "title": "zero-cache Config",
     "searchTitle": "Query URL",
     "sectionTitle": "Query URL",
@@ -7775,7 +7980,7 @@
     "kind": "section"
   },
   {
-    "id": "571-zero-cache-config#replica-file",
+    "id": "586-zero-cache-config#replica-file",
     "title": "zero-cache Config",
     "searchTitle": "Replica File",
     "sectionTitle": "Replica File",
@@ -7785,7 +7990,7 @@
     "kind": "section"
   },
   {
-    "id": "572-zero-cache-config#replica-vacuum-interval-hours",
+    "id": "587-zero-cache-config#replica-vacuum-interval-hours",
     "title": "zero-cache Config",
     "searchTitle": "Replica Vacuum Interval Hours",
     "sectionTitle": "Replica Vacuum Interval Hours",
@@ -7795,7 +8000,7 @@
     "kind": "section"
   },
   {
-    "id": "573-zero-cache-config#replication-lag-report-interval-ms",
+    "id": "588-zero-cache-config#replication-lag-report-interval-ms",
     "title": "zero-cache Config",
     "searchTitle": "Replication Lag Report Interval (ms)",
     "sectionTitle": "Replication Lag Report Interval (ms)",
@@ -7805,7 +8010,7 @@
     "kind": "section"
   },
   {
-    "id": "574-zero-cache-config#server-version",
+    "id": "589-zero-cache-config#server-version",
     "title": "zero-cache Config",
     "searchTitle": "Server Version",
     "sectionTitle": "Server Version",
@@ -7815,7 +8020,7 @@
     "kind": "section"
   },
   {
-    "id": "575-zero-cache-config#shadow-sync-enabled",
+    "id": "590-zero-cache-config#shadow-sync-enabled",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Enabled",
     "sectionTitle": "Shadow Sync Enabled",
@@ -7825,7 +8030,7 @@
     "kind": "section"
   },
   {
-    "id": "576-zero-cache-config#shadow-sync-interval-hours",
+    "id": "591-zero-cache-config#shadow-sync-interval-hours",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Interval Hours",
     "sectionTitle": "Shadow Sync Interval Hours",
@@ -7835,7 +8040,7 @@
     "kind": "section"
   },
   {
-    "id": "577-zero-cache-config#shadow-sync-sample-rate",
+    "id": "592-zero-cache-config#shadow-sync-sample-rate",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Sample Rate",
     "sectionTitle": "Shadow Sync Sample Rate",
@@ -7845,7 +8050,7 @@
     "kind": "section"
   },
   {
-    "id": "578-zero-cache-config#shadow-sync-max-rows-per-table",
+    "id": "593-zero-cache-config#shadow-sync-max-rows-per-table",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Max Rows Per Table",
     "sectionTitle": "Shadow Sync Max Rows Per Table",
@@ -7855,7 +8060,7 @@
     "kind": "section"
   },
   {
-    "id": "579-zero-cache-config#storage-db-temp-dir",
+    "id": "594-zero-cache-config#storage-db-temp-dir",
     "title": "zero-cache Config",
     "searchTitle": "Storage DB Temp Dir",
     "sectionTitle": "Storage DB Temp Dir",
@@ -7865,7 +8070,7 @@
     "kind": "section"
   },
   {
-    "id": "580-zero-cache-config#task-id",
+    "id": "595-zero-cache-config#task-id",
     "title": "zero-cache Config",
     "searchTitle": "Task ID",
     "sectionTitle": "Task ID",
@@ -7875,7 +8080,7 @@
     "kind": "section"
   },
   {
-    "id": "581-zero-cache-config#upstream-max-connections",
+    "id": "596-zero-cache-config#upstream-max-connections",
     "title": "zero-cache Config",
     "searchTitle": "Upstream Max Connections",
     "sectionTitle": "Upstream Max Connections",
@@ -7885,7 +8090,7 @@
     "kind": "section"
   },
   {
-    "id": "582-zero-cache-config#upstream-pg-replication-slot-failover",
+    "id": "597-zero-cache-config#upstream-pg-replication-slot-failover",
     "title": "zero-cache Config",
     "searchTitle": "Upstream PG Replication Slot Failover",
     "sectionTitle": "Upstream PG Replication Slot Failover",
@@ -7895,7 +8100,7 @@
     "kind": "section"
   },
   {
-    "id": "583-zero-cache-config#websocket-compression",
+    "id": "598-zero-cache-config#websocket-compression",
     "title": "zero-cache Config",
     "searchTitle": "Websocket Compression",
     "sectionTitle": "Websocket Compression",
@@ -7905,7 +8110,7 @@
     "kind": "section"
   },
   {
-    "id": "584-zero-cache-config#websocket-compression-options",
+    "id": "599-zero-cache-config#websocket-compression-options",
     "title": "zero-cache Config",
     "searchTitle": "Websocket Compression Options",
     "sectionTitle": "Websocket Compression Options",
@@ -7915,7 +8120,7 @@
     "kind": "section"
   },
   {
-    "id": "585-zero-cache-config#websocket-max-payload-bytes",
+    "id": "600-zero-cache-config#websocket-max-payload-bytes",
     "title": "zero-cache Config",
     "searchTitle": "Websocket Max Payload Bytes",
     "sectionTitle": "Websocket Max Payload Bytes",
@@ -7925,7 +8130,7 @@
     "kind": "section"
   },
   {
-    "id": "586-zero-cache-config#yield-threshold-ms",
+    "id": "601-zero-cache-config#yield-threshold-ms",
     "title": "zero-cache Config",
     "searchTitle": "Yield Threshold (ms)",
     "sectionTitle": "Yield Threshold (ms)",
@@ -7935,7 +8140,7 @@
     "kind": "section"
   },
   {
-    "id": "587-zero-cache-config#deprecated-flags",
+    "id": "602-zero-cache-config#deprecated-flags",
     "title": "zero-cache Config",
     "searchTitle": "Deprecated Flags",
     "sectionTitle": "Deprecated Flags",
@@ -7945,7 +8150,7 @@
     "kind": "section"
   },
   {
-    "id": "588-zero-cache-config#auth-jwk",
+    "id": "603-zero-cache-config#auth-jwk",
     "title": "zero-cache Config",
     "searchTitle": "Auth JWK",
     "sectionTitle": "Auth JWK",
@@ -7955,7 +8160,7 @@
     "kind": "section"
   },
   {
-    "id": "589-zero-cache-config#auth-jwks-url",
+    "id": "604-zero-cache-config#auth-jwks-url",
     "title": "zero-cache Config",
     "searchTitle": "Auth JWKS URL",
     "sectionTitle": "Auth JWKS URL",
@@ -7965,7 +8170,7 @@
     "kind": "section"
   },
   {
-    "id": "590-zero-cache-config#auth-secret",
+    "id": "605-zero-cache-config#auth-secret",
     "title": "zero-cache Config",
     "searchTitle": "Auth Secret",
     "sectionTitle": "Auth Secret",
@@ -7975,7 +8180,7 @@
     "kind": "section"
   },
   {
-    "id": "70-zql",
+    "id": "71-zql",
     "title": "ZQL",
     "searchTitle": "ZQL",
     "url": "/docs/zql",
@@ -8085,7 +8290,7 @@
     "kind": "page"
   },
   {
-    "id": "591-zql#create-a-builder",
+    "id": "606-zql#create-a-builder",
     "title": "ZQL",
     "searchTitle": "Create a Builder",
     "sectionTitle": "Create a Builder",
@@ -8095,7 +8300,7 @@
     "kind": "section"
   },
   {
-    "id": "592-zql#select",
+    "id": "607-zql#select",
     "title": "ZQL",
     "searchTitle": "Select",
     "sectionTitle": "Select",
@@ -8105,7 +8310,7 @@
     "kind": "section"
   },
   {
-    "id": "593-zql#ordering",
+    "id": "608-zql#ordering",
     "title": "ZQL",
     "searchTitle": "Ordering",
     "sectionTitle": "Ordering",
@@ -8115,7 +8320,7 @@
     "kind": "section"
   },
   {
-    "id": "594-zql#limit",
+    "id": "609-zql#limit",
     "title": "ZQL",
     "searchTitle": "Limit",
     "sectionTitle": "Limit",
@@ -8125,7 +8330,7 @@
     "kind": "section"
   },
   {
-    "id": "595-zql#paging",
+    "id": "610-zql#paging",
     "title": "ZQL",
     "searchTitle": "Paging",
     "sectionTitle": "Paging",
@@ -8135,7 +8340,7 @@
     "kind": "section"
   },
   {
-    "id": "596-zql#getting-a-single-result",
+    "id": "611-zql#getting-a-single-result",
     "title": "ZQL",
     "searchTitle": "Getting a Single Result",
     "sectionTitle": "Getting a Single Result",
@@ -8145,7 +8350,7 @@
     "kind": "section"
   },
   {
-    "id": "597-zql#relationships",
+    "id": "612-zql#relationships",
     "title": "ZQL",
     "searchTitle": "Relationships",
     "sectionTitle": "Relationships",
@@ -8155,7 +8360,7 @@
     "kind": "section"
   },
   {
-    "id": "598-zql#refining-relationships",
+    "id": "613-zql#refining-relationships",
     "title": "ZQL",
     "searchTitle": "Refining Relationships",
     "sectionTitle": "Refining Relationships",
@@ -8165,7 +8370,7 @@
     "kind": "section"
   },
   {
-    "id": "599-zql#nested-relationships",
+    "id": "614-zql#nested-relationships",
     "title": "ZQL",
     "searchTitle": "Nested Relationships",
     "sectionTitle": "Nested Relationships",
@@ -8175,7 +8380,7 @@
     "kind": "section"
   },
   {
-    "id": "600-zql#where",
+    "id": "615-zql#where",
     "title": "ZQL",
     "searchTitle": "Where",
     "sectionTitle": "Where",
@@ -8185,7 +8390,7 @@
     "kind": "section"
   },
   {
-    "id": "601-zql#comparison-operators",
+    "id": "616-zql#comparison-operators",
     "title": "ZQL",
     "searchTitle": "Comparison Operators",
     "sectionTitle": "Comparison Operators",
@@ -8195,7 +8400,7 @@
     "kind": "section"
   },
   {
-    "id": "602-zql#equals-is-the-default-comparison-operator",
+    "id": "617-zql#equals-is-the-default-comparison-operator",
     "title": "ZQL",
     "searchTitle": "Equals is the Default Comparison Operator",
     "sectionTitle": "Equals is the Default Comparison Operator",
@@ -8205,7 +8410,7 @@
     "kind": "section"
   },
   {
-    "id": "603-zql#comparing-to-null",
+    "id": "618-zql#comparing-to-null",
     "title": "ZQL",
     "searchTitle": "Comparing to null",
     "sectionTitle": "Comparing to null",
@@ -8215,7 +8420,7 @@
     "kind": "section"
   },
   {
-    "id": "604-zql#comparing-to-undefined",
+    "id": "619-zql#comparing-to-undefined",
     "title": "ZQL",
     "searchTitle": "Comparing to undefined",
     "sectionTitle": "Comparing to undefined",
@@ -8225,7 +8430,7 @@
     "kind": "section"
   },
   {
-    "id": "605-zql#compound-filters",
+    "id": "620-zql#compound-filters",
     "title": "ZQL",
     "searchTitle": "Compound Filters",
     "sectionTitle": "Compound Filters",
@@ -8235,7 +8440,7 @@
     "kind": "section"
   },
   {
-    "id": "606-zql#comparing-literal-values",
+    "id": "621-zql#comparing-literal-values",
     "title": "ZQL",
     "searchTitle": "Comparing Literal Values",
     "sectionTitle": "Comparing Literal Values",
@@ -8245,7 +8450,7 @@
     "kind": "section"
   },
   {
-    "id": "607-zql#relationship-filters",
+    "id": "622-zql#relationship-filters",
     "title": "ZQL",
     "searchTitle": "Relationship Filters",
     "sectionTitle": "Relationship Filters",
@@ -8255,7 +8460,7 @@
     "kind": "section"
   },
   {
-    "id": "608-zql#type-helpers",
+    "id": "623-zql#type-helpers",
     "title": "ZQL",
     "searchTitle": "Type Helpers",
     "sectionTitle": "Type Helpers",
@@ -8265,7 +8470,7 @@
     "kind": "section"
   },
   {
-    "id": "609-zql#planning",
+    "id": "624-zql#planning",
     "title": "ZQL",
     "searchTitle": "Planning",
     "sectionTitle": "Planning",
@@ -8275,7 +8480,7 @@
     "kind": "section"
   },
   {
-    "id": "610-zql#inspecting-query-plans",
+    "id": "625-zql#inspecting-query-plans",
     "title": "ZQL",
     "searchTitle": "Inspecting Query Plans",
     "sectionTitle": "Inspecting Query Plans",
@@ -8285,7 +8490,7 @@
     "kind": "section"
   },
   {
-    "id": "611-zql#manually-flipping-joins",
+    "id": "626-zql#manually-flipping-joins",
     "title": "ZQL",
     "searchTitle": "Manually Flipping Joins",
     "sectionTitle": "Manually Flipping Joins",
@@ -8295,7 +8500,7 @@
     "kind": "section"
   },
   {
-    "id": "612-zql#scalar-subqueries",
+    "id": "627-zql#scalar-subqueries",
     "title": "ZQL",
     "searchTitle": "Scalar Subqueries",
     "sectionTitle": "Scalar Subqueries",
@@ -8305,7 +8510,7 @@
     "kind": "section"
   },
   {
-    "id": "613-zql#why-it-matters",
+    "id": "628-zql#why-it-matters",
     "title": "ZQL",
     "searchTitle": "Why It Matters",
     "sectionTitle": "Why It Matters",
@@ -8315,7 +8520,7 @@
     "kind": "section"
   },
   {
-    "id": "614-zql#trade-offs",
+    "id": "629-zql#trade-offs",
     "title": "ZQL",
     "searchTitle": "Trade-offs",
     "sectionTitle": "Trade-offs",
@@ -8325,7 +8530,7 @@
     "kind": "section"
   },
   {
-    "id": "615-zql#future-work",
+    "id": "630-zql#future-work",
     "title": "ZQL",
     "searchTitle": "Future Work",
     "sectionTitle": "Future Work",

--- a/components/CodeGroup.tsx
+++ b/components/CodeGroup.tsx
@@ -60,13 +60,17 @@ const findBestMatch = (
     const categories = Object.keys(label.sync);
     if (!categories.length) return;
     let score = 0;
+    let hasConflict = false;
     categories.forEach(category => {
       const selectedValue = selection[category];
-      if (selectedValue && label.sync[category] === selectedValue) {
-        score += 1;
+      if (!selectedValue) return;
+      if (label.sync[category] !== selectedValue) {
+        hasConflict = true;
+        return;
       }
+      score += 1;
     });
-    if (score > 0 && score > bestScore) {
+    if (!hasConflict && score > 0 && score > bestScore) {
       bestScore = score;
       bestIndex = index;
     }

--- a/components/IntroductionLanding.tsx
+++ b/components/IntroductionLanding.tsx
@@ -1011,7 +1011,7 @@ export function IntroductionLanding({
           <div className="feature-grid">
             <Link
               className="feature-card feature-card--icon-left feature-card--link"
-              href="/docs/install"
+              href="/docs/introduction"
             >
               <div className="feature-card-icon-left">
                 <svg

--- a/components/StartingPointCards.tsx
+++ b/components/StartingPointCards.tsx
@@ -1,0 +1,62 @@
+import {startingPoints} from '@/lib/starting-points';
+import {ArrowRight, Clock} from 'lucide-react';
+import Link from 'next/link';
+
+export function StartingPointCards() {
+  return (
+    <div className="not-prose my-8 grid gap-4 sm:grid-cols-2">
+      {startingPoints.map(point => (
+        <article
+          key={point.href}
+          className="group relative flex min-h-52 flex-col overflow-hidden rounded-xl border bg-card p-5 shadow-sm transition duration-150 hover:-translate-y-0.5 hover:border-primary-highlight/50 hover:shadow-md focus-within:ring-2 focus-within:ring-primary-highlight focus-within:ring-offset-2 focus-within:ring-offset-background dark:hover:border-primary-highlight/70"
+        >
+          <div className="pointer-events-none relative z-10 flex flex-1 flex-col">
+            <div className="flex items-start justify-between gap-4">
+              <h3 className="m-0 text-xl font-semibold tracking-tight text-foreground">
+                {point.title}
+              </h3>
+              <ArrowRight
+                aria-hidden="true"
+                className="mt-1 text-sm font-medium text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-primary-highlight"
+                size={18}
+                strokeWidth={2}
+              />
+            </div>
+
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              {point.description.map((segment, index) =>
+                typeof segment === 'string' ? (
+                  segment
+                ) : (
+                  <a
+                    key={`${segment.href}-${index}`}
+                    href={segment.href}
+                    className="pointer-events-auto relative z-20 font-medium text-primary-highlight underline underline-offset-4 hover:text-primary-highlight/80"
+                  >
+                    {segment.text}
+                  </a>
+                ),
+              )}
+            </p>
+
+            <div className="mt-auto flex items-center gap-2 pt-6 text-sm font-medium text-foreground">
+              <Clock
+                aria-hidden="true"
+                className="h-4 w-4 text-primary-highlight"
+                size={16}
+                strokeWidth={2}
+              />
+              <span>{point.duration}</span>
+            </div>
+          </div>
+
+          <Link
+            href={point.href}
+            aria-label={`Open ${point.title}`}
+            className="absolute inset-0 z-0 rounded-xl outline-none"
+          />
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/components/StartingPointCards.tsx
+++ b/components/StartingPointCards.tsx
@@ -8,7 +8,7 @@ export function StartingPointCards() {
       {startingPoints.map(point => (
         <article
           key={point.href}
-          className="group relative flex min-h-52 flex-col overflow-hidden rounded-xl border bg-card p-5 shadow-sm transition duration-150 hover:-translate-y-0.5 hover:border-primary-highlight/50 hover:shadow-md focus-within:ring-2 focus-within:ring-primary-highlight focus-within:ring-offset-2 focus-within:ring-offset-background dark:hover:border-primary-highlight/70"
+          className="group relative flex min-h-52 flex-col overflow-hidden rounded-xl border bg-card p-5 shadow-sm transition duration-150 hover:-translate-y-0.5 hover:border-white/40 hover:shadow-md focus-within:ring-2 focus-within:ring-white/40 focus-within:ring-offset-2 focus-within:ring-offset-background"
         >
           <div className="pointer-events-none relative z-10 flex flex-1 flex-col">
             <div className="flex items-start justify-between gap-4">
@@ -17,7 +17,7 @@ export function StartingPointCards() {
               </h3>
               <ArrowRight
                 aria-hidden="true"
-                className="mt-1 text-sm font-medium text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-primary-highlight"
+                className="mt-1 text-sm font-medium text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-white"
                 size={18}
                 strokeWidth={2}
               />
@@ -31,7 +31,7 @@ export function StartingPointCards() {
                   <a
                     key={`${segment.href}-${index}`}
                     href={segment.href}
-                    className="pointer-events-auto relative z-20 font-medium text-primary-highlight underline underline-offset-4 hover:text-primary-highlight/80"
+                    className="pointer-events-auto relative z-20 font-medium text-foreground underline decoration-white/60 underline-offset-4 hover:text-white"
                   >
                     {segment.text}
                   </a>

--- a/contents/docs/install.mdx
+++ b/contents/docs/install.mdx
@@ -241,14 +241,6 @@ function Root() {
     </ZeroProvider>
   )
 }
-
-// mycomponent.tsx
-import {useZero} from '@rocicorp/zero/react'
-
-function MyComponent() {
-  const zero = useZero()
-  console.log('clientID', zero.clientID)
-}
 ```
 
 ```tsx
@@ -268,14 +260,6 @@ function Root() {
       <App />
     </ZeroProvider>
   )
-}
-
-// mycomponent.tsx
-import {useZero} from '@rocicorp/zero/solid'
-
-function MyComponent() {
-  const zero = useZero()
-  console.log('clientID', zero().clientID)
 }
 ```
 

--- a/contents/docs/install.mdx
+++ b/contents/docs/install.mdx
@@ -8,7 +8,14 @@ This guide shows how to add Zero to an existing TypeScript-based web app. For a 
 
 ### Set Up Your Database
 
-You'll need a Postgres database for development. If you don't have a preferred method, we recommend using [Docker](https://www.docker.com/):
+You'll need a Postgres database with logical replication enabled for development.
+
+<CodeGroup
+  labels={[
+    {text: 'Docker', sync: {db: 'docker'}},
+    {text: 'Postgres.app', sync: {db: 'postgres-app'}},
+  ]}
+>
 
 ```bash
 # IMPORTANT: logical WAL level is required for Zero
@@ -21,11 +28,41 @@ docker run -d --name zero-postgres \
   postgres -c wal_level=logical
 ```
 
-See [Provider Support](/docs/connecting-to-postgres) for developing locally with popular cloud Postgres providers.
+```bash
+# Start Postgres.app first. Requires Postgres 15 or higher.
+# If these already exist, you can skip those commands.
+createuser -s postgres
+createdb -O postgres zero
 
-### Install and Run Zero-Cache
+psql -d postgres -c "ALTER USER postgres WITH PASSWORD 'pass';"
+psql -d postgres -c "ALTER SYSTEM SET wal_level = 'logical';"
 
-Add Zero to your project:
+# Restart Postgres.app, then verify:
+psql -d postgres -c "SHOW wal_level;"
+```
+
+</CodeGroup>
+
+<Note
+  emoji="🧑‍💻"
+  type="note"
+  heading="Already using another Postgres provider?"
+  slug="another-postgres-provider"
+>
+  See [Provider Support](/docs/connecting-to-postgres) and
+  make sure `wal_level` is `logical`.
+</Note>
+
+Create a `.env` file so your app server and `zero-cache-dev` use the same Postgres connection:
+
+```bash
+# Update to your app's database connection URL
+ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero"
+```
+
+### Install Zero
+
+Add Zero and the validator used in these examples:
 
 <CodeGroup
   labels={[
@@ -37,52 +74,58 @@ Add Zero to your project:
 >
 
 ```bash
-npm install @rocicorp/zero
+npm install @rocicorp/zero zod
 ```
 
 ```bash
-pnpm add @rocicorp/zero
+pnpm add @rocicorp/zero zod
 
 # Note: pnpm disables postinstall scripts by default for security.
-# Either approve the build:
+# Approve @rocicorp/zero-sqlite3 before continuing:
 pnpm approve-builds
 
-# Or add to package.json:
+# Or add to package.json, then reinstall and rebuild the native package:
 # "pnpm": {
-#   "onlyBuiltDependencies": ["@rocicorp/zero-sqlite3"]
+#   "onlyBuiltDependencies": [
+#     "@rocicorp/zero-sqlite3"
+#   ]
 # }
+pnpm rebuild @rocicorp/zero-sqlite3
 ```
 
 ```bash
-bun add @rocicorp/zero
+bun add @rocicorp/zero zod
 
 # Note: Bun disables postinstall scripts by default for security.
 # Either approve the build:
 bun pm trust @rocicorp/zero-sqlite3
 
-# Or add to package.json:
+# Or add to package.json, then rebuild the native packages:
 # "trustedDependencies": ["@rocicorp/zero-sqlite3"]
 ```
 
 ```bash
-yarn add @rocicorp/zero
+yarn add @rocicorp/zero zod
 
 # Note: Modern Yarn doesn't run postinstall scripts by default.
-# Add to package.json:
+# Add to package.json, then rebuild the native packages:
 # "dependenciesMeta": {
 #   "@rocicorp/zero-sqlite3": {
 #     "built": true
 #   }
 # }
+yarn rebuild @rocicorp/zero-sqlite3
 ```
 
 </CodeGroup>
+
+These examples use Zod; any [Standard Schema](https://standardschema.dev/)-compatible validator works.
 
 ### Set Up Your Zero Schema
 
 Zero uses a file called `schema.ts` to provide a type-safe query API.
 
-If you use Drizzle or Prisma, you can generate `schema.ts` automatically. Otherwise, you can create it manually.
+If you use Drizzle or Prisma, you can generate the schema automatically. Otherwise, you can create it manually.
 
 <CodeGroup
   labels={[
@@ -105,22 +148,22 @@ If you use Drizzle or Prisma, you can generate `schema.ts` automatically. Otherw
 
 ```bash
 npm install -D drizzle-zero
-npx drizzle-zero generate
+npx drizzle-zero generate --output src/zero/schema.ts
 ```
 
 ```bash
 pnpm add -D drizzle-zero
-pnpm dlx drizzle-zero generate
+pnpm exec drizzle-zero generate --output src/zero/schema.ts
 ```
 
 ```bash
 bun add -D drizzle-zero
-bunx drizzle-zero generate
+bunx drizzle-zero generate --output src/zero/schema.ts
 ```
 
 ```bash
 yarn add -D drizzle-zero
-yarn dlx drizzle-zero generate
+yarn exec drizzle-zero generate --output src/zero/schema.ts
 ```
 
 </SyncedCode>
@@ -129,36 +172,40 @@ yarn dlx drizzle-zero generate
 
 ```bash
 npm install -D prisma-zero
-# Add this to your prisma schema:
+# Add this to prisma/schema.prisma:
 # generator zero {
 #   provider = "prisma-zero"
+#   output   = "../src/zero"
 # }
 npx prisma generate
 ```
 
 ```bash
 pnpm add -D prisma-zero
-# Add this to your prisma schema:
+# Add this to prisma/schema.prisma:
 # generator zero {
 #   provider = "prisma-zero"
+#   output   = "../src/zero"
 # }
 pnpx prisma generate
 ```
 
 ```bash
 bun add -D prisma-zero
-# Add this to your prisma schema:
+# Add this to prisma/schema.prisma:
 # generator zero {
 #   provider = "prisma-zero"
+#   output   = "../src/zero"
 # }
 bunx prisma generate
 ```
 
 ```bash
 yarn add -D prisma-zero
-# Add this to your prisma schema:
+# Add this to prisma/schema.prisma:
 # generator zero {
 #   provider = "prisma-zero"
+#   output   = "../src/zero"
 # }
 yarn prisma generate
 ```
@@ -168,7 +215,7 @@ yarn prisma generate
 <InstallTableNameReplace>
 
 ```ts
-// zero/schema.ts
+// src/zero/schema.ts
 import {
   boolean,
   createBuilder,
@@ -204,17 +251,21 @@ declare module '@rocicorp/zero' {
 
 ### Set Up the Zero Client
 
-Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project.
+Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. Choose the tab that most closely matches where your app creates its root layout or client instance.
 
 <CodeGroup
   labels={[
     {
-      text: 'React',
-      sync: {client: 'react'},
+      text: 'TanStack Start',
+      sync: {client: 'react', api: 'tanstack'},
     },
     {
-      text: 'SolidJS',
-      sync: {client: 'solidjs'},
+      text: 'Next.js',
+      sync: {client: 'react', api: 'nextjs'},
+    },
+    {
+      text: 'SolidStart',
+      sync: {client: 'solidjs', api: 'solid'},
     },
     {
       text: 'TypeScript',
@@ -224,50 +275,120 @@ Zero has first-class support for React and SolidJS, and there is also a low-leve
 >
 
 ```tsx
-// root.tsx
+// src/routes/__root.tsx
 import {ZeroProvider} from '@rocicorp/zero/react'
 import type {ZeroOptions} from '@rocicorp/zero'
-import {schema} from './zero/schema.ts'
+import {
+  HeadContent,
+  Scripts,
+  createRootRoute
+} from '@tanstack/react-router'
+import type {ReactNode} from 'react'
+import {schema} from '../zero/schema'
 
 const opts: ZeroOptions = {
   cacheURL: 'http://localhost:4848',
   schema
 }
 
-function Root() {
+export const Route = createRootRoute({
+  shellComponent: RootDocument
+})
+
+function RootDocument({children}: {children: ReactNode}) {
   return (
-    <ZeroProvider {...opts}>
-      <App />
-    </ZeroProvider>
+    <html lang="en">
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <ZeroProvider {...opts}>{children}</ZeroProvider>
+        <Scripts />
+      </body>
+    </html>
   )
 }
 ```
 
 ```tsx
-// root.tsx
+// src/app/providers.tsx
+'use client'
+
+import {ZeroProvider} from '@rocicorp/zero/react'
+import type {ZeroOptions} from '@rocicorp/zero'
+import type {ReactNode} from 'react'
+import {schema} from '../zero/schema'
+
+const opts: ZeroOptions = {
+  cacheURL: 'http://localhost:4848',
+  schema
+}
+
+export function Providers({
+  children
+}: {
+  children: ReactNode
+}) {
+  return <ZeroProvider {...opts}>{children}</ZeroProvider>
+}
+
+// src/app/layout.tsx
+import type {ReactNode} from 'react'
+import {Providers} from './providers'
+
+export default function RootLayout({
+  children
+}: {
+  children: ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  )
+}
+```
+
+```tsx
+// src/app.tsx
+import {MetaProvider, Title} from '@solidjs/meta'
+import {Router} from '@solidjs/router'
+import {FileRoutes} from '@solidjs/start/router'
 import {ZeroProvider} from '@rocicorp/zero/solid'
 import type {ZeroOptions} from '@rocicorp/zero'
-import {schema} from './zero/schema.ts'
+import {Suspense} from 'solid-js'
+import {schema} from './zero/schema'
 
 const opts: ZeroOptions = {
   cacheURL: 'http://localhost:4848',
   schema
 }
 
-function Root() {
+export default function App() {
   return (
     <ZeroProvider {...opts}>
-      <App />
+      <Router
+        root={props => (
+          <MetaProvider>
+            <Title>Zero App</Title>
+            <Suspense>{props.children}</Suspense>
+          </MetaProvider>
+        )}
+      >
+        <FileRoutes />
+      </Router>
     </ZeroProvider>
   )
 }
 ```
 
 ```tsx
-// zero.ts
+// src/zero.ts
 import {Zero} from '@rocicorp/zero'
 import type {ZeroOptions} from '@rocicorp/zero'
-import {schema} from './zero/schema.ts'
+import {schema} from './zero/schema'
 
 const opts: ZeroOptions = {
   cacheURL: 'http://localhost:4848',
@@ -275,8 +396,6 @@ const opts: ZeroOptions = {
 }
 
 const zero = new Zero(opts)
-
-console.log('clientID', zero.clientID)
 
 export {zero}
 ```
@@ -292,9 +411,9 @@ Shared reads are conventionally stored in `queries.ts`. Use `zql` from `schema.t
 <InstallTableNameReplace>
 
 ```tsx
-// zero/queries.ts
+// src/zero/queries.ts
 import {defineQueries, defineQuery} from '@rocicorp/zero'
-import {zql} from './schema.ts'
+import {zql} from './schema'
 
 export const queries = defineQueries({
   allUsers: defineQuery(() => zql.user)
@@ -309,20 +428,20 @@ See [Reading Data](/docs/queries) for more on filters, sorting, relationships, a
 
 Zero doesn't allow clients to send arbitrary ZQL to `zero-cache`.
 
-Instead, Zero sends the query name and arguments to the `query` endpoint on your server, which responds to `zero-cache` with the authoritative ZQL.
+Instead, Zero sends the query name and arguments to the `query` endpoint on your server, which responds to `zero-cache` with the authoritative ZQL. This prevents clients from reading arbitrary data and is the basis of permissions.
 
 <CodeGroup
   labels={[
+    {
+      text: 'TanStack Start',
+      sync: {api: 'tanstack'},
+    },
     {
       text: 'Next.js',
       sync: {api: 'nextjs'},
     },
     {
-      text: 'Tanstack Start',
-      sync: {api: 'tanstack'},
-    },
-    {
-      text: 'Solid Start',
+      text: 'SolidStart',
       sync: {api: 'solid'},
     },
     {
@@ -333,33 +452,12 @@ Instead, Zero sends the query name and arguments to the `query` endpoint on your
 >
 
 ```ts
-// app/api/query/route.ts
-import {handleQueryRequest} from '@rocicorp/zero/server'
-import {mustGetQuery} from '@rocicorp/zero'
-import {queries} from '../../zero/queries.ts'
-import {schema} from '../../zero/schema.ts'
-
-export async function POST(req: Request) {
-  const result = await handleQueryRequest(
-    (name, args) => {
-      const query = mustGetQuery(queries, name)
-      return query.fn({args})
-    },
-    schema,
-    req
-  )
-
-  return Response.json(result)
-}
-```
-
-```ts
 // src/routes/api/query.ts
 import {createFileRoute} from '@tanstack/react-router'
 import {handleQueryRequest} from '@rocicorp/zero/server'
 import {mustGetQuery} from '@rocicorp/zero'
-import {queries} from '../../zero/queries.ts'
-import {schema} from '../../zero/schema.ts'
+import {queries} from '../../zero/queries'
+import {schema} from '../../zero/schema'
 
 export const Route = createFileRoute('/api/query')({
   server: {
@@ -382,12 +480,33 @@ export const Route = createFileRoute('/api/query')({
 ```
 
 ```ts
+// src/app/api/query/route.ts
+import {handleQueryRequest} from '@rocicorp/zero/server'
+import {mustGetQuery} from '@rocicorp/zero'
+import {queries} from '../../../zero/queries'
+import {schema} from '../../../zero/schema'
+
+export async function POST(req: Request) {
+  const result = await handleQueryRequest(
+    (name, args) => {
+      const query = mustGetQuery(queries, name)
+      return query.fn({args})
+    },
+    schema,
+    req
+  )
+
+  return Response.json(result)
+}
+```
+
+```ts
 // src/routes/api/query.ts
 import type {APIEvent} from '@solidjs/start/server'
 import {handleQueryRequest} from '@rocicorp/zero/server'
 import {mustGetQuery} from '@rocicorp/zero'
-import {queries} from '../../zero/queries.ts'
-import {schema} from '../../zero/schema.ts'
+import {queries} from '../../zero/queries'
+import {schema} from '../../zero/schema'
 
 export async function POST(event: APIEvent) {
   const result = await handleQueryRequest(
@@ -404,12 +523,12 @@ export async function POST(event: APIEvent) {
 ```
 
 ```ts
-// api/app.ts
+// src/api/app.ts
 import {Hono} from 'hono'
 import {handleQueryRequest} from '@rocicorp/zero/server'
 import {mustGetQuery} from '@rocicorp/zero'
-import {queries} from '../zero/queries.ts'
-import {schema} from '../zero/schema.ts'
+import {queries} from '../zero/queries'
+import {schema} from '../zero/schema'
 
 const app = new Hono()
 
@@ -454,7 +573,7 @@ Querying for data is framework-specific. Most of the time, you will use a helper
 
 ```tsx
 import {useQuery} from '@rocicorp/zero/react'
-import {queries} from './zero/queries.ts'
+import {queries} from './zero/queries'
 
 const [users] = useQuery(queries.allUsers())
 ```
@@ -465,7 +584,7 @@ const [users] = useQuery(queries.allUsers())
 
 ```tsx
 import {useQuery} from '@rocicorp/zero/solid'
-import {queries} from './zero/queries.ts'
+import {queries} from './zero/queries'
 
 const [users] = useQuery(() => queries.allUsers())
 ```
@@ -475,8 +594,8 @@ const [users] = useQuery(() => queries.allUsers())
 <InstallTableNameReplace>
 
 ```tsx
-import {zero} from './zero.ts'
-import {queries} from './zero/queries.ts'
+import {zero} from './zero'
+import {queries} from './zero/queries'
 
 const users = await zero.run(queries.allUsers())
 ```
@@ -499,7 +618,7 @@ Data is written in Zero apps using mutators. Similar to queries, shared writes u
 <InstallTableNameReplace>
 
 ```tsx
-// zero/mutators.ts
+// src/zero/mutators.ts
 import {defineMutators, defineMutator} from '@rocicorp/zero'
 import {z} from 'zod'
 
@@ -519,21 +638,86 @@ You can use the [CRUD-style API](/docs/mutators#writing-data) with `tx.mutate.<t
 
 Register the mutators where you create the Zero client:
 
-```tsx
+<CodeGroup
+  labels={[
+    {
+      text: 'TanStack Start',
+      sync: {client: 'react', api: 'tanstack'},
+    },
+    {
+      text: 'Next.js',
+      sync: {client: 'react', api: 'nextjs'},
+    },
+    {
+      text: 'SolidStart',
+      sync: {client: 'solidjs', api: 'solid'},
+    },
+    {
+      text: 'TypeScript',
+      sync: {client: 'typescript'},
+    },
+  ]}
+>
+
+```tsx {3,9}
+// src/routes/__root.tsx
 import type {ZeroOptions} from '@rocicorp/zero'
-import {mutators} from './zero/mutators.ts'
+import {mutators} from '../zero/mutators'
+import {schema} from '../zero/schema'
 
 const opts: ZeroOptions = {
-  // ... userID, cacheURL, schema, etc.
+  cacheURL: 'http://localhost:4848',
+  schema,
   mutators
 }
 ```
+
+```tsx {3,9}
+// src/app/providers.tsx
+import type {ZeroOptions} from '@rocicorp/zero'
+import {mutators} from '../zero/mutators'
+import {schema} from '../zero/schema'
+
+const opts: ZeroOptions = {
+  cacheURL: 'http://localhost:4848',
+  schema,
+  mutators
+}
+```
+
+```tsx {3,9}
+// src/app.tsx
+import type {ZeroOptions} from '@rocicorp/zero'
+import {mutators} from './zero/mutators'
+import {schema} from './zero/schema'
+
+const opts: ZeroOptions = {
+  cacheURL: 'http://localhost:4848',
+  schema,
+  mutators
+}
+```
+
+```tsx {3,9}
+// src/zero.ts
+import type {ZeroOptions} from '@rocicorp/zero'
+import {mutators} from './zero/mutators'
+import {schema} from './zero/schema'
+
+const opts: ZeroOptions = {
+  cacheURL: 'http://localhost:4848',
+  schema,
+  mutators
+}
+```
+
+</CodeGroup>
 
 ### Add Mutate Endpoint
 
 Zero requires a `mutate` endpoint that runs on your server and connects directly to Postgres.
 
-First, create a `dbProvider` with the Postgres adapter that matches your stack:
+First, create a `dbProvider` with the Postgres adapter that matches your stack. These examples assume the selected database client is already installed in your app.
 
 <CodeGroup
   labels={[
@@ -561,15 +745,21 @@ First, create a `dbProvider` with the Postgres adapter that matches your stack:
 >
 
 ```ts
-// src/db-provider.ts
+// src/zero/db-provider.ts
 import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle'
 import {drizzle} from 'drizzle-orm/node-postgres'
 import {Pool} from 'pg'
-import {schema} from '../../zero/schema.ts'
-import * as drizzleSchema from '../../drizzle/schema.ts'
+import {schema} from './schema'
+import * as drizzleSchema from '../drizzle/schema'
+
+// If your app uses a different Drizzle driver, reuse your existing client.
+const connectionString = process.env.ZERO_UPSTREAM_DB
+if (!connectionString) {
+  throw new Error('ZERO_UPSTREAM_DB is not set')
+}
 
 const pool = new Pool({
-  connectionString: process.env.ZERO_UPSTREAM_DB!
+  connectionString
 })
 
 export const drizzleClient = drizzle(pool, {
@@ -578,6 +768,7 @@ export const drizzleClient = drizzle(pool, {
 
 export const dbProvider = zeroDrizzle(schema, drizzleClient)
 
+// Register global types for mutators on the server
 declare module '@rocicorp/zero' {
   interface DefaultTypes {
     dbProvider: typeof dbProvider
@@ -586,23 +777,29 @@ declare module '@rocicorp/zero' {
 ```
 
 ```ts
-// src/db-provider.ts
+// src/zero/db-provider.ts
 import {Kysely, PostgresDialect} from 'kysely'
 import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely'
 import {Pool} from 'pg'
-import {schema} from '../../zero/schema.ts'
-import type {Database} from '../../kysely/database.ts'
+import {schema} from './schema'
+import type {Database} from '../kysely/database'
+
+const connectionString = process.env.ZERO_UPSTREAM_DB
+if (!connectionString) {
+  throw new Error('ZERO_UPSTREAM_DB is not set')
+}
 
 const kysely = new Kysely<Database>({
   dialect: new PostgresDialect({
     pool: new Pool({
-      connectionString: process.env.ZERO_UPSTREAM_DB!
+      connectionString
     })
   })
 })
 
 export const dbProvider = zeroKysely(schema, kysely)
 
+// Register global types for mutators on the server
 declare module '@rocicorp/zero' {
   interface DefaultTypes {
     dbProvider: typeof dbProvider
@@ -611,20 +808,26 @@ declare module '@rocicorp/zero' {
 ```
 
 ```ts
-// src/db-provider.ts
+// src/zero/db-provider.ts
 import {PrismaPg} from '@prisma/adapter-pg'
 import {PrismaClient} from '@prisma/client'
 import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma'
-import {schema} from '../../zero/schema.ts'
+import {schema} from './schema'
+
+const connectionString = process.env.ZERO_UPSTREAM_DB
+if (!connectionString) {
+  throw new Error('ZERO_UPSTREAM_DB is not set')
+}
 
 const prisma = new PrismaClient({
   adapter: new PrismaPg({
-    connectionString: process.env.ZERO_UPSTREAM_DB!
+    connectionString
   })
 })
 
 export const dbProvider = zeroPrisma(schema, prisma)
 
+// Register global types for mutators on the server
 declare module '@rocicorp/zero' {
   interface DefaultTypes {
     dbProvider: typeof dbProvider
@@ -633,17 +836,23 @@ declare module '@rocicorp/zero' {
 ```
 
 ```ts
-// src/db-provider.ts
+// src/zero/db-provider.ts
 import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg'
 import {Pool} from 'pg'
-import {schema} from '../../zero/schema.ts'
+import {schema} from './schema'
+
+const connectionString = process.env.ZERO_UPSTREAM_DB
+if (!connectionString) {
+  throw new Error('ZERO_UPSTREAM_DB is not set')
+}
 
 const pool = new Pool({
-  connectionString: process.env.ZERO_UPSTREAM_DB!
+  connectionString
 })
 
 export const dbProvider = zeroNodePg(schema, pool)
 
+// Register global types for mutators on the server
 declare module '@rocicorp/zero' {
   interface DefaultTypes {
     dbProvider: typeof dbProvider
@@ -652,15 +861,21 @@ declare module '@rocicorp/zero' {
 ```
 
 ```ts
-// src/db-provider.ts
+// src/zero/db-provider.ts
 import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs'
 import postgres from 'postgres'
-import {schema} from '../../zero/schema.ts'
+import {schema} from './schema'
 
-const sql = postgres(process.env.ZERO_UPSTREAM_DB!)
+const connectionString = process.env.ZERO_UPSTREAM_DB
+if (!connectionString) {
+  throw new Error('ZERO_UPSTREAM_DB is not set')
+}
+
+const sql = postgres(connectionString)
 
 export const dbProvider = zeroPostgresJS(schema, sql)
 
+// Register global types for mutators on the server
 declare module '@rocicorp/zero' {
   interface DefaultTypes {
     dbProvider: typeof dbProvider
@@ -675,15 +890,15 @@ Then use the `dbProvider` and helpers to define the mutate endpoint:
 <CodeGroup
   labels={[
     {
+      text: 'TanStack Start',
+      sync: {api: 'tanstack'},
+    },
+    {
       text: 'Next.js',
       sync: {api: 'nextjs'},
     },
     {
-      text: 'Tanstack Start',
-      sync: {api: 'tanstack'},
-    },
-    {
-      text: 'Solid Start',
+      text: 'SolidStart',
       sync: {api: 'solid'},
     },
     {
@@ -694,34 +909,12 @@ Then use the `dbProvider` and helpers to define the mutate endpoint:
 >
 
 ```ts
-// app/api/mutate/route.ts
-import {handleMutateRequest} from '@rocicorp/zero/server'
-import {mustGetMutator} from '@rocicorp/zero'
-import {mutators} from '../../zero/mutators.ts'
-import {dbProvider} from '../../db-provider.ts'
-
-export async function POST(req: Request) {
-  const result = await handleMutateRequest(
-    dbProvider,
-    transact =>
-      transact((tx, name, args) => {
-        const mutator = mustGetMutator(mutators, name)
-        return mutator.fn({args, tx})
-      }),
-    req
-  )
-
-  return Response.json(result)
-}
-```
-
-```ts
 // src/routes/api/mutate.ts
 import {createFileRoute} from '@tanstack/react-router'
 import {handleMutateRequest} from '@rocicorp/zero/server'
 import {mustGetMutator} from '@rocicorp/zero'
-import {mutators} from '../../zero/mutators.ts'
-import {dbProvider} from '../../db-provider.ts'
+import {mutators} from '../../zero/mutators'
+import {dbProvider} from '../../zero/db-provider'
 
 export const Route = createFileRoute('/api/mutate')({
   server: {
@@ -745,12 +938,34 @@ export const Route = createFileRoute('/api/mutate')({
 ```
 
 ```ts
+// src/app/api/mutate/route.ts
+import {handleMutateRequest} from '@rocicorp/zero/server'
+import {mustGetMutator} from '@rocicorp/zero'
+import {mutators} from '../../../zero/mutators'
+import {dbProvider} from '../../../zero/db-provider'
+
+export async function POST(req: Request) {
+  const result = await handleMutateRequest(
+    dbProvider,
+    transact =>
+      transact((tx, name, args) => {
+        const mutator = mustGetMutator(mutators, name)
+        return mutator.fn({args, tx})
+      }),
+    req
+  )
+
+  return Response.json(result)
+}
+```
+
+```ts
 // src/routes/api/mutate.ts
 import type {APIEvent} from '@solidjs/start/server'
 import {handleMutateRequest} from '@rocicorp/zero/server'
 import {mustGetMutator} from '@rocicorp/zero'
-import {mutators} from '../../zero/mutators.ts'
-import {dbProvider} from '../../db-provider.ts'
+import {mutators} from '../../zero/mutators'
+import {dbProvider} from '../../zero/db-provider'
 
 export async function POST(event: APIEvent) {
   const result = await handleMutateRequest(
@@ -768,11 +983,11 @@ export async function POST(event: APIEvent) {
 ```
 
 ```ts
-// api/app.ts
+// src/api/app.ts
 import {handleMutateRequest} from '@rocicorp/zero/server'
 import {mustGetMutator} from '@rocicorp/zero'
-import {mutators} from '../zero/mutators.ts'
-import {dbProvider} from './db-provider.ts'
+import {mutators} from '../zero/mutators'
+import {dbProvider} from '../zero/db-provider'
 
 app.post('/api/mutate', async c => {
   const result = await handleMutateRequest(
@@ -802,7 +1017,7 @@ You can also do work after a mutation runs on the server, like send notification
   handlers. See [Authentication](/docs/auth).
 </Note>
 
-Now you can run `zero-cache` locally with `ZERO_UPSTREAM_DB`, `ZERO_QUERY_URL`, and `ZERO_MUTATE_URL` configured:
+Start your app server in another terminal, then run `zero-cache` locally with `ZERO_QUERY_URL` and `ZERO_MUTATE_URL` configured. If your app uses a different origin, update `localhost:3000`.
 
 <CodeGroup
   labels={[
@@ -814,29 +1029,25 @@ Now you can run `zero-cache` locally with `ZERO_UPSTREAM_DB`, `ZERO_QUERY_URL`, 
 >
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
   ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
   npx zero-cache-dev
 ```
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
   ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
   pnpm exec zero-cache-dev
 ```
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
   ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
   bunx zero-cache-dev
 ```
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
   ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
   yarn exec zero-cache-dev
 ```
@@ -868,7 +1079,7 @@ You can call a mutator with `zero.mutate`:
 
 ```tsx
 import {useZero} from '@rocicorp/zero/react'
-import {mutators} from './zero/mutators.ts'
+import {mutators} from './zero/mutators'
 
 const zero = useZero()
 
@@ -883,7 +1094,7 @@ const onClick = () => {
 
 ```tsx
 import {useZero} from '@rocicorp/zero/solid'
-import {mutators} from './zero/mutators.ts'
+import {mutators} from './zero/mutators'
 
 const zero = useZero()
 
@@ -897,8 +1108,8 @@ const onClick = () => {
 <InstallTableNameReplace>
 
 ```tsx
-import {zero} from './zero.ts'
-import {mutators} from './zero/mutators.ts'
+import {zero} from './zero'
+import {mutators} from './zero/mutators'
 
 await zero.mutate(mutators.activateUser({id: '1'}))
 ```

--- a/contents/docs/introduction.mdx
+++ b/contents/docs/introduction.mdx
@@ -2,21 +2,4 @@
 title: Welcome to Zero
 ---
 
-Zero enables instant web applications by syncing a subset of data to the client, before it is needed. Reads and writes happen directly against this local datastore, and are synced with the server continuously in the background.
-
-Unlike previous sync engines that sync entire tables to the client, or use static rules to control what syncs, you control what to sync in Zero by writing normal queries directly in your application code. This provides a huge amount of control over what data is synced and when.
-
-Zero caches query results in a normalized client-side datastore, and reuses that data automatically to answer future queries whenever possible.
-
-The result is that for typical applications, queries are almost always instantly resolved using local data. It feels like you have access to the entire backend database directly from the client in memory.
-
-Occasionally, when you do a more specific query, Zero falls back to the server. But this happens automatically without any extra work required.
-
-## Ready to get started?
-
-Choose your adventure:
-
-- [Build a new app with the tutorial](/docs/tutorial)
-- [Install Zero into an existing project](/docs/install)
-- [Clone a starter app](/docs/quickstart)
-- [Play with a full-featured sample](/docs/samples)
+<StartingPointCards />

--- a/contents/docs/introduction.mdx
+++ b/contents/docs/introduction.mdx
@@ -2,4 +2,8 @@
 title: Welcome to Zero
 ---
 
+Zero makes web apps feel instant by syncing the data your UI needs into a local, normalized client datastore. Reads and writes hit that local store first, then sync continuously with your server in the background.
+
+You control what syncs by writing normal queries in your app code, instead of syncing whole tables or maintaining static sync rules. Zero reuses cached data when it can and automatically falls back to the server when it needs more.
+
 <StartingPointCards />

--- a/contents/docs/schema.mdx
+++ b/contents/docs/schema.mdx
@@ -37,7 +37,7 @@ npx drizzle-zero generate
 
 ```bash
 pnpm add -D drizzle-zero
-pnpm dlx drizzle-zero generate
+pnpm exec drizzle-zero generate
 ```
 
 ```bash
@@ -47,7 +47,7 @@ bunx drizzle-zero generate
 
 ```bash
 yarn add -D drizzle-zero
-yarn dlx drizzle-zero generate
+yarn exec drizzle-zero generate
 ```
 
 </SyncedCode>

--- a/contents/docs/tutorial.mdx
+++ b/contents/docs/tutorial.mdx
@@ -2,13 +2,13 @@
 title: Tutorial
 ---
 
-This guide builds a small music app with Zero from scratch. It's a nice way to get a feel for how Zero works and takes about 15 minutes to complete.
+Let's build a small music app with Zero from scratch. It's a nice way to get a feel for how Zero works and takes about 15 minutes to complete.
 
 You will seed a Postgres database with artists and albums, run `zero-cache`, add a [query](/docs/queries) and a [mutator](/docs/mutators), and watch data sync across clients in realtime.
 
 If you want to wire Zero into your own app, see [Installation](/docs/install).
 
-## Integrate Zero
+## Setup
 
 ### Create a Project
 
@@ -205,6 +205,8 @@ bun pm trust @rocicorp/zero-sqlite3
 
 </CodeGroup>
 
+This tutorial uses Zod; any [Standard Schema](https://standardschema.dev/)-compatible validator works.
+
 Start the development `zero-cache`:
 
 <CodeGroup
@@ -256,6 +258,8 @@ watch -n 0.5 "npx @rocicorp/zero-sqlite3 ./zero.db \
   alt="Zero-cache syncing between Postgres and SQLite"
   animation
 />
+
+## Integrate Zero
 
 ### Set Up Your Zero Schema
 
@@ -462,7 +466,7 @@ export const queries = defineQueries({
 })
 ```
 
-ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more:
+These are defined using Zero Query Language (ZQL) - it allows you to build queries with filters, sorts, relationships, and more:
 
 <Video
   src="/video/onboarding/onboarding-zql-autocomplete.mp4"
@@ -470,11 +474,13 @@ ZQL is quite powerful and allows you to build queries with filters, sorts, relat
   animation
 />
 
+See [Reading Data](/docs/queries) for more on how ZQL works.
+
 ### Add Query Endpoint
 
 Zero doesn't allow clients to send arbitrary ZQL to `zero-cache`.
 
-Instead, Zero sends the query name and arguments to the `query` endpoint on your server, which responds to `zero-cache` with the authoritative ZQL.
+Instead, Zero sends the query name and arguments to the `query` endpoint on your server, which responds to `zero-cache` with the authoritative ZQL. This prevents clients from reading arbitrary data and is the basis of permissions.
 
 <CodeGroup
   labels={[
@@ -1241,3 +1247,9 @@ Your mutate endpoint writes to Postgres and zero-cache will instantly replicate 
 />
 
 That's it! You now have a simple, Zero-powered music app. Try opening multiple browser windows to see the realtime sync in action!
+
+## Next Steps
+
+- [Learn how to add auth](/docs/auth)
+- [Try adding Zero to your existing app](/docs/install)
+- [Play with fully-fleshed out samples](/docs/samples)

--- a/contents/docs/tutorial.mdx
+++ b/contents/docs/tutorial.mdx
@@ -2,17 +2,110 @@
 title: Tutorial
 ---
 
-This guide builds a small music app with Zero from scratch. It's a nice way to get a feel for how Zero works and takes about 20 minutes to complete.
+This guide builds a small music app with Zero from scratch. It's a nice way to get a feel for how Zero works and takes about 15 minutes to complete.
 
 You will seed a Postgres database with artists and albums, run `zero-cache`, add a [query](/docs/queries) and a [mutator](/docs/mutators), and watch data sync across clients in realtime.
 
-If you want to wire Zero into your own app, see [Installation](/docs/install). Or, to skip to the finished music app, check out the [onboarding](/docs/samples#onboarding) sample.
+If you want to wire Zero into your own app, see [Installation](/docs/install).
 
 ## Integrate Zero
 
+### Create a Project
+
+Start with a TypeScript frontend framework:
+
+<CodeGroup
+  labels={[
+    {
+      text: 'TanStack Start',
+      sync: {client: 'react', api: 'tanstack'},
+    },
+    {
+      text: 'Next.js',
+      sync: {client: 'react', api: 'nextjs'},
+    },
+    {
+      text: 'SolidStart',
+      sync: {client: 'solidjs', api: 'solid'},
+    },
+  ]}
+>
+
+<SyncedCode syncKey="pm" syncValues={['npm', 'pnpm', 'bun']}>
+
+```bash
+npx @tanstack/cli@latest create zero-music \
+  --package-manager npm --yes --no-intent
+cd zero-music
+```
+
+```bash
+pnpm dlx @tanstack/cli@latest create zero-music \
+  --package-manager pnpm --yes --no-intent
+cd zero-music
+```
+
+```bash
+bunx @tanstack/cli@latest create zero-music \
+  --package-manager bun --yes --no-intent
+cd zero-music
+```
+
+</SyncedCode>
+
+<SyncedCode syncKey="pm" syncValues={['npm', 'pnpm', 'bun']}>
+
+```bash
+npx create-next-app@latest zero-music --yes --use-npm
+cd zero-music
+```
+
+```bash
+pnpm create next-app zero-music --yes --use-pnpm
+cd zero-music
+```
+
+```bash
+npx create-next-app@latest zero-music --yes --use-bun
+cd zero-music
+```
+
+</SyncedCode>
+
+<SyncedCode syncKey="pm" syncValues={['npm', 'pnpm', 'bun']}>
+
+```bash
+npm init solid -- zero-music basic --solidstart --ts --v2
+cd zero-music
+npm install
+```
+
+```bash
+pnpm create solid zero-music basic --solidstart --ts --v2
+cd zero-music
+pnpm install
+```
+
+```bash
+bun create solid zero-music basic --solidstart --ts --v2
+cd zero-music
+bun install
+```
+
+</SyncedCode>
+
+</CodeGroup>
+
 ### Set Up Your Database
 
-You'll need a Postgres database. If you don't have a preferred method, we recommend using [Docker](https://www.docker.com/):
+You'll need a Postgres database with logical replication enabled.
+
+<CodeGroup
+  labels={[
+    {text: 'Docker', sync: {db: 'docker'}},
+    {text: 'Postgres.app', sync: {db: 'postgres-app'}},
+  ]}
+>
 
 ```bash
 # IMPORTANT: logical WAL level is required for Zero
@@ -25,66 +118,89 @@ docker run -d --name zero-postgres \
   postgres -c wal_level=logical
 ```
 
-Then, create some music-themed tables and seed them with data:
+```bash
+# Start Postgres.app first. Requires Postgres 15 or higher.
+# If these already exist, you can skip those commands.
+createuser -s postgres
+createdb -O postgres zero
+
+psql -d postgres -c "ALTER USER postgres WITH PASSWORD 'pass';"
+psql -d postgres -c "ALTER SYSTEM SET wal_level = 'logical';"
+
+# Restart Postgres.app, then verify:
+psql -d postgres -c "SHOW wal_level;"
+```
+
+</CodeGroup>
+
+<Note
+  emoji="🧑‍💻"
+  type="note"
+  heading="Already using another Postgres provider?"
+  slug="another-postgres-provider"
+>
+  See [Connecting to Postgres](/docs/connecting-to-postgres)
+  and make sure `wal_level` is `logical`.
+</Note>
+
+Then, create some music-themed tables and seed them with data (this step uses `psql` if you don't already have it).
 
 ```bash
 # Creates new albums, artists, fans,
 # and favorites tables with sample music data
-curl -L https://raw.githubusercontent.com/rocicorp/onboarding/1-install/migrations/0000_seed_music.sql \
-  | psql postgresql://postgres:pass@localhost:5432/zero
+curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \
+  | psql postgres://postgres:pass@localhost:5432/zero
+```
+
+Create a `.env` file so your app server and `zero-cache-dev` use the same Postgres connection:
+
+```bash
+ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero"
 ```
 
 ### Install and Run Zero-Cache
 
-Add Zero with your preferred package manager:
+Add Zero and the dependencies used in this tutorial with your preferred package manager:
 
 <CodeGroup
   labels={[
     {text: 'npm', sync: {pm: 'npm'}},
     {text: 'pnpm', sync: {pm: 'pnpm'}},
     {text: 'bun', sync: {pm: 'bun'}},
-    {text: 'yarn', sync: {pm: 'yarn'}},
   ]}
 >
 
 ```bash
-npm install @rocicorp/zero
+npm install @rocicorp/zero zod pg
+npm install -D @types/pg
 ```
 
 ```bash
-pnpm add @rocicorp/zero
+pnpm add @rocicorp/zero zod pg
+pnpm add -D @types/pg
 
 # Note: pnpm disables postinstall scripts by default for security.
-# Either approve the build:
+# Approve @rocicorp/zero-sqlite3 before continuing:
 pnpm approve-builds
 
-# Or add to package.json:
+# Or add to package.json, then rebuild the native packages:
 # "pnpm": {
-#   "onlyBuiltDependencies": ["@rocicorp/zero-sqlite3"]
+#   "onlyBuiltDependencies": [
+#     "@rocicorp/zero-sqlite3"
+#   ]
 # }
 ```
 
 ```bash
-bun add @rocicorp/zero
+bun add @rocicorp/zero zod pg
+bun add -d @types/pg
 
 # Note: Bun disables postinstall scripts by default for security.
 # Either approve the build:
 bun pm trust @rocicorp/zero-sqlite3
 
-# Or add to package.json:
+# Or add to package.json, then rebuild the native packages:
 # "trustedDependencies": ["@rocicorp/zero-sqlite3"]
-```
-
-```bash
-yarn add @rocicorp/zero
-
-# Note: Modern Yarn doesn't run postinstall scripts by default.
-# Add to package.json:
-# "dependenciesMeta": {
-#   "@rocicorp/zero-sqlite3": {
-#     "built": true
-#   }
-# }
 ```
 
 </CodeGroup>
@@ -96,38 +212,29 @@ Start the development `zero-cache`:
     {text: 'npm', sync: {pm: 'npm'}},
     {text: 'pnpm', sync: {pm: 'pnpm'}},
     {text: 'bun', sync: {pm: 'bun'}},
-    {text: 'yarn', sync: {pm: 'yarn'}},
   ]}
 >
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  npx zero-cache-dev
+npx zero-cache-dev
 ```
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  pnpm exec zero-cache-dev
+pnpm exec zero-cache-dev
 ```
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  bunx zero-cache-dev
-```
-
-```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  yarn exec zero-cache-dev
+bunx zero-cache-dev
 ```
 
 </CodeGroup>
 
 Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at `zero.db`.
 
-Inspect the replica in another terminal:
+The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with [`zero-sqlite3`](/docs/debug/replication#inspecting) in another terminal to see how zero-cache syncs data:
 
 ```bash
-npx @rocicorp/zero-sqlite3 ./zero.db "SELECT title FROM albums;"
+npx @rocicorp/zero-sqlite3 ./zero.db "SELECT title FROM albums ORDER BY id;"
 # Abbey Road
 # Kind of Blue
 # Random Access Memories
@@ -135,7 +242,14 @@ npx @rocicorp/zero-sqlite3 ./zero.db "SELECT title FROM albums;"
 # Revolver
 ```
 
-Or try reading from `zero.db` while connected to Postgres. If you change something in Postgres, you'll see it immediately show up in the replica:
+Or try reading from `zero.db` while connected to Postgres at `postgres://postgres:pass@localhost:5432/zero`.
+If you change something in Postgres, you'll see it immediately show up in the replica:
+
+```bash
+# Uses watch, e.g.: brew install watch
+watch -n 0.5 "npx @rocicorp/zero-sqlite3 ./zero.db \
+  'SELECT * FROM albums ORDER BY created_at;'"
+```
 
 <Video
   src="/video/onboarding/zero-cache-sync.mp4"
@@ -150,9 +264,9 @@ Zero uses a `schema.ts` file to provide a type-safe query API on the client.
 Download the music-app schema:
 
 ```bash
-mkdir -p zero
-curl https://raw.githubusercontent.com/rocicorp/onboarding/1-install/packages/zero/src/schema.ts \
-  -o zero/schema.ts
+mkdir -p src/zero
+curl https://raw.githubusercontent.com/rocicorp/zero-music/1-install/packages/zero/src/schema.ts \
+  -o src/zero/schema.ts
 ```
 
 <Note
@@ -175,12 +289,16 @@ Zero has first-class support for React and SolidJS. There is also a low-level AP
 <CodeGroup
   labels={[
     {
-      text: 'React',
-      sync: {client: 'react'},
+      text: 'TanStack Start',
+      sync: {client: 'react', api: 'tanstack'},
     },
     {
-      text: 'SolidJS',
-      sync: {client: 'solidjs'},
+      text: 'Next.js',
+      sync: {client: 'react', api: 'nextjs'},
+    },
+    {
+      text: 'SolidStart',
+      sync: {client: 'solidjs', api: 'solid'},
     },
     {
       text: 'TypeScript',
@@ -190,66 +308,120 @@ Zero has first-class support for React and SolidJS. There is also a low-level AP
 >
 
 ```tsx
-// root.tsx
+// src/routes/__root.tsx
 import {ZeroProvider} from '@rocicorp/zero/react'
 import type {ZeroOptions} from '@rocicorp/zero'
-import {schema} from './zero/schema.ts'
+import {
+  HeadContent,
+  Scripts,
+  createRootRoute
+} from '@tanstack/react-router'
+import type {ReactNode} from 'react'
+import {schema} from '../zero/schema'
 
 const opts: ZeroOptions = {
   cacheURL: 'http://localhost:4848',
   schema
 }
 
-function Root() {
+export const Route = createRootRoute({
+  shellComponent: RootDocument
+})
+
+function RootDocument({children}: {children: ReactNode}) {
   return (
-    <ZeroProvider {...opts}>
-      <App />
-    </ZeroProvider>
+    <html lang="en">
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <ZeroProvider {...opts}>{children}</ZeroProvider>
+        <Scripts />
+      </body>
+    </html>
   )
-}
-
-// mycomponent.tsx
-import {useZero} from '@rocicorp/zero/react'
-
-function MyComponent() {
-  const zero = useZero()
-  console.log('clientID', zero.clientID)
 }
 ```
 
 ```tsx
-// root.tsx
+// src/app/providers.tsx
+'use client'
+
+import {ZeroProvider} from '@rocicorp/zero/react'
+import type {ZeroOptions} from '@rocicorp/zero'
+import type {ReactNode} from 'react'
+import {schema} from '../zero/schema'
+
+const opts: ZeroOptions = {
+  cacheURL: 'http://localhost:4848',
+  schema
+}
+
+export function Providers({
+  children
+}: {
+  children: ReactNode
+}) {
+  return <ZeroProvider {...opts}>{children}</ZeroProvider>
+}
+
+// src/app/layout.tsx
+import type {ReactNode} from 'react'
+import {Providers} from './providers'
+
+export default function RootLayout({
+  children
+}: {
+  children: ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  )
+}
+```
+
+```tsx
+// src/app.tsx
+import {MetaProvider, Title} from '@solidjs/meta'
+import {Router} from '@solidjs/router'
+import {FileRoutes} from '@solidjs/start/router'
 import {ZeroProvider} from '@rocicorp/zero/solid'
 import type {ZeroOptions} from '@rocicorp/zero'
-import {schema} from './zero/schema.ts'
+import {Suspense} from 'solid-js'
+import {schema} from './zero/schema'
 
 const opts: ZeroOptions = {
   cacheURL: 'http://localhost:4848',
   schema
 }
 
-function Root() {
+export default function App() {
   return (
     <ZeroProvider {...opts}>
-      <App />
+      <Router
+        root={props => (
+          <MetaProvider>
+            <Title>Zero Music</Title>
+            <Suspense>{props.children}</Suspense>
+          </MetaProvider>
+        )}
+      >
+        <FileRoutes />
+      </Router>
     </ZeroProvider>
   )
-}
-
-// mycomponent.tsx
-import {useZero} from '@rocicorp/zero/solid'
-
-function MyComponent() {
-  const zero = useZero()
-  console.log('clientID', zero().clientID)
 }
 ```
 
 ```tsx
-// zero.ts
+// src/zero.ts
 import {Zero} from '@rocicorp/zero'
 import type {ZeroOptions} from '@rocicorp/zero'
-import {schema} from './zero/schema.ts'
+import {schema} from './zero/schema'
 
 const opts: ZeroOptions = {
   cacheURL: 'http://localhost:4848',
@@ -257,8 +429,6 @@ const opts: ZeroOptions = {
 }
 
 const zero = new Zero(opts)
-
-console.log('clientID', zero.clientID)
 
 export {zero}
 ```
@@ -272,10 +442,10 @@ export {zero}
 Let's add a way to sync albums by artist. In Zero, shared reads live in `queries.ts`.
 
 ```tsx
-// zero/queries.ts
+// src/zero/queries.ts
 import {defineQueries, defineQuery} from '@rocicorp/zero'
 import {z} from 'zod'
-import {zql} from './schema.ts'
+import {zql} from './schema'
 
 export const queries = defineQueries({
   albums: {
@@ -284,7 +454,7 @@ export const queries = defineQueries({
       ({args: {artistId}}) =>
         zql.albums
           .where('artistId', artistId)
-          .orderBy('createdAt', 'asc')
+          .orderBy('releaseYear', 'desc')
           .limit(10)
           .related('artist', q => q.one())
     )
@@ -309,52 +479,27 @@ Instead, Zero sends the query name and arguments to the `query` endpoint on your
 <CodeGroup
   labels={[
     {
+      text: 'TanStack Start',
+      sync: {api: 'tanstack'},
+    },
+    {
       text: 'Next.js',
       sync: {api: 'nextjs'},
     },
     {
-      text: 'Tanstack Start',
-      sync: {api: 'tanstack'},
-    },
-    {
-      text: 'Solid Start',
+      text: 'SolidStart',
       sync: {api: 'solid'},
-    },
-    {
-      text: 'Hono',
-      sync: {api: 'hono'},
     },
   ]}
 >
-
-```ts
-// app/api/query/route.ts
-import {handleQueryRequest} from '@rocicorp/zero/server'
-import {mustGetQuery} from '@rocicorp/zero'
-import {queries} from '../../zero/queries.ts'
-import {schema} from '../../zero/schema.ts'
-
-export async function POST(req: Request) {
-  const result = await handleQueryRequest(
-    (name, args) => {
-      const query = mustGetQuery(queries, name)
-      return query.fn({args})
-    },
-    schema,
-    req
-  )
-
-  return Response.json(result)
-}
-```
 
 ```ts
 // src/routes/api/query.ts
 import {createFileRoute} from '@tanstack/react-router'
 import {handleQueryRequest} from '@rocicorp/zero/server'
 import {mustGetQuery} from '@rocicorp/zero'
-import {queries} from '../../zero/queries.ts'
-import {schema} from '../../zero/schema.ts'
+import {queries} from '../../zero/queries'
+import {schema} from '../../zero/schema'
 
 export const Route = createFileRoute('/api/query')({
   server: {
@@ -377,12 +522,33 @@ export const Route = createFileRoute('/api/query')({
 ```
 
 ```ts
+// src/app/api/query/route.ts
+import {handleQueryRequest} from '@rocicorp/zero/server'
+import {mustGetQuery} from '@rocicorp/zero'
+import {queries} from '../../../zero/queries'
+import {schema} from '../../../zero/schema'
+
+export async function POST(req: Request) {
+  const result = await handleQueryRequest(
+    (name, args) => {
+      const query = mustGetQuery(queries, name)
+      return query.fn({args})
+    },
+    schema,
+    req
+  )
+
+  return Response.json(result)
+}
+```
+
+```ts
 // src/routes/api/query.ts
 import type {APIEvent} from '@solidjs/start/server'
 import {handleQueryRequest} from '@rocicorp/zero/server'
 import {mustGetQuery} from '@rocicorp/zero'
-import {queries} from '../../zero/queries.ts'
-import {schema} from '../../zero/schema.ts'
+import {queries} from '../../zero/queries'
+import {schema} from '../../zero/schema'
 
 export async function POST(event: APIEvent) {
   const result = await handleQueryRequest(
@@ -398,28 +564,28 @@ export async function POST(event: APIEvent) {
 }
 ```
 
-```ts
-// api/app.ts
-import {Hono} from 'hono'
-import {handleQueryRequest} from '@rocicorp/zero/server'
-import {mustGetQuery} from '@rocicorp/zero'
-import {queries} from '../zero/queries.ts'
-import {schema} from '../zero/schema.ts'
+</CodeGroup>
 
-const app = new Hono()
+Start your app server in another terminal so `zero-cache` can reach the query endpoint:
 
-app.post('/api/query', async c => {
-  const result = await handleQueryRequest(
-    (name, args) => {
-      const query = mustGetQuery(queries, name)
-      return query.fn({args})
-    },
-    schema,
-    c.req.raw
-  )
+<CodeGroup
+  labels={[
+    {text: 'npm', sync: {pm: 'npm'}},
+    {text: 'pnpm', sync: {pm: 'pnpm'}},
+    {text: 'bun', sync: {pm: 'bun'}},
+  ]}
+>
 
-  return c.json(result)
-})
+```bash
+npm run dev
+```
+
+```bash
+pnpm dev
+```
+
+```bash
+bun run dev
 ```
 
 </CodeGroup>
@@ -431,32 +597,25 @@ Restart `zero-cache` with `ZERO_QUERY_URL` so it knows about the new query endpo
     {text: 'npm', sync: {pm: 'npm'}},
     {text: 'pnpm', sync: {pm: 'pnpm'}},
     {text: 'bun', sync: {pm: 'bun'}},
-    {text: 'yarn', sync: {pm: 'yarn'}},
   ]}
 >
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
+# Update localhost:3000 with your local server
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
   npx zero-cache-dev
 ```
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
+# Update localhost:3000 with your local server
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
   pnpm exec zero-cache-dev
 ```
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
+# Update localhost:3000 with your local server
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
   bunx zero-cache-dev
-```
-
-```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
-  yarn exec zero-cache-dev
 ```
 
 </CodeGroup>
@@ -468,12 +627,16 @@ Use the seeded data to fetch albums for The Beatles under `artist_1`.
 <CodeGroup
   labels={[
     {
-      text: 'React',
-      sync: {client: 'react'},
+      text: 'TanStack Start',
+      sync: {client: 'react', api: 'tanstack'},
     },
     {
-      text: 'SolidJS',
-      sync: {client: 'solidjs'},
+      text: 'Next.js',
+      sync: {client: 'react', api: 'nextjs'},
+    },
+    {
+      text: 'SolidStart',
+      sync: {client: 'solidjs', api: 'solid'},
     },
     {
       text: 'TypeScript',
@@ -483,44 +646,83 @@ Use the seeded data to fetch albums for The Beatles under `artist_1`.
 >
 
 ```tsx
-// mycomponent.tsx
+// src/routes/index.tsx
+import {createFileRoute} from '@tanstack/react-router'
 import {useQuery} from '@rocicorp/zero/react'
-import {queries} from './zero/queries.ts'
+import {queries} from '../zero/queries'
 
-function MyComponent() {
+export const Route = createFileRoute('/')({
+  component: Home
+})
+
+function Home() {
   const [albums] = useQuery(
     queries.albums.byArtist({artistId: 'artist_1'})
   )
 
-  return albums.map(album => (
-    <div key={album.id}>{album.title}</div>
-  ))
+  return (
+    <main>
+      <ul>
+        {albums.map(album => (
+          <li key={album.id}>{album.title}</li>
+        ))}
+      </ul>
+    </main>
+  )
 }
 ```
 
 ```tsx
-// mycomponent.tsx
+// src/app/page.tsx
+'use client'
+
+import {useQuery} from '@rocicorp/zero/react'
+import {queries} from '../zero/queries'
+
+export default function Page() {
+  const [albums] = useQuery(
+    queries.albums.byArtist({artistId: 'artist_1'})
+  )
+
+  return (
+    <main>
+      <ul>
+        {albums.map(album => (
+          <li key={album.id}>{album.title}</li>
+        ))}
+      </ul>
+    </main>
+  )
+}
+```
+
+```tsx
+// src/routes/index.tsx
 import {For} from 'solid-js'
 import {useQuery} from '@rocicorp/zero/solid'
-import {queries} from './zero/queries.ts'
+import {queries} from '../zero/queries'
 
-function MyComponent() {
+export default function Home() {
   const [albums] = useQuery(() =>
     queries.albums.byArtist({artistId: 'artist_1'})
   )
 
   return (
-    <For each={albums()}>
-      {album => <div>{album.title}</div>}
-    </For>
+    <main>
+      <ul>
+        <For each={albums()}>
+          {album => <li>{album.title}</li>}
+        </For>
+      </ul>
+    </main>
   )
 }
 ```
 
 ```tsx
-// albums.ts
-import {zero} from './zero.ts'
-import {queries} from './zero/queries.ts'
+// src/albums.ts
+import {zero} from './zero'
+import {queries} from './zero/queries'
 
 const albums = await zero.run(
   queries.albums.byArtist({artistId: 'artist_1'})
@@ -548,7 +750,7 @@ Also, Zero queries are reactive, so if you edit data in Postgres directly, you w
 Now let's add a write path that inserts a new album:
 
 ```tsx
-// zero/mutators.ts
+// src/zero/mutators.ts
 import {defineMutators, defineMutator} from '@rocicorp/zero'
 import {z} from 'zod'
 
@@ -576,10 +778,32 @@ You can use the [CRUD-style API](/docs/mutators#writing-data) with `tx.mutate.<t
 
 Register the mutators where you create the Zero client:
 
-```tsx
+<CodeGroup
+  labels={[
+    {
+      text: 'TanStack Start',
+      sync: {client: 'react', api: 'tanstack'},
+    },
+    {
+      text: 'Next.js',
+      sync: {client: 'react', api: 'nextjs'},
+    },
+    {
+      text: 'SolidStart',
+      sync: {client: 'solidjs', api: 'solid'},
+    },
+    {
+      text: 'TypeScript',
+      sync: {client: 'typescript'},
+    },
+  ]}
+>
+
+```tsx {3,9}
+// src/routes/__root.tsx
 import type {ZeroOptions} from '@rocicorp/zero'
-import {mutators} from './zero/mutators.ts'
-import {schema} from './zero/schema.ts'
+import {mutators} from '../zero/mutators'
+import {schema} from '../zero/schema'
 
 const opts: ZeroOptions = {
   cacheURL: 'http://localhost:4848',
@@ -587,6 +811,47 @@ const opts: ZeroOptions = {
   mutators
 }
 ```
+
+```tsx {3,9}
+// src/app/providers.tsx
+import type {ZeroOptions} from '@rocicorp/zero'
+import {mutators} from '../zero/mutators'
+import {schema} from '../zero/schema'
+
+const opts: ZeroOptions = {
+  cacheURL: 'http://localhost:4848',
+  schema,
+  mutators
+}
+```
+
+```tsx {3,9}
+// src/app.tsx
+import type {ZeroOptions} from '@rocicorp/zero'
+import {mutators} from './zero/mutators'
+import {schema} from './zero/schema'
+
+const opts: ZeroOptions = {
+  cacheURL: 'http://localhost:4848',
+  schema,
+  mutators
+}
+```
+
+```tsx {3,9}
+// src/zero.ts
+import type {ZeroOptions} from '@rocicorp/zero'
+import {mutators} from './zero/mutators'
+import {schema} from './zero/schema'
+
+const opts: ZeroOptions = {
+  cacheURL: 'http://localhost:4848',
+  schema,
+  mutators
+}
+```
+
+</CodeGroup>
 
 ### Add Mutate Endpoint
 
@@ -598,195 +863,58 @@ Zero requires a `mutate` endpoint that runs on your server and connects directly
   tables will also sync instantly to the client.
 </Note>
 
-First, create a `dbProvider` with the Postgres adapter that matches your stack:
-
-<CodeGroup
-  labels={[
-    {
-      text: 'Drizzle',
-      sync: {pgClient: 'drizzle'},
-    },
-    {
-      text: 'Prisma',
-      sync: {pgClient: 'prisma'},
-    },
-    {
-      text: 'Kysely',
-      sync: {pgClient: 'kysely'},
-    },
-    {
-      text: 'node-postgres',
-      sync: {pgClient: 'node-postgres'},
-    },
-    {
-      text: 'postgres.js',
-      sync: {pgClient: 'postgres-js'},
-    },
-  ]}
->
+First, create a `dbProvider` with `node-postgres`:
 
 ```ts
-// src/db-provider.ts
-import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle'
-import {drizzle} from 'drizzle-orm/node-postgres'
-import {Pool} from 'pg'
-import {schema} from '../../zero/schema.ts'
-import * as drizzleSchema from '../../drizzle/schema.ts'
-
-const pool = new Pool({
-  connectionString: process.env.ZERO_UPSTREAM_DB!
-})
-
-export const drizzleClient = drizzle(pool, {
-  schema: drizzleSchema
-})
-
-export const dbProvider = zeroDrizzle(schema, drizzleClient)
-
-declare module '@rocicorp/zero' {
-  interface DefaultTypes {
-    dbProvider: typeof dbProvider
-  }
-}
-```
-
-```ts
-// src/db-provider.ts
-import {PrismaPg} from '@prisma/adapter-pg'
-import {PrismaClient} from '@prisma/client'
-import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma'
-import {schema} from '../../zero/schema.ts'
-
-const prisma = new PrismaClient({
-  adapter: new PrismaPg({
-    connectionString: process.env.ZERO_UPSTREAM_DB!
-  })
-})
-
-export const dbProvider = zeroPrisma(schema, prisma)
-
-declare module '@rocicorp/zero' {
-  interface DefaultTypes {
-    dbProvider: typeof dbProvider
-  }
-}
-```
-
-```ts
-// src/db-provider.ts
-import {Kysely, PostgresDialect} from 'kysely'
-import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely'
-import {Pool} from 'pg'
-import {schema} from '../../zero/schema.ts'
-import type {Database} from '../../kysely/database.ts'
-
-const kysely = new Kysely<Database>({
-  dialect: new PostgresDialect({
-    pool: new Pool({
-      connectionString: process.env.ZERO_UPSTREAM_DB!
-    })
-  })
-})
-
-export const dbProvider = zeroKysely(schema, kysely)
-
-declare module '@rocicorp/zero' {
-  interface DefaultTypes {
-    dbProvider: typeof dbProvider
-  }
-}
-```
-
-```ts
-// src/db-provider.ts
+// src/zero/db-provider.ts
 import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg'
 import {Pool} from 'pg'
-import {schema} from '../../zero/schema.ts'
+import {schema} from './schema'
+
+const connectionString = process.env.ZERO_UPSTREAM_DB
+if (!connectionString) {
+  throw new Error('ZERO_UPSTREAM_DB is not set')
+}
 
 const pool = new Pool({
-  connectionString: process.env.ZERO_UPSTREAM_DB!
+  connectionString
 })
-
 export const dbProvider = zeroNodePg(schema, pool)
 
+// Register global types for mutators on the server
 declare module '@rocicorp/zero' {
   interface DefaultTypes {
     dbProvider: typeof dbProvider
   }
 }
 ```
-
-```ts
-// src/db-provider.ts
-import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs'
-import postgres from 'postgres'
-import {schema} from '../../zero/schema.ts'
-
-const sql = postgres(process.env.ZERO_UPSTREAM_DB!)
-
-export const dbProvider = zeroPostgresJS(schema, sql)
-
-declare module '@rocicorp/zero' {
-  interface DefaultTypes {
-    dbProvider: typeof dbProvider
-  }
-}
-```
-
-</CodeGroup>
 
 Add the mutate endpoint itself:
 
 <CodeGroup
   labels={[
     {
+      text: 'TanStack Start',
+      sync: {api: 'tanstack'},
+    },
+    {
       text: 'Next.js',
       sync: {api: 'nextjs'},
     },
     {
-      text: 'Tanstack Start',
-      sync: {api: 'tanstack'},
-    },
-    {
-      text: 'Solid Start',
+      text: 'SolidStart',
       sync: {api: 'solid'},
-    },
-    {
-      text: 'Hono',
-      sync: {api: 'hono'},
     },
   ]}
 >
-
-```ts
-// app/api/mutate/route.ts
-import {handleMutateRequest} from '@rocicorp/zero/server'
-import {mustGetMutator} from '@rocicorp/zero'
-import {mutators} from '../../zero/mutators.ts'
-import {dbProvider} from '../../db-provider.ts'
-
-export async function POST(req: Request) {
-  const result = await handleMutateRequest(
-    dbProvider,
-    transact =>
-      transact((tx, name, args) => {
-        const mutator = mustGetMutator(mutators, name)
-        return mutator.fn({args, tx})
-      }),
-    req
-  )
-
-  return Response.json(result)
-}
-```
 
 ```ts
 // src/routes/api/mutate.ts
 import {createFileRoute} from '@tanstack/react-router'
 import {handleMutateRequest} from '@rocicorp/zero/server'
 import {mustGetMutator} from '@rocicorp/zero'
-import {mutators} from '../../zero/mutators.ts'
-import {dbProvider} from '../../db-provider.ts'
+import {mutators} from '../../zero/mutators'
+import {dbProvider} from '../../zero/db-provider'
 
 export const Route = createFileRoute('/api/mutate')({
   server: {
@@ -810,12 +938,34 @@ export const Route = createFileRoute('/api/mutate')({
 ```
 
 ```ts
+// src/app/api/mutate/route.ts
+import {handleMutateRequest} from '@rocicorp/zero/server'
+import {mustGetMutator} from '@rocicorp/zero'
+import {mutators} from '../../../zero/mutators'
+import {dbProvider} from '../../../zero/db-provider'
+
+export async function POST(req: Request) {
+  const result = await handleMutateRequest(
+    dbProvider,
+    transact =>
+      transact((tx, name, args) => {
+        const mutator = mustGetMutator(mutators, name)
+        return mutator.fn({args, tx})
+      }),
+    req
+  )
+
+  return Response.json(result)
+}
+```
+
+```ts
 // src/routes/api/mutate.ts
 import type {APIEvent} from '@solidjs/start/server'
 import {handleMutateRequest} from '@rocicorp/zero/server'
 import {mustGetMutator} from '@rocicorp/zero'
-import {mutators} from '../../zero/mutators.ts'
-import {dbProvider} from '../../db-provider.ts'
+import {mutators} from '../../zero/mutators'
+import {dbProvider} from '../../zero/db-provider'
 
 export async function POST(event: APIEvent) {
   const result = await handleMutateRequest(
@@ -832,28 +982,6 @@ export async function POST(event: APIEvent) {
 }
 ```
 
-```ts
-// api/app.ts
-import {handleMutateRequest} from '@rocicorp/zero/server'
-import {mustGetMutator} from '@rocicorp/zero'
-import {mutators} from '../zero/mutators.ts'
-import {dbProvider} from './db-provider.ts'
-
-app.post('/api/mutate', async c => {
-  const result = await handleMutateRequest(
-    dbProvider,
-    transact =>
-      transact((tx, name, args) => {
-        const mutator = mustGetMutator(mutators, name)
-        return mutator.fn({args, tx})
-      }),
-    c.req.raw
-  )
-
-  return c.json(result)
-})
-```
-
 </CodeGroup>
 
 Restart `zero-cache` with `ZERO_MUTATE_URL` configured:
@@ -863,53 +991,94 @@ Restart `zero-cache` with `ZERO_MUTATE_URL` configured:
     {text: 'npm', sync: {pm: 'npm'}},
     {text: 'pnpm', sync: {pm: 'pnpm'}},
     {text: 'bun', sync: {pm: 'bun'}},
-    {text: 'yarn', sync: {pm: 'yarn'}},
   ]}
 >
 
+<SyncedCode syncKey="api" syncValues={['tanstack', 'nextjs', 'solid']}>
+
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
   ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
   npx zero-cache-dev
 ```
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
+  ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
+  npx zero-cache-dev
+```
+
+```bash
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
+  ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
+  npx zero-cache-dev
+```
+
+</SyncedCode>
+
+<SyncedCode syncKey="api" syncValues={['tanstack', 'nextjs', 'solid']}>
+
+```bash
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
   ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
   pnpm exec zero-cache-dev
 ```
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
+  ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
+  pnpm exec zero-cache-dev
+```
+
+```bash
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
+  ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
+  pnpm exec zero-cache-dev
+```
+
+</SyncedCode>
+
+<SyncedCode syncKey="api" syncValues={['tanstack', 'nextjs', 'solid']}>
+
+```bash
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
   ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
   bunx zero-cache-dev
 ```
 
 ```bash
-ZERO_UPSTREAM_DB="postgres://postgres:pass@localhost:5432/zero" \
-  ZERO_QUERY_URL="http://localhost:3000/api/query" \
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
   ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
-  yarn exec zero-cache-dev
+  bunx zero-cache-dev
 ```
+
+```bash
+ZERO_QUERY_URL="http://localhost:3000/api/query" \
+  ZERO_MUTATE_URL="http://localhost:3000/api/mutate" \
+  bunx zero-cache-dev
+```
+
+</SyncedCode>
 
 </CodeGroup>
 
 ### Invoke Mutators
 
-We can now add a simple button to add an album for The Beatles:
+Now add a button to create an album:
 
 <CodeGroup
   labels={[
     {
-      text: 'React',
-      sync: {client: 'react'},
+      text: 'TanStack Start',
+      sync: {client: 'react', api: 'tanstack'},
     },
     {
-      text: 'SolidJS',
-      sync: {client: 'solidjs'},
+      text: 'Next.js',
+      sync: {client: 'react', api: 'nextjs'},
+    },
+    {
+      text: 'SolidStart',
+      sync: {client: 'solidjs', api: 'solid'},
     },
     {
       text: 'TypeScript',
@@ -918,64 +1087,127 @@ We can now add a simple button to add an album for The Beatles:
   ]}
 >
 
-```tsx
-// mycomponent.tsx
-import {useZero} from '@rocicorp/zero/react'
-import {mutators} from './zero/mutators.ts'
+```tsx {3-4,12,17-26,30}
+// src/routes/index.tsx
+import {createFileRoute} from '@tanstack/react-router'
+import {useQuery, useZero} from '@rocicorp/zero/react'
+import {mutators} from '../zero/mutators'
+import {queries} from '../zero/queries'
 
-function MyComponent() {
+export const Route = createFileRoute('/')({
+  component: Home
+})
+
+function Home() {
   const zero = useZero()
+  const [albums] = useQuery(
+    queries.albums.byArtist({artistId: 'artist_1'})
+  )
 
-  const onClick = async () => {
-    const client = await zero.mutate(
+  const onClick = () => {
+    zero.mutate(
       mutators.albums.create({
         id: crypto.randomUUID(),
         artistId: 'artist_1',
         title: 'Please Please Me',
         releaseYear: 1963
       })
-    ).client
-
-    if (client.type === 'success') {
-      console.log('Album created!')
-    }
+    )
   }
 
-  return <button onClick={onClick}>Create Album</button>
+  return (
+    <main>
+      <button onClick={onClick}>Create Album</button>
+      <ul>
+        {albums.map(album => (
+          <li key={album.id}>{album.title}</li>
+        ))}
+      </ul>
+    </main>
+  )
 }
 ```
 
-```tsx
-// mycomponent.tsx
-import {useZero} from '@rocicorp/zero/solid'
-import {mutators} from './zero/mutators.ts'
+```tsx {4-5,9,14-23,27}
+// src/app/page.tsx
+'use client'
 
-function MyComponent() {
+import {useQuery, useZero} from '@rocicorp/zero/react'
+import {mutators} from '../zero/mutators'
+import {queries} from '../zero/queries'
+
+export default function Page() {
   const zero = useZero()
+  const [albums] = useQuery(
+    queries.albums.byArtist({artistId: 'artist_1'})
+  )
 
-  const onClick = async () => {
-    const client = await zero().mutate(
+  const onClick = () => {
+    zero.mutate(
       mutators.albums.create({
         id: crypto.randomUUID(),
         artistId: 'artist_1',
         title: 'Please Please Me',
         releaseYear: 1963
       })
-    ).client
-
-    if (client.type === 'success') {
-      console.log('Album created!')
-    }
+    )
   }
 
-  return <button onClick={onClick}>Create Album</button>
+  return (
+    <main>
+      <button onClick={onClick}>Create Album</button>
+      <ul>
+        {albums.map(album => (
+          <li key={album.id}>{album.title}</li>
+        ))}
+      </ul>
+    </main>
+  )
 }
 ```
 
-```tsx
-// albums.ts
-import {zero} from './zero.ts'
-import {mutators} from './zero/mutators.ts'
+```tsx {3-4,8,13-22,26}
+// src/routes/index.tsx
+import {For} from 'solid-js'
+import {useQuery, useZero} from '@rocicorp/zero/solid'
+import {mutators} from '../zero/mutators'
+import {queries} from '../zero/queries'
+
+export default function Home() {
+  const zero = useZero()
+  const [albums] = useQuery(() =>
+    queries.albums.byArtist({artistId: 'artist_1'})
+  )
+
+  const onClick = () => {
+    zero().mutate(
+      mutators.albums.create({
+        id: crypto.randomUUID(),
+        artistId: 'artist_1',
+        title: 'Please Please Me',
+        releaseYear: 1963
+      })
+    )
+  }
+
+  return (
+    <main>
+      <button onClick={onClick}>Create Album</button>
+      <ul>
+        <For each={albums()}>
+          {album => <li>{album.title}</li>}
+        </For>
+      </ul>
+    </main>
+  )
+}
+```
+
+```tsx {3,6-13}
+// src/albums.ts
+import {zero} from './zero'
+import {mutators} from './zero/mutators'
+import {queries} from './zero/queries'
 
 const client = await zero.mutate(
   mutators.albums.create({
@@ -986,14 +1218,19 @@ const client = await zero.mutate(
   })
 ).client
 
-if (client.type === 'success') {
-  console.log('Album created!')
-}
+const albums = await zero.run(
+  queries.albums.byArtist({artistId: 'artist_1'})
+)
+
+console.log(
+  'albums',
+  albums.map(album => album.title)
+)
 ```
 
 </CodeGroup>
 
-When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint.
+When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. `Please Please Me` will appear in the album list immediately.
 
 Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients:
 

--- a/lib/mdx-to-markdown.ts
+++ b/lib/mdx-to-markdown.ts
@@ -8,6 +8,8 @@ import type {Node, Parent} from 'unist';
 import type {
   Blockquote,
   Content,
+  List,
+  ListItem,
   Image,
   Link,
   Paragraph,
@@ -17,6 +19,10 @@ import type {
 } from 'mdast';
 import {page_routes as pageRoutes} from '@/lib/routes-config';
 import {getBaseUrl, getDocsContentPath} from '@/lib/docs-utils';
+import {
+  startingPoints,
+  type StartingPointDescriptionSegment,
+} from '@/lib/starting-points';
 
 const DOC_ROUTE_LOOKUP = (() => {
   const map = new Map<string, string>();
@@ -177,6 +183,9 @@ function transformMdxJsx(node: MdxJsxNode): TransformOutcome | null {
     case 'SyncedCode':
       return {action: 'unwrap', children: transformSyncedCode(node)};
 
+    case 'StartingPointCards':
+      return {action: 'replace', node: transformStartingPointCards()};
+
     case 'InstallTableNameReplace':
     case 'InstallTableNameInput':
       return {
@@ -244,6 +253,62 @@ function transformSyncedCode(node: MdxJsxNode): Node[] {
   return variants.flatMap((variant, index) => {
     const label = syncValues[index] ?? `Variant ${index + 1}`;
     return [createLabelParagraph(label), ...normalizeNode(variant)];
+  });
+}
+
+function transformStartingPointCards(): List {
+  const children = startingPoints.map<ListItem>(point => {
+    const paragraphChildren: PhrasingContent[] = [
+      {
+        type: 'link',
+        url: point.href,
+        title: null,
+        children: [
+          {
+            type: 'strong',
+            children: [{type: 'text', value: point.title}],
+          },
+        ],
+      },
+      {type: 'text', value: ': '},
+      ...transformStartingPointDescription(point.description),
+      {type: 'text', value: ` Time: ${point.duration}`},
+    ];
+
+    return {
+      type: 'listItem',
+      spread: false,
+      children: [
+        {
+          type: 'paragraph',
+          children: paragraphChildren,
+        },
+      ],
+    };
+  });
+
+  return {
+    type: 'list',
+    ordered: false,
+    spread: true,
+    children,
+  };
+}
+
+function transformStartingPointDescription(
+  description: readonly StartingPointDescriptionSegment[],
+): PhrasingContent[] {
+  return description.map(segment => {
+    if (typeof segment === 'string') {
+      return {type: 'text', value: segment};
+    }
+
+    return {
+      type: 'link',
+      url: segment.href,
+      title: null,
+      children: [{type: 'text', value: segment.text}],
+    };
   });
 }
 

--- a/lib/mdx.ts
+++ b/lib/mdx.ts
@@ -14,6 +14,7 @@ import {
   InstallTableNameInput,
   InstallTableNameReplace,
 } from '@/components/InstallTableName';
+import {StartingPointCards} from '@/components/StartingPointCards';
 import SyncedCode from '@/components/SyncedCode';
 import Note from '@/components/note';
 import ImageLightbox from '@/components/ui/ImageLightbox';
@@ -31,6 +32,7 @@ const components = {
   Video,
   Button,
   CodeGroup,
+  StartingPointCards,
   InstallTableNameInput,
   InstallTableNameReplace,
   SyncedCode,

--- a/lib/routes-config.ts
+++ b/lib/routes-config.ts
@@ -15,9 +15,10 @@ export const ROUTES = [
     href: null,
     new: false,
     items: [
-      {title: 'Installation', href: '/install'},
+      {title: 'Introduction', href: '/introduction'},
+      {title: 'Install', href: '/install'},
       {title: 'Tutorial', href: '/tutorial'},
-      {title: 'Quickstart', href: '/quickstart'},
+      {title: 'Quickstarts', href: '/quickstart'},
       {title: 'Samples', href: '/samples'},
     ],
   },

--- a/lib/starting-points.ts
+++ b/lib/starting-points.ts
@@ -1,0 +1,46 @@
+export type StartingPointDescriptionSegment =
+  | string
+  | {
+      text: string;
+      href: string;
+    };
+
+export type StartingPoint = {
+  title: string;
+  href: string;
+  description: StartingPointDescriptionSegment[];
+  duration: string;
+};
+
+export const startingPoints: StartingPoint[] = [
+  {
+    title: 'Install',
+    href: '/docs/install',
+    description: [
+      'Add Zero to your existing application following our step-by-step guide.',
+    ],
+    duration: '30 minutes',
+  },
+  {
+    title: 'Tutorial',
+    href: '/docs/tutorial',
+    description: [
+      'Learn how Zero works by following our guided tutorial building a music app.',
+    ],
+    duration: '15 minutes',
+  },
+  {
+    title: 'Quickstarts',
+    href: '/docs/quickstart',
+    description: ['Start a new app with one of our bare-bones templates.'],
+    duration: '1 minute',
+  },
+  {
+    title: 'Samples',
+    href: '/docs/samples',
+    description: [
+      'Explore our more fully-featured samples to see what Zero can do.',
+    ],
+    duration: 'Stay as long as you like',
+  },
+];


### PR DESCRIPTION
- Adds cards to the introduction page.
- Reworks the tutorial and install docs around the current Zero onboarding flow, including framework-specific setup, Postgres setup, query/mutate endpoints, and local zero-cache commands.