### PR TITLE
docs: update PlanetScale role scoped IP restriction guidance

### DIFF
--- a/assets/search-index.json
+++ b/assets/search-index.json
@@ -14,7 +14,7 @@
     "kind": "page"
   },
   {
-    "id": "72-agents#options",
+    "id": "73-agents#options",
     "title": "Agent Support",
     "searchTitle": "Options",
     "sectionTitle": "Options",
@@ -28,47 +28,43 @@
     "title": "Authentication",
     "searchTitle": "Authentication",
     "url": "/docs/auth",
-    "content": "Setting up auth in Zero apps has a few steps: Setting the userID on the client Defining the Context type for permissions Wiring credentials to the mutate and queries endpoints Logging out Setting userID Authenticated Zero clients should provide a userID on construction: import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' const opts: ZeroOptions = { // ... userID: 'user-123' } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' const opts: ZeroOptions = { // ... userID: 'user-123' } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' const opts: ZeroOptions = { // ... userID: 'user-123' } const zero = new Zero(opts) If the user is logged out, omit userID, or set to undefined / null: const opts: ZeroOptions = { // ... userID: undefined } Zero uses this to segregate the client-side storage for each user. This allows users to quickly switch between multiple users and accounts without resyncing. All users that have access to a browser profile have access to the same IndexedDB instances. There is nothing that Zero can do about this – users can just open the folder where the data is stored and look inside it. If you do not want Zero to store synced data in IndexedDB on the client, set kvStore: 'mem' in your ZeroOptions. This uses in-memory storage instead, so data is not persisted on the device and is cleared on full reloads and browser restarts. If you have more than one set of Zero data per-user (i.e., for different apps in the same domain), you can additionally use the storageKey parameter: const opts: ZeroOptions = { // ... userID: 'user-123', storageKey: 'my-app' } If specified, storageKey is concatenated along with userID and other internal Zero information to form a unique IndexedDB database name. Context When a user is authenticated, you will want to know who they are in your queries and mutators to enforce permissions. To do this, first define a Context type that includes the user's ID and any other relevant information, then register that type globally with Zero: export type ZeroContext = { id: string } declare module '@rocicorp/zero' { interface DefaultTypes { context: ZeroContext } } Then pass an instance of this context when instantiating Zero on the client: const opts: ZeroOptions = { // ... userID: 'user-123', context: { id: 'user-123' } } If your app also supports guest access, allow Context to be undefined (or null) when the request is unauthenticated, and pass undefined or null for the userID. declare module '@rocicorp/zero' { interface DefaultTypes { context: ZeroContext | undefined } } const opts: ZeroOptions = { // ... userID: undefined, context: undefined } Sending Credentials You can send credentials using either cookies or tokens. Cookies The most common way to authenticate Zero is with cookies. To enable it, set the ZERO_QUERY_FORWARD_COOKIES and ZERO_MUTATE_FORWARD_COOKIES options to true: # ... other env vars export ZERO_QUERY_FORWARD_COOKIES=\"true\" export ZERO_MUTATE_FORWARD_COOKIES=\"true\" # run zero-cache, e.g. `npx zero-cache-dev` Zero-cache will then forward all cookies sent to cacheURL to your mutators and queries endpoints: const opts: ZeroOptions = { schema, // Cookies sent to zero.example.com will be forwarded to // api.example.com/mutate and api.example.com/queries. cacheURL: 'https://zero.example.com', mutateURL: 'https://api.example.com/mutate', queryURL: 'https://api.example.com/queries' } Cookies will show up in the normal HTTP Cookie header and you can authenticate these endpoints just like you would any API request. Query Handler You can now build ctx from the validated cookie and pass it to your queries to enforce permissions. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return c.json(result) }) Mutate Handler You can now also build ctx from the validated cookie and pass it to your mutators to enforce permissions. // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return c.json(result) }) Deployment In order for cookie auth to work, the browser must send your frontend's cookies to zero-cache, so that zero-cache can forward them to your API. During development, this works automatically as long as your frontend and zero-cache are both running on localhost with different ports. Browsers send cookies based on domain name, not port number, so cookies set by localhost:3000 are also sent to localhost:4848. For production you'll need to do two things: Run zero-cache on a subdomain of your main site (e.g., zero.example.com if your main site is example.com). Consult your hosting provider's docs, or your favorite LLM for how to configure this. Set cookies from your main site with the Domain attribute set to your root domain (e.g., .example.com). If you use a third-party auth provider, consult their docs on how to do this. For example, for Better Auth, this is done with the crossSubDomainCookies feature. Do not set SameSite=None on cookies used for authentication with Zero. Because Zero uses WebSockets, setting SameSite=None can expose your application to Cross-Site WebSocket Hijacking (CSWSH) attacks. Use SameSite=Lax (the browser default) or SameSite=Strict instead. Tokens Zero also supports token-based authentication. If you have an opaque auth token, such as a JWT or a token from your auth provider, you can pass it to Zero's auth parameter: const opts: ZeroOptions = { // ... userID: 'user-123', auth: token } If you set auth, you must also set userID to the authenticated user's ID. Zero will forward this token to your mutators and queries endpoints in an Authorization: Bearer <token> header. Authenticate the request first and derive your context from it when invoking your query and mutator implementations. Query Handler You can now build ctx from the validated token header and pass it to your queries to enforce permissions. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return c.json(result) }) Mutate Handler You can now also build ctx from the validated token header and pass it to your mutators to enforce permissions. // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return c.json(result) }) Updating Tokens If you are using token auth and the user stays signed in as the same user, you can update the token without recreating Zero: const nextToken = await fetchNewToken() await zero.connection.connect({auth: nextToken}) When called while connected, Zero refreshes server-side auth context and re-transforms queries without reconnecting. The new token is also reused for later reconnects. Use this only to refresh credentials for the current user. For logging out or logging in as a different user, recreate Zero with the new userID and auth values instead. Auth Failure and Refresh To mark a request as unauthorized, return a 401 or 403 status code from your queries or mutators endpoint. const session = await authenticate( request.headers.get('Authorization') ) if (!session) { // can be 401 or 403 return Response.json( {error: 'Unauthorized'}, {status: 401} ) } // handle mutate/query request ... This will cause Zero to disconnect from zero-cache and the connection status will change to needs-auth. For cookie auth, refresh the cookie and call zero.connection.connect(). For token auth, fetch a new token and call zero.connection.connect({auth: newToken}). function NeedsAuthDialog() { const connectionState = useConnectionState() const refreshCookie = async () => { await login() // no token needed since we use cookie auth zero.connection.connect() } if (connectionState.name === 'needs-auth') { return ( <div> <h1>Authentication Required</h1> <button onClick={refreshCookie}>Login</button> </div> ) } return null } Or, if you are using token auth: function NeedsAuthDialog() { const connectionState = useConnectionState() const refreshAuthToken = async () => { const token = await fetchNewToken() // pass a new token to use when reconnecting to zero-cache zero.connection.connect({auth: token}) } if (connectionState.name === 'needs-auth') { return ( <div> <h1>Authentication Required</h1> <button onClick={refreshAuthToken}>Login</button> </div> ) } return null } Permission Patterns Zero does not have (or need) a first-class permission system like RLS. Instead, you implement permissions by authenticating the user in your queries and mutators endpoints, and creating a Context object that contains the user's ID and other information. This context is passed to your queries and mutators and used to control what data the user can access. Here are a collection of common permissions patterns and how to implement them in Zero. Read Permissions Only Owned Rows // Use the context's user ID to filter the rows to only the // ones owned by the user. const myPosts = defineQuery(({ctx}) => { return zql.post.where('authorID', ctx.id) }) Owned or Shared Rows // Use the context's user ID to filter the rows to only the // ones owned by the user or shared with the user. const allowedPosts = defineQuery(({ctx}) => { return zql.post.where(({cmp, exists, or}) => or( cmp('authorID', ctx.id), exists('sharedWith', q => q.where('userID', ctx.id)) ) ) }) Owned Rows or All if Admin const allowedPosts = defineQuery(({ctx}) => { if (ctx.role === 'admin') { return zql.post } return zql.post.where('authorID', ctx.id) }) Deny by Returning No Rows Read permissions in Zero are filter-based. If a user should not be able to see any rows for a query, return a query that matches no rows instead of throwing an error. // The empty `or()` expression is always false, // so this returns no rows. const myPosts = defineQuery(({ctx}) => { if (!ctx?.id) { return zql.post.where(({or}) => or()) } return zql.post.where('authorID', ctx.id) }) Write Permissions Enforce Ownership // All created items are owned by the user who created them. const createPost = defineMutator( z.object({ id: z.string(), title: z.string(), content: z.string() }), (tx, {ctx, args: {id, title, content}}) => { return zql.post.insert({ id, title, content, authorID: userID }) } ) Edit Owned Rows const updatePost = defineMutator( z.object({ id: z.string(), content: z.string().optional() }), (tx, {ctx, args: {id, content}}) => { const prev = await tx.run( zql.post.where('id', id).one() ) if (!prev) { return } if (prev.authorID !== ctx.id) { throw new Error('Access denied') } return zql.post.update({ id, content }) } ) Edit Owned or Shared Rows const updatePost = defineMutator( z.object({ id: z.string(), content: z.string().optional() }), (tx, {ctx, args: {id, content}}) => { const prev = await tx.run( zql.post .where('id', id) .related('sharedWith', q => q.where('userID', ctx.id) ) .one() ) if (!prev) { return } if ( prev.authorID !== ctx.id && prev.sharedWith.length === 0 ) { throw new Error('Access denied') } return zql.post.update({ id, content }) } ) Edit Owned or All if Admin const updatePost = defineMutator( z.object({ id: z.string(), content: z.string().optional() }), (tx, {ctx, args: {id, content}}) => { const prev = await tx.run( zql.post.where('id', id).one() ) if (!prev) { return } if (ctx.role !== 'admin' && prev.authorID !== ctx.id) { throw new Error('Access denied') } return zql.post.update({ id, content }) } ) Logging Out When a user logs out, you should recreate Zero without userID, and consider what should happen to the synced data. If you do nothing, the synced data will be left on the device. The next login will be a little faster because Zero doesn't have to resync that data from scratch. But also, the data will be left on the device indefinitely which could be undesirable for privacy and security. If you instead want to clear data on logout, use zero.delete(): await zero.delete() This immediately closes the Zero instance and deletes all data from the browser's IndexedDB database.",
+    "content": "Setting up auth in Zero apps has the following steps: Set userID on the client Define the Context type for permissions Implement query and mutate endpoints Log out Set userID on Client Your app will already know the logged-in user from whatever auth provider you use. Pass this userID to Zero on construction: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={userID}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={userID}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' const zero = new Zero({ userID // ... }) If the user is logged out, omit userID, or set to undefined / null: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={null}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={null}> <App /> </ZeroProvider> )const zero = new Zero({ userID: null // ... }) Zero uses the userID field to segregate the client-side storage for each user. This allows users to quickly switch between multiple users and accounts without resyncing. There is nothing that Zero can do about this – users can just open the folder where the data is stored and look inside it. If preventing this is important to you, set kvStore: 'mem' in your ZeroOptions. This uses in-memory storage instead, so data is not persisted on the device and is cleared on full reloads and browser restarts. If you have more than one set of Zero data per-user (i.e., for different apps in the same domain), you can additionally use the storageKey parameter: const opts: ZeroOptions = { // ... userID: 'user-123', storageKey: 'my-app' } If specified, storageKey is concatenated along with userID and other internal Zero information to form a unique IndexedDB database name. Define the Context Type When a user is authenticated, you will want to know who they are in your queries and mutators to enforce permissions. To do this, first define a Context type that includes the user's ID and any other relevant information, then register that type globally with Zero: export type ZeroContext = { id: string } declare module '@rocicorp/zero' { interface DefaultTypes { context: ZeroContext } } Then pass an instance of this context when instantiating Zero on the client: const opts: ZeroOptions = { // ... userID: 'user-123', context: { id: 'user-123' } } If your app also supports guest access, allow Context to be undefined (or null) when the request is unauthenticated, and pass undefined or null for the userID. declare module '@rocicorp/zero' { interface DefaultTypes { context: ZeroContext | undefined } } const opts: ZeroOptions = { // ... userID: undefined, context: undefined } Send Credentials Both cookies and tokens are supported. Cookies The most common way to authenticate Zero is with cookies. To enable it, set the ZERO_QUERY_FORWARD_COOKIES and ZERO_MUTATE_FORWARD_COOKIES options to true: # ... other env vars export ZERO_QUERY_FORWARD_COOKIES=\"true\" export ZERO_MUTATE_FORWARD_COOKIES=\"true\" # run zero-cache, e.g. `npx zero-cache-dev` Zero-cache will then forward all cookies sent to cacheURL to your mutators and queries endpoints. Cookies will show up in the normal HTTP Cookie header and you can authenticate these endpoints just like you would any API request: // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... } } } })// app/api/zero/query/route.ts export async function POST(request: Request) { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) // ... handle query ... }// api/app.ts import {Hono} from 'hono' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... }) Cookie Deployment In order for cookie auth to work, the browser must send your frontend's cookies to zero-cache, so that zero-cache can forward them to your API. During development, this works automatically as long as your frontend and zero-cache are both running on localhost with different ports. Browsers send cookies based on domain name, not port number, so cookies set by localhost:3000 are also sent to localhost:4848. For production you'll need to do two things: Run zero-cache on a subdomain of your main site (e.g., zero.example.com if your main site is example.com). Consult your hosting provider's docs, or your favorite LLM for how to configure this. Set cookies from your main site with the Domain attribute set to your root domain (e.g., .example.com). If you use a third-party auth provider, consult their docs on how to do this. For example, for Better Auth, this is done with the crossSubDomainCookies feature. Do not set SameSite=None on cookies used for authentication with Zero. Because Zero uses WebSockets, setting SameSite=None can expose your application to Cross-Site WebSocket Hijacking (CSWSH) attacks. Use SameSite=Lax (the browser default) or SameSite=Strict instead. Tokens Zero also supports token-based authentication. If you have an opaque auth token, such as a JWT or a token from your auth provider, you can pass it to Zero's auth parameter: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={userID} auth={token}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={userID} auth={token}> <App /> </ZeroProvider> )const zero = new Zero({ userID, auth: token // ... }) Zero will forward this token to your mutators and queries endpoints in an Authorization: Bearer <token> header: // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... } } } })// app/api/zero/query/route.ts export async function POST(request: Request) { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) // ... handle query ... }// api/app.ts import {Hono} from 'hono' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... }) Implement API Endpoints Create a Context object from the validated credentials and pass it to your query and mutator functions. Query // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request, userID: session?.user?.id }) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(request: Request) { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request, userID: session?.user?.id }) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request: event.request, userID: session?.user?.id }) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request, userID: session?.user?.id }) return c.json(result) }) Mutate // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request, userID: session?.user?.id }) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(request: Request) { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request, userID: session?.user?.id }) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request: event.request, userID: session?.user?.id }) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request, userID: session?.user?.id }) return c.json(result) }) Tabs in the same browser share synced data. This group of tabs is called a \"client group\", keyed by clientGroupID. New tabs join a client group by providing the clientGroupID during connection. The clientGroupID is randomly-generated client-side and non-trivial for attackers to guess. However, it could be stolen with XSS or leaked in logs. Passing the server-verified userID to handleMutateRequest and handleQueryRequest lets Zero enforce that only tabs belonging to the same user can be in the same client group. Updating Tokens If you are using token auth and the user stays signed in as the same user, you can update the token without recreating Zero: const nextToken = await fetchNewToken() await zero.connection.connect({auth: nextToken}) When called while connected, Zero refreshes server-side auth context and re-transforms queries without reconnecting. The new token is also reused for later reconnects. Use this only to refresh credentials for the current user. For logging out or logging in as a different user, recreate Zero with the new userID and auth values instead. Auth Failure and Refresh To mark a request as unauthorized, return a 401 or 403 status code from your queries or mutators endpoint. const session = await authenticate( request.headers.get('Authorization') ) if (!session) { // can be 401 or 403 return Response.json( {error: 'Unauthorized'}, {status: 401} ) } // handle mutate/query request ... This will cause Zero to disconnect from zero-cache and the connection status will change to needs-auth. For cookie auth, refresh the cookie and call zero.connection.connect(). For token auth, fetch a new token and call zero.connection.connect({auth: newToken}). function NeedsAuthDialog() { const connectionState = useConnectionState() const refreshCookie = async () => { await login() // no token needed since we use cookie auth zero.connection.connect() } if (connectionState.name === 'needs-auth') { return ( <div> <h1>Authentication Required</h1> <button onClick={refreshCookie}>Login</button> </div> ) } return null } Or, if you are using token auth: function NeedsAuthDialog() { const connectionState = useConnectionState() const refreshAuthToken = async () => { const token = await fetchNewToken() // pass a new token to use when reconnecting to zero-cache zero.connection.connect({auth: token}) } if (connectionState.name === 'needs-auth') { return ( <div> <h1>Authentication Required</h1> <button onClick={refreshAuthToken}>Login</button> </div> ) } return null } Permission Patterns Zero does not have (or need) a first-class permission system like RLS. Instead, you implement permissions by authenticating the user in your queries and mutators endpoints, and creating a Context object that contains the user's ID and other information. This context is passed to your queries and mutators and used to control what data the user can access. Here are a collection of common permissions patterns and how to implement them in Zero. Read Permissions Only Owned Rows // Use the context's user ID to filter the rows to only the // ones owned by the user. const myPosts = defineQuery(({ctx}) => { return zql.post.where('authorID', ctx.id) }) Owned or Shared Rows // Use the context's user ID to filter the rows to only the // ones owned by the user or shared with the user. const allowedPosts = defineQuery(({ctx}) => { return zql.post.where(({cmp, exists, or}) => or( cmp('authorID', ctx.id), exists('sharedWith', q => q.where('userID', ctx.id)) ) ) }) Owned Rows or All if Admin const allowedPosts = defineQuery(({ctx}) => { if (ctx.role === 'admin') { return zql.post } return zql.post.where('authorID', ctx.id) }) Deny by Returning No Rows Read permissions in Zero are filter-based. If a user should not be able to see any rows for a query, return a query that matches no rows instead of throwing an error. // The empty `or()` expression is always false, // so this returns no rows. const myPosts = defineQuery(({ctx}) => { if (!ctx?.id) { return zql.post.where(({or}) => or()) } return zql.post.where('authorID', ctx.id) }) Write Permissions Enforce Ownership // All created items are owned by the user who created them. const createPost = defineMutator( z.object({ id: z.string(), title: z.string(), content: z.string() }), (tx, {ctx, args: {id, title, content}}) => { return zql.post.insert({ id, title, content, authorID: userID }) } ) Edit Owned Rows const updatePost = defineMutator( z.object({ id: z.string(), content: z.string().optional() }), (tx, {ctx, args: {id, content}}) => { const prev = await tx.run( zql.post.where('id', id).one() ) if (!prev) { return } if (prev.authorID !== ctx.id) { throw new Error('Access denied') } return zql.post.update({ id, content }) } ) Edit Owned or Shared Rows const updatePost = defineMutator( z.object({ id: z.string(), content: z.string().optional() }), (tx, {ctx, args: {id, content}}) => { const prev = await tx.run( zql.post .where('id', id) .related('sharedWith', q => q.where('userID', ctx.id) ) .one() ) if (!prev) { return } if ( prev.authorID !== ctx.id && prev.sharedWith.length === 0 ) { throw new Error('Access denied') } return zql.post.update({ id, content }) } ) Edit Owned or All if Admin const updatePost = defineMutator( z.object({ id: z.string(), content: z.string().optional() }), (tx, {ctx, args: {id, content}}) => { const prev = await tx.run( zql.post.where('id', id).one() ) if (!prev) { return } if (ctx.role !== 'admin' && prev.authorID !== ctx.id) { throw new Error('Access denied') } return zql.post.update({ id, content }) } ) Logging Out When a user logs out, you should recreate Zero without userID, and consider what should happen to the synced data. If you do nothing, the synced data will be left on the device. The next login will be a little faster because Zero doesn't have to resync that data from scratch. But also, the data will be left on the device indefinitely which could be undesirable for privacy and security. If you instead want to clear data on logout, use zero.delete(): await zero.delete() This immediately closes the Zero instance and deletes all data from the browser's IndexedDB database.",
     "headings": [
       {
-        "text": "Setting userID",
-        "id": "setting-userid"
+        "text": "Set userID on Client",
+        "id": "set-userid-on-client"
       },
       {
-        "text": "Context",
-        "id": "context"
+        "text": "Define the Context Type",
+        "id": "define-the-context-type"
       },
       {
-        "text": "Sending Credentials",
-        "id": "sending-credentials"
+        "text": "Send Credentials",
+        "id": "send-credentials"
       },
       {
         "text": "Cookies",
         "id": "cookies"
       },
       {
-        "text": "Query Handler",
-        "id": "query-handler"
-      },
-      {
-        "text": "Mutate Handler",
-        "id": "mutate-handler"
-      },
-      {
-        "text": "Deployment",
-        "id": "deployment"
+        "text": "Cookie Deployment",
+        "id": "cookie-deployment"
       },
       {
         "text": "Tokens",
         "id": "tokens"
       },
       {
-        "text": "Query Handler",
-        "id": "query-handler-1"
+        "text": "Implement API Endpoints",
+        "id": "implement-api-endpoints"
       },
       {
-        "text": "Mutate Handler",
-        "id": "mutate-handler-1"
+        "text": "Query",
+        "id": "query"
+      },
+      {
+        "text": "Mutate",
+        "id": "mutate"
       },
       {
         "text": "Updating Tokens",
@@ -130,103 +126,93 @@
     "kind": "page"
   },
   {
-    "id": "73-auth#setting-userid",
+    "id": "74-auth#set-userid-on-client",
     "title": "Authentication",
-    "searchTitle": "Setting userID",
-    "sectionTitle": "Setting userID",
-    "sectionId": "setting-userid",
+    "searchTitle": "Set userID on Client",
+    "sectionTitle": "Set userID on Client",
+    "sectionId": "set-userid-on-client",
     "url": "/docs/auth",
-    "content": "Authenticated Zero clients should provide a userID on construction: import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' const opts: ZeroOptions = { // ... userID: 'user-123' } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' const opts: ZeroOptions = { // ... userID: 'user-123' } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' const opts: ZeroOptions = { // ... userID: 'user-123' } const zero = new Zero(opts) If the user is logged out, omit userID, or set to undefined / null: const opts: ZeroOptions = { // ... userID: undefined } Zero uses this to segregate the client-side storage for each user. This allows users to quickly switch between multiple users and accounts without resyncing. All users that have access to a browser profile have access to the same IndexedDB instances. There is nothing that Zero can do about this – users can just open the folder where the data is stored and look inside it. If you do not want Zero to store synced data in IndexedDB on the client, set kvStore: 'mem' in your ZeroOptions. This uses in-memory storage instead, so data is not persisted on the device and is cleared on full reloads and browser restarts. If you have more than one set of Zero data per-user (i.e., for different apps in the same domain), you can additionally use the storageKey parameter: const opts: ZeroOptions = { // ... userID: 'user-123', storageKey: 'my-app' } If specified, storageKey is concatenated along with userID and other internal Zero information to form a unique IndexedDB database name.",
+    "content": "Your app will already know the logged-in user from whatever auth provider you use. Pass this userID to Zero on construction: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={userID}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={userID}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' const zero = new Zero({ userID // ... }) If the user is logged out, omit userID, or set to undefined / null: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={null}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={null}> <App /> </ZeroProvider> )const zero = new Zero({ userID: null // ... }) Zero uses the userID field to segregate the client-side storage for each user. This allows users to quickly switch between multiple users and accounts without resyncing. There is nothing that Zero can do about this – users can just open the folder where the data is stored and look inside it. If preventing this is important to you, set kvStore: 'mem' in your ZeroOptions. This uses in-memory storage instead, so data is not persisted on the device and is cleared on full reloads and browser restarts. If you have more than one set of Zero data per-user (i.e., for different apps in the same domain), you can additionally use the storageKey parameter: const opts: ZeroOptions = { // ... userID: 'user-123', storageKey: 'my-app' } If specified, storageKey is concatenated along with userID and other internal Zero information to form a unique IndexedDB database name.",
     "kind": "section"
   },
   {
-    "id": "74-auth#context",
+    "id": "75-auth#define-the-context-type",
     "title": "Authentication",
-    "searchTitle": "Context",
-    "sectionTitle": "Context",
-    "sectionId": "context",
+    "searchTitle": "Define the Context Type",
+    "sectionTitle": "Define the Context Type",
+    "sectionId": "define-the-context-type",
     "url": "/docs/auth",
     "content": "When a user is authenticated, you will want to know who they are in your queries and mutators to enforce permissions. To do this, first define a Context type that includes the user's ID and any other relevant information, then register that type globally with Zero: export type ZeroContext = { id: string } declare module '@rocicorp/zero' { interface DefaultTypes { context: ZeroContext } } Then pass an instance of this context when instantiating Zero on the client: const opts: ZeroOptions = { // ... userID: 'user-123', context: { id: 'user-123' } } If your app also supports guest access, allow Context to be undefined (or null) when the request is unauthenticated, and pass undefined or null for the userID. declare module '@rocicorp/zero' { interface DefaultTypes { context: ZeroContext | undefined } } const opts: ZeroOptions = { // ... userID: undefined, context: undefined }",
     "kind": "section"
   },
   {
-    "id": "75-auth#sending-credentials",
+    "id": "76-auth#send-credentials",
     "title": "Authentication",
-    "searchTitle": "Sending Credentials",
-    "sectionTitle": "Sending Credentials",
-    "sectionId": "sending-credentials",
+    "searchTitle": "Send Credentials",
+    "sectionTitle": "Send Credentials",
+    "sectionId": "send-credentials",
     "url": "/docs/auth",
-    "content": "You can send credentials using either cookies or tokens. Cookies The most common way to authenticate Zero is with cookies. To enable it, set the ZERO_QUERY_FORWARD_COOKIES and ZERO_MUTATE_FORWARD_COOKIES options to true: # ... other env vars export ZERO_QUERY_FORWARD_COOKIES=\"true\" export ZERO_MUTATE_FORWARD_COOKIES=\"true\" # run zero-cache, e.g. `npx zero-cache-dev` Zero-cache will then forward all cookies sent to cacheURL to your mutators and queries endpoints: const opts: ZeroOptions = { schema, // Cookies sent to zero.example.com will be forwarded to // api.example.com/mutate and api.example.com/queries. cacheURL: 'https://zero.example.com', mutateURL: 'https://api.example.com/mutate', queryURL: 'https://api.example.com/queries' } Cookies will show up in the normal HTTP Cookie header and you can authenticate these endpoints just like you would any API request. Query Handler You can now build ctx from the validated cookie and pass it to your queries to enforce permissions. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return c.json(result) }) Mutate Handler You can now also build ctx from the validated cookie and pass it to your mutators to enforce permissions. // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return c.json(result) }) Deployment In order for cookie auth to work, the browser must send your frontend's cookies to zero-cache, so that zero-cache can forward them to your API. During development, this works automatically as long as your frontend and zero-cache are both running on localhost with different ports. Browsers send cookies based on domain name, not port number, so cookies set by localhost:3000 are also sent to localhost:4848. For production you'll need to do two things: Run zero-cache on a subdomain of your main site (e.g., zero.example.com if your main site is example.com). Consult your hosting provider's docs, or your favorite LLM for how to configure this. Set cookies from your main site with the Domain attribute set to your root domain (e.g., .example.com). If you use a third-party auth provider, consult their docs on how to do this. For example, for Better Auth, this is done with the crossSubDomainCookies feature. Do not set SameSite=None on cookies used for authentication with Zero. Because Zero uses WebSockets, setting SameSite=None can expose your application to Cross-Site WebSocket Hijacking (CSWSH) attacks. Use SameSite=Lax (the browser default) or SameSite=Strict instead. Tokens Zero also supports token-based authentication. If you have an opaque auth token, such as a JWT or a token from your auth provider, you can pass it to Zero's auth parameter: const opts: ZeroOptions = { // ... userID: 'user-123', auth: token } If you set auth, you must also set userID to the authenticated user's ID. Zero will forward this token to your mutators and queries endpoints in an Authorization: Bearer <token> header. Authenticate the request first and derive your context from it when invoking your query and mutator implementations. Query Handler You can now build ctx from the validated token header and pass it to your queries to enforce permissions. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return c.json(result) }) Mutate Handler You can now also build ctx from the validated token header and pass it to your mutators to enforce permissions. // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return c.json(result) })",
+    "content": "Both cookies and tokens are supported. Cookies The most common way to authenticate Zero is with cookies. To enable it, set the ZERO_QUERY_FORWARD_COOKIES and ZERO_MUTATE_FORWARD_COOKIES options to true: # ... other env vars export ZERO_QUERY_FORWARD_COOKIES=\"true\" export ZERO_MUTATE_FORWARD_COOKIES=\"true\" # run zero-cache, e.g. `npx zero-cache-dev` Zero-cache will then forward all cookies sent to cacheURL to your mutators and queries endpoints. Cookies will show up in the normal HTTP Cookie header and you can authenticate these endpoints just like you would any API request: // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... } } } })// app/api/zero/query/route.ts export async function POST(request: Request) { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) // ... handle query ... }// api/app.ts import {Hono} from 'hono' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... }) Cookie Deployment In order for cookie auth to work, the browser must send your frontend's cookies to zero-cache, so that zero-cache can forward them to your API. During development, this works automatically as long as your frontend and zero-cache are both running on localhost with different ports. Browsers send cookies based on domain name, not port number, so cookies set by localhost:3000 are also sent to localhost:4848. For production you'll need to do two things: Run zero-cache on a subdomain of your main site (e.g., zero.example.com if your main site is example.com). Consult your hosting provider's docs, or your favorite LLM for how to configure this. Set cookies from your main site with the Domain attribute set to your root domain (e.g., .example.com). If you use a third-party auth provider, consult their docs on how to do this. For example, for Better Auth, this is done with the crossSubDomainCookies feature. Do not set SameSite=None on cookies used for authentication with Zero. Because Zero uses WebSockets, setting SameSite=None can expose your application to Cross-Site WebSocket Hijacking (CSWSH) attacks. Use SameSite=Lax (the browser default) or SameSite=Strict instead. Tokens Zero also supports token-based authentication. If you have an opaque auth token, such as a JWT or a token from your auth provider, you can pass it to Zero's auth parameter: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={userID} auth={token}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={userID} auth={token}> <App /> </ZeroProvider> )const zero = new Zero({ userID, auth: token // ... }) Zero will forward this token to your mutators and queries endpoints in an Authorization: Bearer <token> header: // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... } } } })// app/api/zero/query/route.ts export async function POST(request: Request) { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) // ... handle query ... }// api/app.ts import {Hono} from 'hono' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... })",
     "kind": "section"
   },
   {
-    "id": "76-auth#cookies",
+    "id": "77-auth#cookies",
     "title": "Authentication",
     "searchTitle": "Cookies",
     "sectionTitle": "Cookies",
     "sectionId": "cookies",
     "url": "/docs/auth",
-    "content": "The most common way to authenticate Zero is with cookies. To enable it, set the ZERO_QUERY_FORWARD_COOKIES and ZERO_MUTATE_FORWARD_COOKIES options to true: # ... other env vars export ZERO_QUERY_FORWARD_COOKIES=\"true\" export ZERO_MUTATE_FORWARD_COOKIES=\"true\" # run zero-cache, e.g. `npx zero-cache-dev` Zero-cache will then forward all cookies sent to cacheURL to your mutators and queries endpoints: const opts: ZeroOptions = { schema, // Cookies sent to zero.example.com will be forwarded to // api.example.com/mutate and api.example.com/queries. cacheURL: 'https://zero.example.com', mutateURL: 'https://api.example.com/mutate', queryURL: 'https://api.example.com/queries' } Cookies will show up in the normal HTTP Cookie header and you can authenticate these endpoints just like you would any API request. Query Handler You can now build ctx from the validated cookie and pass it to your queries to enforce permissions. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return c.json(result) }) Mutate Handler You can now also build ctx from the validated cookie and pass it to your mutators to enforce permissions. // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return c.json(result) }) Deployment In order for cookie auth to work, the browser must send your frontend's cookies to zero-cache, so that zero-cache can forward them to your API. During development, this works automatically as long as your frontend and zero-cache are both running on localhost with different ports. Browsers send cookies based on domain name, not port number, so cookies set by localhost:3000 are also sent to localhost:4848. For production you'll need to do two things: Run zero-cache on a subdomain of your main site (e.g., zero.example.com if your main site is example.com). Consult your hosting provider's docs, or your favorite LLM for how to configure this. Set cookies from your main site with the Domain attribute set to your root domain (e.g., .example.com). If you use a third-party auth provider, consult their docs on how to do this. For example, for Better Auth, this is done with the crossSubDomainCookies feature. Do not set SameSite=None on cookies used for authentication with Zero. Because Zero uses WebSockets, setting SameSite=None can expose your application to Cross-Site WebSocket Hijacking (CSWSH) attacks. Use SameSite=Lax (the browser default) or SameSite=Strict instead.",
+    "content": "The most common way to authenticate Zero is with cookies. To enable it, set the ZERO_QUERY_FORWARD_COOKIES and ZERO_MUTATE_FORWARD_COOKIES options to true: # ... other env vars export ZERO_QUERY_FORWARD_COOKIES=\"true\" export ZERO_MUTATE_FORWARD_COOKIES=\"true\" # run zero-cache, e.g. `npx zero-cache-dev` Zero-cache will then forward all cookies sent to cacheURL to your mutators and queries endpoints. Cookies will show up in the normal HTTP Cookie header and you can authenticate these endpoints just like you would any API request: // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... } } } })// app/api/zero/query/route.ts export async function POST(request: Request) { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) // ... handle query ... }// api/app.ts import {Hono} from 'hono' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... })",
     "kind": "section"
   },
   {
-    "id": "77-auth#query-handler",
+    "id": "78-auth#cookie-deployment",
     "title": "Authentication",
-    "searchTitle": "Query Handler",
-    "sectionTitle": "Query Handler",
-    "sectionId": "query-handler",
-    "url": "/docs/auth",
-    "content": "You can now build ctx from the validated cookie and pass it to your queries to enforce permissions. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return c.json(result) })",
-    "kind": "section"
-  },
-  {
-    "id": "78-auth#mutate-handler",
-    "title": "Authentication",
-    "searchTitle": "Mutate Handler",
-    "sectionTitle": "Mutate Handler",
-    "sectionId": "mutate-handler",
-    "url": "/docs/auth",
-    "content": "You can now also build ctx from the validated cookie and pass it to your mutators to enforce permissions. // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return c.json(result) })",
-    "kind": "section"
-  },
-  {
-    "id": "79-auth#deployment",
-    "title": "Authentication",
-    "searchTitle": "Deployment",
-    "sectionTitle": "Deployment",
-    "sectionId": "deployment",
+    "searchTitle": "Cookie Deployment",
+    "sectionTitle": "Cookie Deployment",
+    "sectionId": "cookie-deployment",
     "url": "/docs/auth",
     "content": "In order for cookie auth to work, the browser must send your frontend's cookies to zero-cache, so that zero-cache can forward them to your API. During development, this works automatically as long as your frontend and zero-cache are both running on localhost with different ports. Browsers send cookies based on domain name, not port number, so cookies set by localhost:3000 are also sent to localhost:4848. For production you'll need to do two things: Run zero-cache on a subdomain of your main site (e.g., zero.example.com if your main site is example.com). Consult your hosting provider's docs, or your favorite LLM for how to configure this. Set cookies from your main site with the Domain attribute set to your root domain (e.g., .example.com). If you use a third-party auth provider, consult their docs on how to do this. For example, for Better Auth, this is done with the crossSubDomainCookies feature. Do not set SameSite=None on cookies used for authentication with Zero. Because Zero uses WebSockets, setting SameSite=None can expose your application to Cross-Site WebSocket Hijacking (CSWSH) attacks. Use SameSite=Lax (the browser default) or SameSite=Strict instead.",
     "kind": "section"
   },
   {
-    "id": "80-auth#tokens",
+    "id": "79-auth#tokens",
     "title": "Authentication",
     "searchTitle": "Tokens",
     "sectionTitle": "Tokens",
     "sectionId": "tokens",
     "url": "/docs/auth",
-    "content": "Zero also supports token-based authentication. If you have an opaque auth token, such as a JWT or a token from your auth provider, you can pass it to Zero's auth parameter: const opts: ZeroOptions = { // ... userID: 'user-123', auth: token } If you set auth, you must also set userID to the authenticated user's ID. Zero will forward this token to your mutators and queries endpoints in an Authorization: Bearer <token> header. Authenticate the request first and derive your context from it when invoking your query and mutator implementations. Query Handler You can now build ctx from the validated token header and pass it to your queries to enforce permissions. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return c.json(result) }) Mutate Handler You can now also build ctx from the validated token header and pass it to your mutators to enforce permissions. // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return c.json(result) })",
+    "content": "Zero also supports token-based authentication. If you have an opaque auth token, such as a JWT or a token from your auth provider, you can pass it to Zero's auth parameter: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={userID} auth={token}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={userID} auth={token}> <App /> </ZeroProvider> )const zero = new Zero({ userID, auth: token // ... }) Zero will forward this token to your mutators and queries endpoints in an Authorization: Bearer <token> header: // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... } } } })// app/api/zero/query/route.ts export async function POST(request: Request) { const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) // ... handle query ... }// api/app.ts import {Hono} from 'hono' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) // ... handle query ... })",
     "kind": "section"
   },
   {
-    "id": "81-auth#query-handler-1",
+    "id": "80-auth#implement-api-endpoints",
     "title": "Authentication",
-    "searchTitle": "Query Handler",
-    "sectionTitle": "Query Handler",
-    "sectionId": "query-handler-1",
+    "searchTitle": "Implement API Endpoints",
+    "sectionTitle": "Implement API Endpoints",
+    "sectionId": "implement-api-endpoints",
     "url": "/docs/auth",
-    "content": "You can now build ctx from the validated token header and pass it to your queries to enforce permissions. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Authorization') ) const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request ) return c.json(result) })",
+    "content": "Create a Context object from the validated credentials and pass it to your query and mutator functions. Query // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request, userID: session?.user?.id }) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(request: Request) { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request, userID: session?.user?.id }) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request: event.request, userID: session?.user?.id }) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request, userID: session?.user?.id }) return c.json(result) }) Mutate // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request, userID: session?.user?.id }) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(request: Request) { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request, userID: session?.user?.id }) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request: event.request, userID: session?.user?.id }) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request, userID: session?.user?.id }) return c.json(result) }) Tabs in the same browser share synced data. This group of tabs is called a \"client group\", keyed by clientGroupID. New tabs join a client group by providing the clientGroupID during connection. The clientGroupID is randomly-generated client-side and non-trivial for attackers to guess. However, it could be stolen with XSS or leaked in logs. Passing the server-verified userID to handleMutateRequest and handleQueryRequest lets Zero enforce that only tabs belonging to the same user can be in the same client group.",
     "kind": "section"
   },
   {
-    "id": "82-auth#mutate-handler-1",
+    "id": "81-auth#query",
     "title": "Authentication",
-    "searchTitle": "Mutate Handler",
-    "sectionTitle": "Mutate Handler",
-    "sectionId": "mutate-handler-1",
+    "searchTitle": "Query",
+    "sectionTitle": "Query",
+    "sectionId": "query",
     "url": "/docs/auth",
-    "content": "You can now also build ctx from the validated token header and pass it to your mutators to enforce permissions. // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const session = await authenticate( req.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request ) return c.json(result) })",
+    "content": "// src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request, userID: session?.user?.id }) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(request: Request) { const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request, userID: session?.user?.id }) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request: event.request, userID: session?.user?.id }) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' const app = new Hono() app.post('/api/zero/query', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Cookie') ) const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({ args, ctx: session?.user }) }, schema, request, userID: session?.user?.id }) return c.json(result) })",
+    "kind": "section"
+  },
+  {
+    "id": "82-auth#mutate",
+    "title": "Authentication",
+    "searchTitle": "Mutate",
+    "sectionTitle": "Mutate",
+    "sectionId": "mutate",
+    "url": "/docs/auth",
+    "content": "// src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request, userID: session?.user?.id }) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(request: Request) { const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request, userID: session?.user?.id }) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const session = await authenticate( event.request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request: event.request, userID: session?.user?.id }) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const request = c.req.raw const session = await authenticate( request.headers.get('Authorization') ) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx, ctx: session?.user }) }), request, userID: session?.user?.id }) return c.json(result) }) Tabs in the same browser share synced data. This group of tabs is called a \"client group\", keyed by clientGroupID. New tabs join a client group by providing the clientGroupID during connection. The clientGroupID is randomly-generated client-side and non-trivial for attackers to guess. However, it could be stolen with XSS or leaked in logs. Passing the server-verified userID to handleMutateRequest and handleQueryRequest lets Zero enforce that only tabs belonging to the same user can be in the same client group.",
     "kind": "section"
   },
   {
@@ -421,7 +407,7 @@
     "title": "Connecting to Postgres",
     "searchTitle": "Connecting to Postgres",
     "url": "/docs/connecting-to-postgres",
-    "content": "In the future, Zero will work with many different backend databases. Today only Postgres is supported. Specifically, Zero requires Postgres v15.0 or higher, and support for logical replication. Here are some common Postgres options and what we know about their support level: Event Triggers Zero uses Postgres “Event Triggers” when possible to implement high-quality, efficient schema migration. Some hosted Postgres providers don't provide access to Event Triggers. Zero still works out of the box with these providers, but for correctness, any schema change triggers a full reset of all server-side and client-side state. For small databases (< 10GB) this can be OK, but for bigger databases we recommend choosing a provider that grants access to Event Triggers. Configuration WAL Level The Postgres wal_level config parameter has to be set to logical. You can check what level your pg has with this command: psql -c 'SHOW wal_level' If it doesn’t output logical then you need to change the wal level. To do this, run: psql -c \"ALTER SYSTEM SET wal_level = 'logical';\" Then restart Postgres. On most pg systems you can do this like so: data_dir=$(psql -t -A -c 'SHOW data_directory') pg_ctl -D \"$data_dir\" restart After your server restarts, show the wal_level again to ensure it has changed: psql -c 'SHOW wal_level' Bounding WAL Size For development databases, you can set a max_slot_wal_keep_size value in Postgres. This will help limit the amount of WAL kept around. This is a configuration parameter that bounds the amount of WAL kept around for replication slots, and invalidates the slots that are too far behind. Zero-cache will automatically detect if the replication slot has been invalidated and re-sync replicas from scratch. This configuration can cause problems like slot has been invalidated because it exceeded the maximum reserved size and is not recommended for production databases. Provider-Specific Notes PlanetScale for Postgres You should use the default role that PlanetScale provides, because PlanetScale user-defined roles cannot create replication slots. Planetscale Postgres defaults max_connections to 25, which can easily be exhausted by Zero's connection pools. This will result in an error like remaining connection slots are reserved for roles with the SUPERUSER attribute. You should increase this value in the Parameters section of the PlanetScale dashboard to 100 or more. Make sure to only use a direct connection for the ZERO_UPSTREAM_DB, and use pooled URLs for ZERO_CVR_DB, ZERO_CHANGE_DB, and your API (see Deployment). Neon Logical Replication Neon supports logical replication, but you need to enable it in the Neon console for your branch/endpoint. Enable logical replication Branching Neon fully supports Zero, but you should be aware of how Neon's pricing model and Zero interact: because Zero keeps an open connection to Postgres to replicate changes, as long as zero-cache is running, Postgres will be running and you will be charged by Neon. For production databases that have enough usage to always be running anyway, this is fine. But for smaller applications that would otherwise not always be running, this can create a surprisingly high bill. You may want to choose a provider that charge a flat monthly rate instead. Also some users choose Neon because they hope to use branching for previews. This can work, but if not done with care, Zero can end up keeping each Neon preview branch running too 😳. For the recommended approach to preview URLs, see Previews. Fly.io Networking Fly Managed Postgres is the latest offering from Fly.io, and it is private-network-only by default. If zero-cache runs outside Fly, connect via Fly WireGuard or run a proxy like fly-mpg-proxy. Fly does not support TLS on its private network. If zero-cache connects to Postgres over the Fly private network (including WireGuard), add sslmode=disable to your connection strings. Permissions Fly Managed Postgres does not provide superuser access, so zero-cache cannot create event triggers. Also, some publication operations (like FOR TABLES IN SCHEMA ... / FOR ALL TABLES) can be permission-restricted. If zero-cache can't create its default publication, create one listing tables explicitly and set the app publication. Pooling You should use Fly's pgBouncer endpoint for ZERO_CVR_DB and ZERO_CHANGE_DB. Supabase Supabase requires at least 15.8.1.083 for event trigger support. If you have a lower 15.x, Zero will still work but schema updates will be slower. See Supabase's docs for upgrading your Postgres version. Zero must use the \"Direct Connection\" string: This is because Zero sets up a logical replication slot, which is only supported with a direct connection. For ZERO_CVR_DB and ZERO_CHANGE_DB, prefer Supabase's session pooler. The transaction pooler can break prepared statements and cause errors like 26000 prepared statement ... does not exist. Publication Changes Supabase does not fire DDL event triggers for ALTER PUBLICATION. Starting in Zero >=v1.0, you can work around this by bookending each ALTER PUBLICATION statement with COMMENT ON PUBLICATION statements in the same transaction: BEGIN; COMMENT ON PUBLICATION zero_pub IS 'anything'; ALTER PUBLICATION zero_pub ADD TABLE ...; COMMENT ON PUBLICATION zero_pub IS 'anything'; -- ... other statements ... COMMIT; Both COMMENT ON PUBLICATION statements must target the publication being modified. All three statements must be in the same transaction, and the comment value can be anything. On non-Supabase Postgres, these COMMENT ON PUBLICATION statements are harmless when publication event triggers already work. Also, the event trigger messages emitted for this workaround are backwards compatible with the previous minor version of the processing code, so rolling back one minor version is safe. IPv4 You may also need to assign an IPv4 address to your Supabase instance: This will be required if you cannot use IPv6 from wherever zero-cache is running. Most cloud providers support IPv6, but some do not. For example, if you are running zero-cache in AWS, it is possible to use IPv6 but difficult. Hetzner offers cheap hosted VPS that supports IPv6. IPv4 addresses are only supported on the Pro plan and are an extra $4/month. Render Render can work with Zero, but requires admin/support-side setup, and does not support a few core Zero features. App roles can't create event triggers, so schema changes will fall back to full resets. You also must ensure wal_level=logical by creating a Render support ticket. Render does not provide superuser access, but you can submit another support ticket to ask Render to create a publication with FOR ALL TABLES for you, and then set that publication in App Publications. Google Cloud SQL Zero works with Google Cloud SQL out of the box. In many configurations, when you connect with a user that has sufficient privileges, zero-cache will create its default publication automatically. If your Cloud SQL user does not have permission to create publications, you can still use Zero by creating a publication manually and then specifying that publication name in App Publications when running zero-cache. On Google Cloud SQL for PostgreSQL, enable logical decoding by turning on the instance flag cloudsql.logical_decoding. You do not set wal_level directly on Cloud SQL. See Google's documentation for details: Configure logical replication.",
+    "content": "In the future, Zero will work with many different backend databases. Today only Postgres is supported. Specifically, Zero requires Postgres v15.0 or higher, and support for logical replication. Here are some common Postgres options and what we know about their support level: Event Triggers Zero uses Postgres “Event Triggers” when possible to implement high-quality, efficient schema migration. Some hosted Postgres providers don't provide access to Event Triggers. Zero still works out of the box with these providers, but for correctness, any schema change triggers a full reset of all server-side and client-side state. For small databases (< 10GB) this can be OK, but for bigger databases you should either manually tell Zero about the schema change or choose a provider with event trigger support. Configuration WAL Level The Postgres wal_level config parameter has to be set to logical. You can check what level your pg has with this command: psql -c 'SHOW wal_level' If it doesn’t output logical then you need to change the wal level. To do this, run: psql -c \"ALTER SYSTEM SET wal_level = 'logical';\" Then restart Postgres. On most pg systems you can do this like so: data_dir=$(psql -t -A -c 'SHOW data_directory') pg_ctl -D \"$data_dir\" restart After your server restarts, show the wal_level again to ensure it has changed: psql -c 'SHOW wal_level' Bounding WAL Size For development databases, you can set a max_slot_wal_keep_size value in Postgres. This will help limit the amount of WAL kept around. This is a configuration parameter that bounds the amount of WAL kept around for replication slots, and invalidates the slots that are too far behind. Zero-cache will automatically detect if the replication slot has been invalidated and re-sync replicas from scratch. This configuration can cause problems like slot has been invalidated because it exceeded the maximum reserved size and is not recommended for production databases. Provider-Specific Notes PlanetScale for Postgres Planetscale Postgres defaults max_connections to 25, which can easily be exhausted by Zero's connection pools. This will result in an error like remaining connection slots are reserved for roles with the SUPERUSER attribute. You should increase this value in the Parameters section of the PlanetScale dashboard to 100 or more. Make sure to only use a direct connection for the ZERO_UPSTREAM_DB, and use pooled URLs for ZERO_CVR_DB, ZERO_CHANGE_DB, and your API (see Deployment). You do not need role-scoped IP restrictions to use Zero with PlanetScale Postgres. Zero works with a normal direct ZERO_UPSTREAM_DB connection and the usual role and password setup. The rest of this section describes an optional hardening pattern that is especially useful for Cloud Zero, and can also be useful for self-hosted Zero when the database connection still crosses the public internet instead of a private path such as PrivateLink. The goal is to restrict the Zero upstream role to a small set of known egress IPs while preserving existing application access. For the smoothest rollout, get Zero working first, then add these hardening steps one layer at a time. Suggested order The easiest setup is to get Zero running first, then add security from lowest to highest operational overhead: During setup: get Zero working with a direct ZERO_UPSTREAM_DB connection and the recommended role grants below. During setup or later: use a dedicated zero role instead of the PlanetScale default role if you want cleaner credential rotation and role-scoped IP restrictions. Later: add PlanetScale role-scoped IP restrictions so existing app roles can stay open while zero is limited to Cloud Zero egress IPs. Later, and only if you want tighter least privilege: replace pg_read_all_data with publication-scoped app-table grants and optionally automate them with an admin-owned helper. Custom Zero roles You can use PlanetScale's default role for Zero if you want the simplest setup. For production, a dedicated zero role is usually better because it separates Zero from the rest of your application for credential rotation and role-scoped IP restrictions. A dedicated Zero role needs three things: LOGIN and REPLICATION so it can connect and read the replication stream read access to the application tables it replicates, because initial sync copies rows with COPY (SELECT ...) ownership or write access to Zero's internal z_% metadata schemas, because tables like replicas track Zero state Zero's internal schema names are not fixed. Current deployments commonly use schemas named like z_abcd1234 and z_abcd1234_0. If those metadata privileges are missing, Zero can still connect and read app tables but later fail with errors such as permission denied for table replicas. Recommended role setup If you want the low-maintenance setup, give the dedicated role replication access, broad read access for app tables, and the ability to create future internal schemas. pg_read_all_data is the simplest option because publication changes keep working without table-grant churn. pg_read_all_settings and pg_read_all_stats give Zero read-only visibility into the upstream database state it inspects during setup and operation. This is the best first setup. Get it working before you add IP restrictions or tighter app-data grants. CREATE ROLE zero WITH LOGIN REPLICATION PASSWORD 'replace-me'; GRANT CONNECT ON DATABASE \"app\" TO zero; GRANT CREATE ON DATABASE \"app\" TO zero; GRANT pg_read_all_data TO zero; GRANT pg_read_all_settings TO zero; GRANT pg_read_all_stats TO zero; If the role already exists, use ALTER ROLE instead: ALTER ROLE zero WITH LOGIN REPLICATION PASSWORD 'replace-me'; Existing z_% schemas If Zero has already run against this database and z_% schemas already exist, grant the role access to those current schemas and tables too. This gives Zero write access to existing metadata tables such as replicas. If the schemas do not exist yet, zero can create them later because it has database CREATE, but any existing z_% schemas still need this retroactive grant loop. DO $$ DECLARE schema_name text; BEGIN FOR schema_name IN SELECT nspname FROM pg_namespace WHERE nspname LIKE 'z\\_%' ESCAPE '\\' ORDER BY nspname LOOP EXECUTE format('GRANT USAGE, CREATE ON SCHEMA %I TO zero', schema_name); EXECUTE format( 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I TO zero', schema_name ); EXECUTE format( 'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO zero', schema_name ); END LOOP; END $$; If Zero creates future z_% schemas itself, it owns them. If an admin role creates a future z_% schema instead, rerun the block. The publication-scoped helper below only manages app-table SELECT. It does not replace REPLICATION, database CREATE, pg_read_all_settings, pg_read_all_stats, or these retroactive z_% metadata grants. Optional: keep app data grants publication-scoped If you want tighter app-table reads than pg_read_all_data, grant SELECT only on the tables currently exposed by your app publications. PostgreSQL does not have a native GRANT ... ON PUBLICATION, so this path is generated from pg_publication_tables and must be rerun when publication membership changes. Treat this as a later hardening step after the recommended setup already works. DO $$ DECLARE publication_names text[] := ARRAY[ 'replace_with_app_publication', 'replace_with_another_publication' ]; r record; BEGIN FOR r IN SELECT DISTINCT schemaname FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT USAGE ON SCHEMA %I TO zero', r.schemaname); END LOOP; FOR r IN SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT SELECT ON TABLE %I.%I TO zero', r.schemaname, r.tablename); END LOOP; END $$; If you are migrating away from pg_read_all_data, the safe order is: generate the explicit publication grants first, validate that zero can still read the published app tables, then revoke pg_read_all_data in the same transaction. If you want to keep those grants in sync automatically, wrap the same logic in admin-owned automation. The helper must be owned by an admin or table-owner role with grant authority, not by zero, and SECURITY DEFINER should pin search_path to pg_catalog. A practical shape is to keep the helper in a dedicated admin-owned schema, track which table grants it manages, and revoke SELECT from tables that leave the publication later. CREATE SCHEMA IF NOT EXISTS zero_publication_grants; CREATE TABLE IF NOT EXISTS zero_publication_grants.synced_tables ( schemaname text NOT NULL, tablename text NOT NULL, PRIMARY KEY (schemaname, tablename) ); CREATE OR REPLACE FUNCTION zero_publication_grants.sync_zero_publication_read_grants() RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog AS $$ DECLARE publication_names text[] := ARRAY[ 'replace_with_app_publication', 'replace_with_another_publication' ]; r record; BEGIN FOR r IN SELECT DISTINCT schemaname FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT USAGE ON SCHEMA %I TO zero', r.schemaname); END LOOP; FOR r IN SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT SELECT ON TABLE %I.%I TO zero', r.schemaname, r.tablename); END LOOP; FOR r IN WITH current_tables AS ( SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) ) SELECT st.schemaname, st.tablename, EXISTS ( SELECT 1 FROM pg_catalog.pg_class AS c JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE n.nspname = st.schemaname AND c.relname = st.tablename AND c.relkind IN ('r', 'p') ) AS table_exists FROM zero_publication_grants.synced_tables AS st LEFT JOIN current_tables AS ct ON ct.schemaname = st.schemaname AND ct.tablename = st.tablename WHERE ct.tablename IS NULL LOOP IF r.table_exists THEN EXECUTE format('REVOKE SELECT ON TABLE %I.%I FROM zero', r.schemaname, r.tablename); END IF; END LOOP; DELETE FROM zero_publication_grants.synced_tables AS st WHERE NOT EXISTS ( SELECT 1 FROM pg_catalog.pg_publication_tables AS pt WHERE pt.pubname = ANY (publication_names) AND pt.schemaname = st.schemaname AND pt.tablename = st.tablename ); INSERT INTO zero_publication_grants.synced_tables (schemaname, tablename) SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) ON CONFLICT DO NOTHING; END; $$; SELECT zero_publication_grants.sync_zero_publication_read_grants(); CREATE OR REPLACE FUNCTION zero_publication_grants.sync_zero_publication_read_grants_event() RETURNS event_trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog AS $$ BEGIN PERFORM zero_publication_grants.sync_zero_publication_read_grants(); END; $$; CREATE EVENT TRIGGER sync_zero_publication_read_grants_trigger ON ddl_command_end WHEN TAG IN ( 'CREATE TABLE', 'ALTER TABLE', 'DROP TABLE', 'CREATE PUBLICATION', 'ALTER PUBLICATION', 'DROP PUBLICATION', 'DROP SCHEMA' ) EXECUTE FUNCTION zero_publication_grants.sync_zero_publication_read_grants_event(); This is optional operational machinery for teams that want tighter app-data reads than pg_read_all_data. The recommended default stays pg_read_all_data. Verify that your provider permits event triggers. If it does not, rerun the helper after publication changes from your deployment or migration step instead. If you use this path, revoke EXECUTE from PUBLIC on the helper functions. Also audit for existing grants to PUBLIC: those apply to every role, including zero, and sit outside this role-specific grant model. How PlanetScale IP restrictions behave Once the role and grants work, you can add network restrictions. PlanetScale Postgres IP restrictions are allow rules. Once a branch has any IP restriction, new connections must match at least one rule. A blank-role 0.0.0.0/0 rule allows every role, including zero, so it defeats a restricted Zero role while it exists. To keep existing application access unchanged while restricting only zero, add explicit role-scoped 0.0.0.0/0 rules for the app and user roles that should stay public, then add narrow CIDR rules only for zero. In PlanetScale, go to Settings → IP restrictions and create or edit rules there. Use the role username, not a descriptive label, and enter IPv4 addresses as /32 CIDRs such as 203.0.113.10/32. If PlanetScale shows a username like pscale_api_<suffix>.<branch_id>, use only the first part, pscale_api_<suffix>. If you are using Cloud Zero, you can find the current egress IPs in the Cloud Zero dashboard under Instances → Cluster → Egress IPs. Use those addresses as /32 CIDRs. This applies both to hosted Cloud Zero and AWS-managed instances. Keep that console-provided list current. During an egress IP change, temporarily allowing both the old and new listed addresses can prevent accidental breakage while you validate fresh connections. If you are self-hosting, use the public egress IPs of your own deployment. PlanetScale internal service roles are not usually part of your app role model. Do not add custom rules for internal pscale_* roles unless PlanetScale tells you to. The exception is app or automation roles you actually use, such as a pscale_api_* role that backs production automation. One common final rule layout looks like this: Safe rollout for role-scoped restrictions Use this order to avoid accidental lockouts: Inventory the roles that still need public access, including any pscale_api_* roles your automation actually uses. If the branch currently has no IP rules and you want a bridge while assembling the final rules, add a temporary blank-role 0.0.0.0/0. Add explicit role-scoped 0.0.0.0/0 rules for the existing app and user roles that should stay public, then validate fresh connections for those roles. Create or update the dedicated zero role and grants. Add the zero IP rule with only the Cloud Zero egress CIDRs. If you need to test from your laptop, temporarily append your operator /32 to that same zero rule, validate, then remove it. Remove the temporary blank-role catchall last, then validate fresh app connections again and confirm that zero is blocked from a non-allowlisted IP. PlanetScale may reject a second IP restriction record for the same database and role. If you need to temporarily allow an operator IP for testing, edit the existing Zero rule and add one more CIDR, then remove it after testing. Practical validation checks After creating the role and applying the IP rule, validate it with a fresh psql connection as the zero role. Supply one replicated app table and check that the role can read app data, perform a no-op write against replicas inside a transaction, and create a temporary logical replication slot. export ZERO_PROBE_DSN='postgres://zero:<password>@db.example.com:5432/app' export ZERO_PROBE_SCHEMA='public' export ZERO_PROBE_TABLE='some_replicated_table' slot_name=\"zero_probe_$(date +%s)\" psql \"$ZERO_PROBE_DSN\" \\ -X \\ -v ON_ERROR_STOP=1 \\ -v zero_probe_schema=\"$ZERO_PROBE_SCHEMA\" \\ -v zero_probe_table=\"$ZERO_PROBE_TABLE\" \\ -v zero_probe_slot=\"$slot_name\" <<'SQL' SELECT current_user, inet_client_addr(); SELECT has_database_privilege(current_user, current_database(), 'CREATE'); SELECT format( 'SELECT 1 FROM %I.%I LIMIT 1', :'zero_probe_schema', :'zero_probe_table' ) WHERE :'zero_probe_schema' <> '' AND :'zero_probe_table' <> '' \\gexec BEGIN; SELECT format( 'UPDATE %I.%I SET version = version WHERE false', n.nspname, c.relname ) FROM pg_class AS c JOIN pg_namespace AS n ON n.oid = c.relnamespace WHERE n.nspname LIKE 'z\\_%' ESCAPE '\\' AND c.relname = 'replicas' AND c.relkind IN ('r', 'p') ORDER BY n.nspname LIMIT 1 \\gexec ROLLBACK; SELECT * FROM pg_create_logical_replication_slot( :'zero_probe_slot', 'pgoutput', true ); SQL PlanetScale currently supports PostgreSQL 17 and 18, so the third argument true form shown here is supported there. It requests a temporary logical replication slot. Choose a unique slot name. The no-op UPDATE ... WHERE false runs inside a transaction and rolls back, so it validates replicas write access without changing data. If no z_% schemas exist yet, that UPDATE check does nothing. Let Zero start once so it can create its own internal schemas, then rerun the script. Cleanup is automatic: the replication slot is temporary, so PostgreSQL drops it when the psql session ends. If you need to validate from a laptop, temporarily append your operator /32 to the existing Zero role rule, run the script, then remove that /32 and rerun the connection. The second run should fail before any SQL executes, which is the expected negative control. Common pitfalls App-table SELECT alone is not enough. Zero also needs write access to its internal z_% schemas or you may see errors like permission denied for table replicas. A blank-role 0.0.0.0/0 rule defeats a restricted zero role while it exists. Preserve existing app and user roles with explicit role-scoped 0.0.0.0/0 rules before narrowing zero. PlanetScale may reject duplicate restriction records for the same database and role. Edit the existing zero rule instead. Validate fresh connections after each change. Long-lived existing connections are not enough to prove the rollout is safe. Neon Logical Replication Neon supports logical replication, but you need to enable it in the Neon console for your branch/endpoint. Enable logical replication Branching Neon fully supports Zero, but you should be aware of how Neon's pricing model and Zero interact: because Zero keeps an open connection to Postgres to replicate changes, as long as zero-cache is running, Postgres will be running and you will be charged by Neon. For production databases that have enough usage to always be running anyway, this is fine. But for smaller applications that would otherwise not always be running, this can create a surprisingly high bill. You may want to choose a provider that charge a flat monthly rate instead. Also some users choose Neon because they hope to use branching for previews. This can work, but if not done with care, Zero can end up keeping each Neon preview branch running too 😳. For the recommended approach to preview URLs, see Previews. Fly.io Networking Fly Managed Postgres is the latest offering from Fly.io, and it is private-network-only by default. If zero-cache runs outside Fly, connect via Fly WireGuard or run a proxy like fly-mpg-proxy. Fly does not support TLS on its private network. If zero-cache connects to Postgres over the Fly private network (including WireGuard), add sslmode=disable to your connection strings. Permissions Fly Managed Postgres does not provide superuser access, so zero-cache cannot create event triggers. Also, some publication operations (like FOR TABLES IN SCHEMA ... / FOR ALL TABLES) can be permission-restricted. If zero-cache can't create its default publication, create one listing tables explicitly and set the app publication. Pooling You should use Fly's pgBouncer endpoint for ZERO_CVR_DB and ZERO_CHANGE_DB. Supabase Supabase requires at least 15.8.1.083 for event trigger support. If you have a lower 15.x, Zero will still work but schema updates will be slower. See Supabase's docs for upgrading your Postgres version. Zero must use the \"Direct Connection\" string: This is because Zero sets up a logical replication slot, which is only supported with a direct connection. For ZERO_CVR_DB and ZERO_CHANGE_DB, prefer Supabase's session pooler. The transaction pooler can break prepared statements and cause errors like 26000 prepared statement ... does not exist. Publication Changes Supabase does not fire DDL event triggers for ALTER PUBLICATION. Call a schema change hook after the ALTER PUBLICATION to replicate the change. IPv4 You may also need to assign an IPv4 address to your Supabase instance: This will be required if you cannot use IPv6 from wherever zero-cache is running. Most cloud providers support IPv6, but some do not. For example, if you are running zero-cache in AWS, it is possible to use IPv6 but difficult. Hetzner offers cheap hosted VPS that supports IPv6. IPv4 addresses are only supported on the Pro plan and are an extra $4/month. Render Render can work with Zero, but requires admin/support-side setup, and does not support a few core Zero features. App roles can't create event triggers, so schema changes will fall back to full resets unless you use schema change hooks. You also must ensure wal_level=logical by creating a Render support ticket. Render does not provide superuser access, but you can submit another support ticket to ask Render to create a publication with FOR ALL TABLES for you, and then set that publication in App Publications. Google Cloud SQL Zero works with Google Cloud SQL out of the box. In many configurations, when you connect with a user that has sufficient privileges, zero-cache will create its default publication automatically. If your Cloud SQL user does not have permission to create publications, you can still use Zero by creating a publication manually and then specifying that publication name in App Publications when running zero-cache. On Google Cloud SQL for PostgreSQL, enable logical decoding by turning on the instance flag cloudsql.logical_decoding. You do not set wal_level directly on Cloud SQL. See Google's documentation for details: Configure logical replication. Schema Change Hooks For providers that don't support or allow event triggers, Zero provides a manual hook you can call after a schema change to avoid a full reset. To enable the hook, first opt into manual DDL detection by setting ddlDetection to true in Zero's upstream shard config. With the default app id of zero and the default shard 0, that looks like: UPDATE zero_0.\"shardConfig\" SET \"ddlDetection\" = true; Then call update_schemas() after any DDL statements: SELECT zero_0.update_schemas(); It is important to call update_schemas() after the DDL statements but before any dependent data changes. A good way to do this is to wrap the DDL and the update_schemas() call in a single transaction: BEGIN; ALTER TABLE foo ADD COLUMN bar TEXT; CREATE INDEX foo_bar_idx ON foo(bar); SELECT zero_0.update_schemas(); COMMIT; You can also tell Zero about publication changes specifically by following the ALTER PUBLICATION with a COMMENT ON PUBLICATION statement: ALTER PUBLICATION zero_pub ADD TABLE ...; COMMENT ON PUBLICATION zero_pub IS 'anything'; It is still supported, but was replaced by update_schemas() because the latter is catches changes to any DDL, not just publication changes.",
     "headings": [
       {
         "text": "Event Triggers",
@@ -446,6 +432,42 @@
       {
         "text": "PlanetScale for Postgres",
         "id": "planetscale-for-postgres"
+      },
+      {
+        "text": "Suggested order",
+        "id": "suggested-order"
+      },
+      {
+        "text": "Custom Zero roles",
+        "id": "custom-zero-roles"
+      },
+      {
+        "text": "Recommended role setup",
+        "id": "recommended-role-setup"
+      },
+      {
+        "text": "Existing z_% schemas",
+        "id": "existing-z_-schemas"
+      },
+      {
+        "text": "Optional: keep app data grants publication-scoped",
+        "id": "optional-keep-app-data-grants-publication-scoped"
+      },
+      {
+        "text": "How PlanetScale IP restrictions behave",
+        "id": "how-planetscale-ip-restrictions-behave"
+      },
+      {
+        "text": "Safe rollout for role-scoped restrictions",
+        "id": "safe-rollout-for-role-scoped-restrictions"
+      },
+      {
+        "text": "Practical validation checks",
+        "id": "practical-validation-checks"
+      },
+      {
+        "text": "Common pitfalls",
+        "id": "common-pitfalls"
       },
       {
         "text": "Neon",
@@ -494,6 +516,10 @@
       {
         "text": "Google Cloud SQL",
         "id": "google-cloud-sql"
+      },
+      {
+        "text": "Schema Change Hooks",
+        "id": "schema-change-hooks"
       }
     ],
     "kind": "page"
@@ -505,7 +531,7 @@
     "sectionTitle": "Event Triggers",
     "sectionId": "event-triggers",
     "url": "/docs/connecting-to-postgres",
-    "content": "Zero uses Postgres “Event Triggers” when possible to implement high-quality, efficient schema migration. Some hosted Postgres providers don't provide access to Event Triggers. Zero still works out of the box with these providers, but for correctness, any schema change triggers a full reset of all server-side and client-side state. For small databases (< 10GB) this can be OK, but for bigger databases we recommend choosing a provider that grants access to Event Triggers.",
+    "content": "Zero uses Postgres “Event Triggers” when possible to implement high-quality, efficient schema migration. Some hosted Postgres providers don't provide access to Event Triggers. Zero still works out of the box with these providers, but for correctness, any schema change triggers a full reset of all server-side and client-side state. For small databases (< 10GB) this can be OK, but for bigger databases you should either manually tell Zero about the schema change or choose a provider with event trigger support.",
     "kind": "section"
   },
   {
@@ -545,7 +571,7 @@
     "sectionTitle": "Provider-Specific Notes",
     "sectionId": "provider-specific-notes",
     "url": "/docs/connecting-to-postgres",
-    "content": "PlanetScale for Postgres You should use the default role that PlanetScale provides, because PlanetScale user-defined roles cannot create replication slots. Planetscale Postgres defaults max_connections to 25, which can easily be exhausted by Zero's connection pools. This will result in an error like remaining connection slots are reserved for roles with the SUPERUSER attribute. You should increase this value in the Parameters section of the PlanetScale dashboard to 100 or more. Make sure to only use a direct connection for the ZERO_UPSTREAM_DB, and use pooled URLs for ZERO_CVR_DB, ZERO_CHANGE_DB, and your API (see Deployment). Neon Logical Replication Neon supports logical replication, but you need to enable it in the Neon console for your branch/endpoint. Enable logical replication Branching Neon fully supports Zero, but you should be aware of how Neon's pricing model and Zero interact: because Zero keeps an open connection to Postgres to replicate changes, as long as zero-cache is running, Postgres will be running and you will be charged by Neon. For production databases that have enough usage to always be running anyway, this is fine. But for smaller applications that would otherwise not always be running, this can create a surprisingly high bill. You may want to choose a provider that charge a flat monthly rate instead. Also some users choose Neon because they hope to use branching for previews. This can work, but if not done with care, Zero can end up keeping each Neon preview branch running too 😳. For the recommended approach to preview URLs, see Previews. Fly.io Networking Fly Managed Postgres is the latest offering from Fly.io, and it is private-network-only by default. If zero-cache runs outside Fly, connect via Fly WireGuard or run a proxy like fly-mpg-proxy. Fly does not support TLS on its private network. If zero-cache connects to Postgres over the Fly private network (including WireGuard), add sslmode=disable to your connection strings. Permissions Fly Managed Postgres does not provide superuser access, so zero-cache cannot create event triggers. Also, some publication operations (like FOR TABLES IN SCHEMA ... / FOR ALL TABLES) can be permission-restricted. If zero-cache can't create its default publication, create one listing tables explicitly and set the app publication. Pooling You should use Fly's pgBouncer endpoint for ZERO_CVR_DB and ZERO_CHANGE_DB. Supabase Supabase requires at least 15.8.1.083 for event trigger support. If you have a lower 15.x, Zero will still work but schema updates will be slower. See Supabase's docs for upgrading your Postgres version. Zero must use the \"Direct Connection\" string: This is because Zero sets up a logical replication slot, which is only supported with a direct connection. For ZERO_CVR_DB and ZERO_CHANGE_DB, prefer Supabase's session pooler. The transaction pooler can break prepared statements and cause errors like 26000 prepared statement ... does not exist. Publication Changes Supabase does not fire DDL event triggers for ALTER PUBLICATION. Starting in Zero >=v1.0, you can work around this by bookending each ALTER PUBLICATION statement with COMMENT ON PUBLICATION statements in the same transaction: BEGIN; COMMENT ON PUBLICATION zero_pub IS 'anything'; ALTER PUBLICATION zero_pub ADD TABLE ...; COMMENT ON PUBLICATION zero_pub IS 'anything'; -- ... other statements ... COMMIT; Both COMMENT ON PUBLICATION statements must target the publication being modified. All three statements must be in the same transaction, and the comment value can be anything. On non-Supabase Postgres, these COMMENT ON PUBLICATION statements are harmless when publication event triggers already work. Also, the event trigger messages emitted for this workaround are backwards compatible with the previous minor version of the processing code, so rolling back one minor version is safe. IPv4 You may also need to assign an IPv4 address to your Supabase instance: This will be required if you cannot use IPv6 from wherever zero-cache is running. Most cloud providers support IPv6, but some do not. For example, if you are running zero-cache in AWS, it is possible to use IPv6 but difficult. Hetzner offers cheap hosted VPS that supports IPv6. IPv4 addresses are only supported on the Pro plan and are an extra $4/month. Render Render can work with Zero, but requires admin/support-side setup, and does not support a few core Zero features. App roles can't create event triggers, so schema changes will fall back to full resets. You also must ensure wal_level=logical by creating a Render support ticket. Render does not provide superuser access, but you can submit another support ticket to ask Render to create a publication with FOR ALL TABLES for you, and then set that publication in App Publications. Google Cloud SQL Zero works with Google Cloud SQL out of the box. In many configurations, when you connect with a user that has sufficient privileges, zero-cache will create its default publication automatically. If your Cloud SQL user does not have permission to create publications, you can still use Zero by creating a publication manually and then specifying that publication name in App Publications when running zero-cache. On Google Cloud SQL for PostgreSQL, enable logical decoding by turning on the instance flag cloudsql.logical_decoding. You do not set wal_level directly on Cloud SQL. See Google's documentation for details: Configure logical replication.",
+    "content": "PlanetScale for Postgres Planetscale Postgres defaults max_connections to 25, which can easily be exhausted by Zero's connection pools. This will result in an error like remaining connection slots are reserved for roles with the SUPERUSER attribute. You should increase this value in the Parameters section of the PlanetScale dashboard to 100 or more. Make sure to only use a direct connection for the ZERO_UPSTREAM_DB, and use pooled URLs for ZERO_CVR_DB, ZERO_CHANGE_DB, and your API (see Deployment). You do not need role-scoped IP restrictions to use Zero with PlanetScale Postgres. Zero works with a normal direct ZERO_UPSTREAM_DB connection and the usual role and password setup. The rest of this section describes an optional hardening pattern that is especially useful for Cloud Zero, and can also be useful for self-hosted Zero when the database connection still crosses the public internet instead of a private path such as PrivateLink. The goal is to restrict the Zero upstream role to a small set of known egress IPs while preserving existing application access. For the smoothest rollout, get Zero working first, then add these hardening steps one layer at a time. Suggested order The easiest setup is to get Zero running first, then add security from lowest to highest operational overhead: During setup: get Zero working with a direct ZERO_UPSTREAM_DB connection and the recommended role grants below. During setup or later: use a dedicated zero role instead of the PlanetScale default role if you want cleaner credential rotation and role-scoped IP restrictions. Later: add PlanetScale role-scoped IP restrictions so existing app roles can stay open while zero is limited to Cloud Zero egress IPs. Later, and only if you want tighter least privilege: replace pg_read_all_data with publication-scoped app-table grants and optionally automate them with an admin-owned helper. Custom Zero roles You can use PlanetScale's default role for Zero if you want the simplest setup. For production, a dedicated zero role is usually better because it separates Zero from the rest of your application for credential rotation and role-scoped IP restrictions. A dedicated Zero role needs three things: LOGIN and REPLICATION so it can connect and read the replication stream read access to the application tables it replicates, because initial sync copies rows with COPY (SELECT ...) ownership or write access to Zero's internal z_% metadata schemas, because tables like replicas track Zero state Zero's internal schema names are not fixed. Current deployments commonly use schemas named like z_abcd1234 and z_abcd1234_0. If those metadata privileges are missing, Zero can still connect and read app tables but later fail with errors such as permission denied for table replicas. Recommended role setup If you want the low-maintenance setup, give the dedicated role replication access, broad read access for app tables, and the ability to create future internal schemas. pg_read_all_data is the simplest option because publication changes keep working without table-grant churn. pg_read_all_settings and pg_read_all_stats give Zero read-only visibility into the upstream database state it inspects during setup and operation. This is the best first setup. Get it working before you add IP restrictions or tighter app-data grants. CREATE ROLE zero WITH LOGIN REPLICATION PASSWORD 'replace-me'; GRANT CONNECT ON DATABASE \"app\" TO zero; GRANT CREATE ON DATABASE \"app\" TO zero; GRANT pg_read_all_data TO zero; GRANT pg_read_all_settings TO zero; GRANT pg_read_all_stats TO zero; If the role already exists, use ALTER ROLE instead: ALTER ROLE zero WITH LOGIN REPLICATION PASSWORD 'replace-me'; Existing z_% schemas If Zero has already run against this database and z_% schemas already exist, grant the role access to those current schemas and tables too. This gives Zero write access to existing metadata tables such as replicas. If the schemas do not exist yet, zero can create them later because it has database CREATE, but any existing z_% schemas still need this retroactive grant loop. DO $$ DECLARE schema_name text; BEGIN FOR schema_name IN SELECT nspname FROM pg_namespace WHERE nspname LIKE 'z\\_%' ESCAPE '\\' ORDER BY nspname LOOP EXECUTE format('GRANT USAGE, CREATE ON SCHEMA %I TO zero', schema_name); EXECUTE format( 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I TO zero', schema_name ); EXECUTE format( 'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO zero', schema_name ); END LOOP; END $$; If Zero creates future z_% schemas itself, it owns them. If an admin role creates a future z_% schema instead, rerun the block. The publication-scoped helper below only manages app-table SELECT. It does not replace REPLICATION, database CREATE, pg_read_all_settings, pg_read_all_stats, or these retroactive z_% metadata grants. Optional: keep app data grants publication-scoped If you want tighter app-table reads than pg_read_all_data, grant SELECT only on the tables currently exposed by your app publications. PostgreSQL does not have a native GRANT ... ON PUBLICATION, so this path is generated from pg_publication_tables and must be rerun when publication membership changes. Treat this as a later hardening step after the recommended setup already works. DO $$ DECLARE publication_names text[] := ARRAY[ 'replace_with_app_publication', 'replace_with_another_publication' ]; r record; BEGIN FOR r IN SELECT DISTINCT schemaname FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT USAGE ON SCHEMA %I TO zero', r.schemaname); END LOOP; FOR r IN SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT SELECT ON TABLE %I.%I TO zero', r.schemaname, r.tablename); END LOOP; END $$; If you are migrating away from pg_read_all_data, the safe order is: generate the explicit publication grants first, validate that zero can still read the published app tables, then revoke pg_read_all_data in the same transaction. If you want to keep those grants in sync automatically, wrap the same logic in admin-owned automation. The helper must be owned by an admin or table-owner role with grant authority, not by zero, and SECURITY DEFINER should pin search_path to pg_catalog. A practical shape is to keep the helper in a dedicated admin-owned schema, track which table grants it manages, and revoke SELECT from tables that leave the publication later. CREATE SCHEMA IF NOT EXISTS zero_publication_grants; CREATE TABLE IF NOT EXISTS zero_publication_grants.synced_tables ( schemaname text NOT NULL, tablename text NOT NULL, PRIMARY KEY (schemaname, tablename) ); CREATE OR REPLACE FUNCTION zero_publication_grants.sync_zero_publication_read_grants() RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog AS $$ DECLARE publication_names text[] := ARRAY[ 'replace_with_app_publication', 'replace_with_another_publication' ]; r record; BEGIN FOR r IN SELECT DISTINCT schemaname FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT USAGE ON SCHEMA %I TO zero', r.schemaname); END LOOP; FOR r IN SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT SELECT ON TABLE %I.%I TO zero', r.schemaname, r.tablename); END LOOP; FOR r IN WITH current_tables AS ( SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) ) SELECT st.schemaname, st.tablename, EXISTS ( SELECT 1 FROM pg_catalog.pg_class AS c JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE n.nspname = st.schemaname AND c.relname = st.tablename AND c.relkind IN ('r', 'p') ) AS table_exists FROM zero_publication_grants.synced_tables AS st LEFT JOIN current_tables AS ct ON ct.schemaname = st.schemaname AND ct.tablename = st.tablename WHERE ct.tablename IS NULL LOOP IF r.table_exists THEN EXECUTE format('REVOKE SELECT ON TABLE %I.%I FROM zero', r.schemaname, r.tablename); END IF; END LOOP; DELETE FROM zero_publication_grants.synced_tables AS st WHERE NOT EXISTS ( SELECT 1 FROM pg_catalog.pg_publication_tables AS pt WHERE pt.pubname = ANY (publication_names) AND pt.schemaname = st.schemaname AND pt.tablename = st.tablename ); INSERT INTO zero_publication_grants.synced_tables (schemaname, tablename) SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) ON CONFLICT DO NOTHING; END; $$; SELECT zero_publication_grants.sync_zero_publication_read_grants(); CREATE OR REPLACE FUNCTION zero_publication_grants.sync_zero_publication_read_grants_event() RETURNS event_trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog AS $$ BEGIN PERFORM zero_publication_grants.sync_zero_publication_read_grants(); END; $$; CREATE EVENT TRIGGER sync_zero_publication_read_grants_trigger ON ddl_command_end WHEN TAG IN ( 'CREATE TABLE', 'ALTER TABLE', 'DROP TABLE', 'CREATE PUBLICATION', 'ALTER PUBLICATION', 'DROP PUBLICATION', 'DROP SCHEMA' ) EXECUTE FUNCTION zero_publication_grants.sync_zero_publication_read_grants_event(); This is optional operational machinery for teams that want tighter app-data reads than pg_read_all_data. The recommended default stays pg_read_all_data. Verify that your provider permits event triggers. If it does not, rerun the helper after publication changes from your deployment or migration step instead. If you use this path, revoke EXECUTE from PUBLIC on the helper functions. Also audit for existing grants to PUBLIC: those apply to every role, including zero, and sit outside this role-specific grant model. How PlanetScale IP restrictions behave Once the role and grants work, you can add network restrictions. PlanetScale Postgres IP restrictions are allow rules. Once a branch has any IP restriction, new connections must match at least one rule. A blank-role 0.0.0.0/0 rule allows every role, including zero, so it defeats a restricted Zero role while it exists. To keep existing application access unchanged while restricting only zero, add explicit role-scoped 0.0.0.0/0 rules for the app and user roles that should stay public, then add narrow CIDR rules only for zero. In PlanetScale, go to Settings → IP restrictions and create or edit rules there. Use the role username, not a descriptive label, and enter IPv4 addresses as /32 CIDRs such as 203.0.113.10/32. If PlanetScale shows a username like pscale_api_<suffix>.<branch_id>, use only the first part, pscale_api_<suffix>. If you are using Cloud Zero, you can find the current egress IPs in the Cloud Zero dashboard under Instances → Cluster → Egress IPs. Use those addresses as /32 CIDRs. This applies both to hosted Cloud Zero and AWS-managed instances. Keep that console-provided list current. During an egress IP change, temporarily allowing both the old and new listed addresses can prevent accidental breakage while you validate fresh connections. If you are self-hosting, use the public egress IPs of your own deployment. PlanetScale internal service roles are not usually part of your app role model. Do not add custom rules for internal pscale_* roles unless PlanetScale tells you to. The exception is app or automation roles you actually use, such as a pscale_api_* role that backs production automation. One common final rule layout looks like this: Safe rollout for role-scoped restrictions Use this order to avoid accidental lockouts: Inventory the roles that still need public access, including any pscale_api_* roles your automation actually uses. If the branch currently has no IP rules and you want a bridge while assembling the final rules, add a temporary blank-role 0.0.0.0/0. Add explicit role-scoped 0.0.0.0/0 rules for the existing app and user roles that should stay public, then validate fresh connections for those roles. Create or update the dedicated zero role and grants. Add the zero IP rule with only the Cloud Zero egress CIDRs. If you need to test from your laptop, temporarily append your operator /32 to that same zero rule, validate, then remove it. Remove the temporary blank-role catchall last, then validate fresh app connections again and confirm that zero is blocked from a non-allowlisted IP. PlanetScale may reject a second IP restriction record for the same database and role. If you need to temporarily allow an operator IP for testing, edit the existing Zero rule and add one more CIDR, then remove it after testing. Practical validation checks After creating the role and applying the IP rule, validate it with a fresh psql connection as the zero role. Supply one replicated app table and check that the role can read app data, perform a no-op write against replicas inside a transaction, and create a temporary logical replication slot. export ZERO_PROBE_DSN='postgres://zero:<password>@db.example.com:5432/app' export ZERO_PROBE_SCHEMA='public' export ZERO_PROBE_TABLE='some_replicated_table' slot_name=\"zero_probe_$(date +%s)\" psql \"$ZERO_PROBE_DSN\" \\ -X \\ -v ON_ERROR_STOP=1 \\ -v zero_probe_schema=\"$ZERO_PROBE_SCHEMA\" \\ -v zero_probe_table=\"$ZERO_PROBE_TABLE\" \\ -v zero_probe_slot=\"$slot_name\" <<'SQL' SELECT current_user, inet_client_addr(); SELECT has_database_privilege(current_user, current_database(), 'CREATE'); SELECT format( 'SELECT 1 FROM %I.%I LIMIT 1', :'zero_probe_schema', :'zero_probe_table' ) WHERE :'zero_probe_schema' <> '' AND :'zero_probe_table' <> '' \\gexec BEGIN; SELECT format( 'UPDATE %I.%I SET version = version WHERE false', n.nspname, c.relname ) FROM pg_class AS c JOIN pg_namespace AS n ON n.oid = c.relnamespace WHERE n.nspname LIKE 'z\\_%' ESCAPE '\\' AND c.relname = 'replicas' AND c.relkind IN ('r', 'p') ORDER BY n.nspname LIMIT 1 \\gexec ROLLBACK; SELECT * FROM pg_create_logical_replication_slot( :'zero_probe_slot', 'pgoutput', true ); SQL PlanetScale currently supports PostgreSQL 17 and 18, so the third argument true form shown here is supported there. It requests a temporary logical replication slot. Choose a unique slot name. The no-op UPDATE ... WHERE false runs inside a transaction and rolls back, so it validates replicas write access without changing data. If no z_% schemas exist yet, that UPDATE check does nothing. Let Zero start once so it can create its own internal schemas, then rerun the script. Cleanup is automatic: the replication slot is temporary, so PostgreSQL drops it when the psql session ends. If you need to validate from a laptop, temporarily append your operator /32 to the existing Zero role rule, run the script, then remove that /32 and rerun the connection. The second run should fail before any SQL executes, which is the expected negative control. Common pitfalls App-table SELECT alone is not enough. Zero also needs write access to its internal z_% schemas or you may see errors like permission denied for table replicas. A blank-role 0.0.0.0/0 rule defeats a restricted zero role while it exists. Preserve existing app and user roles with explicit role-scoped 0.0.0.0/0 rules before narrowing zero. PlanetScale may reject duplicate restriction records for the same database and role. Edit the existing zero rule instead. Validate fresh connections after each change. Long-lived existing connections are not enough to prove the rollout is safe. Neon Logical Replication Neon supports logical replication, but you need to enable it in the Neon console for your branch/endpoint. Enable logical replication Branching Neon fully supports Zero, but you should be aware of how Neon's pricing model and Zero interact: because Zero keeps an open connection to Postgres to replicate changes, as long as zero-cache is running, Postgres will be running and you will be charged by Neon. For production databases that have enough usage to always be running anyway, this is fine. But for smaller applications that would otherwise not always be running, this can create a surprisingly high bill. You may want to choose a provider that charge a flat monthly rate instead. Also some users choose Neon because they hope to use branching for previews. This can work, but if not done with care, Zero can end up keeping each Neon preview branch running too 😳. For the recommended approach to preview URLs, see Previews. Fly.io Networking Fly Managed Postgres is the latest offering from Fly.io, and it is private-network-only by default. If zero-cache runs outside Fly, connect via Fly WireGuard or run a proxy like fly-mpg-proxy. Fly does not support TLS on its private network. If zero-cache connects to Postgres over the Fly private network (including WireGuard), add sslmode=disable to your connection strings. Permissions Fly Managed Postgres does not provide superuser access, so zero-cache cannot create event triggers. Also, some publication operations (like FOR TABLES IN SCHEMA ... / FOR ALL TABLES) can be permission-restricted. If zero-cache can't create its default publication, create one listing tables explicitly and set the app publication. Pooling You should use Fly's pgBouncer endpoint for ZERO_CVR_DB and ZERO_CHANGE_DB. Supabase Supabase requires at least 15.8.1.083 for event trigger support. If you have a lower 15.x, Zero will still work but schema updates will be slower. See Supabase's docs for upgrading your Postgres version. Zero must use the \"Direct Connection\" string: This is because Zero sets up a logical replication slot, which is only supported with a direct connection. For ZERO_CVR_DB and ZERO_CHANGE_DB, prefer Supabase's session pooler. The transaction pooler can break prepared statements and cause errors like 26000 prepared statement ... does not exist. Publication Changes Supabase does not fire DDL event triggers for ALTER PUBLICATION. Call a schema change hook after the ALTER PUBLICATION to replicate the change. IPv4 You may also need to assign an IPv4 address to your Supabase instance: This will be required if you cannot use IPv6 from wherever zero-cache is running. Most cloud providers support IPv6, but some do not. For example, if you are running zero-cache in AWS, it is possible to use IPv6 but difficult. Hetzner offers cheap hosted VPS that supports IPv6. IPv4 addresses are only supported on the Pro plan and are an extra $4/month. Render Render can work with Zero, but requires admin/support-side setup, and does not support a few core Zero features. App roles can't create event triggers, so schema changes will fall back to full resets unless you use schema change hooks. You also must ensure wal_level=logical by creating a Render support ticket. Render does not provide superuser access, but you can submit another support ticket to ask Render to create a publication with FOR ALL TABLES for you, and then set that publication in App Publications. Google Cloud SQL Zero works with Google Cloud SQL out of the box. In many configurations, when you connect with a user that has sufficient privileges, zero-cache will create its default publication automatically. If your Cloud SQL user does not have permission to create publications, you can still use Zero by creating a publication manually and then specifying that publication name in App Publications when running zero-cache. On Google Cloud SQL for PostgreSQL, enable logical decoding by turning on the instance flag cloudsql.logical_decoding. You do not set wal_level directly on Cloud SQL. See Google's documentation for details: Configure logical replication.",
     "kind": "section"
   },
   {
@@ -555,11 +581,101 @@
     "sectionTitle": "PlanetScale for Postgres",
     "sectionId": "planetscale-for-postgres",
     "url": "/docs/connecting-to-postgres",
-    "content": "You should use the default role that PlanetScale provides, because PlanetScale user-defined roles cannot create replication slots. Planetscale Postgres defaults max_connections to 25, which can easily be exhausted by Zero's connection pools. This will result in an error like remaining connection slots are reserved for roles with the SUPERUSER attribute. You should increase this value in the Parameters section of the PlanetScale dashboard to 100 or more. Make sure to only use a direct connection for the ZERO_UPSTREAM_DB, and use pooled URLs for ZERO_CVR_DB, ZERO_CHANGE_DB, and your API (see Deployment).",
+    "content": "Planetscale Postgres defaults max_connections to 25, which can easily be exhausted by Zero's connection pools. This will result in an error like remaining connection slots are reserved for roles with the SUPERUSER attribute. You should increase this value in the Parameters section of the PlanetScale dashboard to 100 or more. Make sure to only use a direct connection for the ZERO_UPSTREAM_DB, and use pooled URLs for ZERO_CVR_DB, ZERO_CHANGE_DB, and your API (see Deployment). You do not need role-scoped IP restrictions to use Zero with PlanetScale Postgres. Zero works with a normal direct ZERO_UPSTREAM_DB connection and the usual role and password setup. The rest of this section describes an optional hardening pattern that is especially useful for Cloud Zero, and can also be useful for self-hosted Zero when the database connection still crosses the public internet instead of a private path such as PrivateLink. The goal is to restrict the Zero upstream role to a small set of known egress IPs while preserving existing application access. For the smoothest rollout, get Zero working first, then add these hardening steps one layer at a time. Suggested order The easiest setup is to get Zero running first, then add security from lowest to highest operational overhead: During setup: get Zero working with a direct ZERO_UPSTREAM_DB connection and the recommended role grants below. During setup or later: use a dedicated zero role instead of the PlanetScale default role if you want cleaner credential rotation and role-scoped IP restrictions. Later: add PlanetScale role-scoped IP restrictions so existing app roles can stay open while zero is limited to Cloud Zero egress IPs. Later, and only if you want tighter least privilege: replace pg_read_all_data with publication-scoped app-table grants and optionally automate them with an admin-owned helper. Custom Zero roles You can use PlanetScale's default role for Zero if you want the simplest setup. For production, a dedicated zero role is usually better because it separates Zero from the rest of your application for credential rotation and role-scoped IP restrictions. A dedicated Zero role needs three things: LOGIN and REPLICATION so it can connect and read the replication stream read access to the application tables it replicates, because initial sync copies rows with COPY (SELECT ...) ownership or write access to Zero's internal z_% metadata schemas, because tables like replicas track Zero state Zero's internal schema names are not fixed. Current deployments commonly use schemas named like z_abcd1234 and z_abcd1234_0. If those metadata privileges are missing, Zero can still connect and read app tables but later fail with errors such as permission denied for table replicas. Recommended role setup If you want the low-maintenance setup, give the dedicated role replication access, broad read access for app tables, and the ability to create future internal schemas. pg_read_all_data is the simplest option because publication changes keep working without table-grant churn. pg_read_all_settings and pg_read_all_stats give Zero read-only visibility into the upstream database state it inspects during setup and operation. This is the best first setup. Get it working before you add IP restrictions or tighter app-data grants. CREATE ROLE zero WITH LOGIN REPLICATION PASSWORD 'replace-me'; GRANT CONNECT ON DATABASE \"app\" TO zero; GRANT CREATE ON DATABASE \"app\" TO zero; GRANT pg_read_all_data TO zero; GRANT pg_read_all_settings TO zero; GRANT pg_read_all_stats TO zero; If the role already exists, use ALTER ROLE instead: ALTER ROLE zero WITH LOGIN REPLICATION PASSWORD 'replace-me'; Existing z_% schemas If Zero has already run against this database and z_% schemas already exist, grant the role access to those current schemas and tables too. This gives Zero write access to existing metadata tables such as replicas. If the schemas do not exist yet, zero can create them later because it has database CREATE, but any existing z_% schemas still need this retroactive grant loop. DO $$ DECLARE schema_name text; BEGIN FOR schema_name IN SELECT nspname FROM pg_namespace WHERE nspname LIKE 'z\\_%' ESCAPE '\\' ORDER BY nspname LOOP EXECUTE format('GRANT USAGE, CREATE ON SCHEMA %I TO zero', schema_name); EXECUTE format( 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I TO zero', schema_name ); EXECUTE format( 'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO zero', schema_name ); END LOOP; END $$; If Zero creates future z_% schemas itself, it owns them. If an admin role creates a future z_% schema instead, rerun the block. The publication-scoped helper below only manages app-table SELECT. It does not replace REPLICATION, database CREATE, pg_read_all_settings, pg_read_all_stats, or these retroactive z_% metadata grants. Optional: keep app data grants publication-scoped If you want tighter app-table reads than pg_read_all_data, grant SELECT only on the tables currently exposed by your app publications. PostgreSQL does not have a native GRANT ... ON PUBLICATION, so this path is generated from pg_publication_tables and must be rerun when publication membership changes. Treat this as a later hardening step after the recommended setup already works. DO $$ DECLARE publication_names text[] := ARRAY[ 'replace_with_app_publication', 'replace_with_another_publication' ]; r record; BEGIN FOR r IN SELECT DISTINCT schemaname FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT USAGE ON SCHEMA %I TO zero', r.schemaname); END LOOP; FOR r IN SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT SELECT ON TABLE %I.%I TO zero', r.schemaname, r.tablename); END LOOP; END $$; If you are migrating away from pg_read_all_data, the safe order is: generate the explicit publication grants first, validate that zero can still read the published app tables, then revoke pg_read_all_data in the same transaction. If you want to keep those grants in sync automatically, wrap the same logic in admin-owned automation. The helper must be owned by an admin or table-owner role with grant authority, not by zero, and SECURITY DEFINER should pin search_path to pg_catalog. A practical shape is to keep the helper in a dedicated admin-owned schema, track which table grants it manages, and revoke SELECT from tables that leave the publication later. CREATE SCHEMA IF NOT EXISTS zero_publication_grants; CREATE TABLE IF NOT EXISTS zero_publication_grants.synced_tables ( schemaname text NOT NULL, tablename text NOT NULL, PRIMARY KEY (schemaname, tablename) ); CREATE OR REPLACE FUNCTION zero_publication_grants.sync_zero_publication_read_grants() RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog AS $$ DECLARE publication_names text[] := ARRAY[ 'replace_with_app_publication', 'replace_with_another_publication' ]; r record; BEGIN FOR r IN SELECT DISTINCT schemaname FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT USAGE ON SCHEMA %I TO zero', r.schemaname); END LOOP; FOR r IN SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT SELECT ON TABLE %I.%I TO zero', r.schemaname, r.tablename); END LOOP; FOR r IN WITH current_tables AS ( SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) ) SELECT st.schemaname, st.tablename, EXISTS ( SELECT 1 FROM pg_catalog.pg_class AS c JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE n.nspname = st.schemaname AND c.relname = st.tablename AND c.relkind IN ('r', 'p') ) AS table_exists FROM zero_publication_grants.synced_tables AS st LEFT JOIN current_tables AS ct ON ct.schemaname = st.schemaname AND ct.tablename = st.tablename WHERE ct.tablename IS NULL LOOP IF r.table_exists THEN EXECUTE format('REVOKE SELECT ON TABLE %I.%I FROM zero', r.schemaname, r.tablename); END IF; END LOOP; DELETE FROM zero_publication_grants.synced_tables AS st WHERE NOT EXISTS ( SELECT 1 FROM pg_catalog.pg_publication_tables AS pt WHERE pt.pubname = ANY (publication_names) AND pt.schemaname = st.schemaname AND pt.tablename = st.tablename ); INSERT INTO zero_publication_grants.synced_tables (schemaname, tablename) SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) ON CONFLICT DO NOTHING; END; $$; SELECT zero_publication_grants.sync_zero_publication_read_grants(); CREATE OR REPLACE FUNCTION zero_publication_grants.sync_zero_publication_read_grants_event() RETURNS event_trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog AS $$ BEGIN PERFORM zero_publication_grants.sync_zero_publication_read_grants(); END; $$; CREATE EVENT TRIGGER sync_zero_publication_read_grants_trigger ON ddl_command_end WHEN TAG IN ( 'CREATE TABLE', 'ALTER TABLE', 'DROP TABLE', 'CREATE PUBLICATION', 'ALTER PUBLICATION', 'DROP PUBLICATION', 'DROP SCHEMA' ) EXECUTE FUNCTION zero_publication_grants.sync_zero_publication_read_grants_event(); This is optional operational machinery for teams that want tighter app-data reads than pg_read_all_data. The recommended default stays pg_read_all_data. Verify that your provider permits event triggers. If it does not, rerun the helper after publication changes from your deployment or migration step instead. If you use this path, revoke EXECUTE from PUBLIC on the helper functions. Also audit for existing grants to PUBLIC: those apply to every role, including zero, and sit outside this role-specific grant model. How PlanetScale IP restrictions behave Once the role and grants work, you can add network restrictions. PlanetScale Postgres IP restrictions are allow rules. Once a branch has any IP restriction, new connections must match at least one rule. A blank-role 0.0.0.0/0 rule allows every role, including zero, so it defeats a restricted Zero role while it exists. To keep existing application access unchanged while restricting only zero, add explicit role-scoped 0.0.0.0/0 rules for the app and user roles that should stay public, then add narrow CIDR rules only for zero. In PlanetScale, go to Settings → IP restrictions and create or edit rules there. Use the role username, not a descriptive label, and enter IPv4 addresses as /32 CIDRs such as 203.0.113.10/32. If PlanetScale shows a username like pscale_api_<suffix>.<branch_id>, use only the first part, pscale_api_<suffix>. If you are using Cloud Zero, you can find the current egress IPs in the Cloud Zero dashboard under Instances → Cluster → Egress IPs. Use those addresses as /32 CIDRs. This applies both to hosted Cloud Zero and AWS-managed instances. Keep that console-provided list current. During an egress IP change, temporarily allowing both the old and new listed addresses can prevent accidental breakage while you validate fresh connections. If you are self-hosting, use the public egress IPs of your own deployment. PlanetScale internal service roles are not usually part of your app role model. Do not add custom rules for internal pscale_* roles unless PlanetScale tells you to. The exception is app or automation roles you actually use, such as a pscale_api_* role that backs production automation. One common final rule layout looks like this: Safe rollout for role-scoped restrictions Use this order to avoid accidental lockouts: Inventory the roles that still need public access, including any pscale_api_* roles your automation actually uses. If the branch currently has no IP rules and you want a bridge while assembling the final rules, add a temporary blank-role 0.0.0.0/0. Add explicit role-scoped 0.0.0.0/0 rules for the existing app and user roles that should stay public, then validate fresh connections for those roles. Create or update the dedicated zero role and grants. Add the zero IP rule with only the Cloud Zero egress CIDRs. If you need to test from your laptop, temporarily append your operator /32 to that same zero rule, validate, then remove it. Remove the temporary blank-role catchall last, then validate fresh app connections again and confirm that zero is blocked from a non-allowlisted IP. PlanetScale may reject a second IP restriction record for the same database and role. If you need to temporarily allow an operator IP for testing, edit the existing Zero rule and add one more CIDR, then remove it after testing. Practical validation checks After creating the role and applying the IP rule, validate it with a fresh psql connection as the zero role. Supply one replicated app table and check that the role can read app data, perform a no-op write against replicas inside a transaction, and create a temporary logical replication slot. export ZERO_PROBE_DSN='postgres://zero:<password>@db.example.com:5432/app' export ZERO_PROBE_SCHEMA='public' export ZERO_PROBE_TABLE='some_replicated_table' slot_name=\"zero_probe_$(date +%s)\" psql \"$ZERO_PROBE_DSN\" \\ -X \\ -v ON_ERROR_STOP=1 \\ -v zero_probe_schema=\"$ZERO_PROBE_SCHEMA\" \\ -v zero_probe_table=\"$ZERO_PROBE_TABLE\" \\ -v zero_probe_slot=\"$slot_name\" <<'SQL' SELECT current_user, inet_client_addr(); SELECT has_database_privilege(current_user, current_database(), 'CREATE'); SELECT format( 'SELECT 1 FROM %I.%I LIMIT 1', :'zero_probe_schema', :'zero_probe_table' ) WHERE :'zero_probe_schema' <> '' AND :'zero_probe_table' <> '' \\gexec BEGIN; SELECT format( 'UPDATE %I.%I SET version = version WHERE false', n.nspname, c.relname ) FROM pg_class AS c JOIN pg_namespace AS n ON n.oid = c.relnamespace WHERE n.nspname LIKE 'z\\_%' ESCAPE '\\' AND c.relname = 'replicas' AND c.relkind IN ('r', 'p') ORDER BY n.nspname LIMIT 1 \\gexec ROLLBACK; SELECT * FROM pg_create_logical_replication_slot( :'zero_probe_slot', 'pgoutput', true ); SQL PlanetScale currently supports PostgreSQL 17 and 18, so the third argument true form shown here is supported there. It requests a temporary logical replication slot. Choose a unique slot name. The no-op UPDATE ... WHERE false runs inside a transaction and rolls back, so it validates replicas write access without changing data. If no z_% schemas exist yet, that UPDATE check does nothing. Let Zero start once so it can create its own internal schemas, then rerun the script. Cleanup is automatic: the replication slot is temporary, so PostgreSQL drops it when the psql session ends. If you need to validate from a laptop, temporarily append your operator /32 to the existing Zero role rule, run the script, then remove that /32 and rerun the connection. The second run should fail before any SQL executes, which is the expected negative control. Common pitfalls App-table SELECT alone is not enough. Zero also needs write access to its internal z_% schemas or you may see errors like permission denied for table replicas. A blank-role 0.0.0.0/0 rule defeats a restricted zero role while it exists. Preserve existing app and user roles with explicit role-scoped 0.0.0.0/0 rules before narrowing zero. PlanetScale may reject duplicate restriction records for the same database and role. Edit the existing zero rule instead. Validate fresh connections after each change. Long-lived existing connections are not enough to prove the rollout is safe.",
     "kind": "section"
   },
   {
-    "id": "105-connecting-to-postgres#neon",
+    "id": "105-connecting-to-postgres#suggested-order",
+    "title": "Connecting to Postgres",
+    "searchTitle": "Suggested order",
+    "sectionTitle": "Suggested order",
+    "sectionId": "suggested-order",
+    "url": "/docs/connecting-to-postgres",
+    "content": "The easiest setup is to get Zero running first, then add security from lowest to highest operational overhead: During setup: get Zero working with a direct ZERO_UPSTREAM_DB connection and the recommended role grants below. During setup or later: use a dedicated zero role instead of the PlanetScale default role if you want cleaner credential rotation and role-scoped IP restrictions. Later: add PlanetScale role-scoped IP restrictions so existing app roles can stay open while zero is limited to Cloud Zero egress IPs. Later, and only if you want tighter least privilege: replace pg_read_all_data with publication-scoped app-table grants and optionally automate them with an admin-owned helper.",
+    "kind": "section"
+  },
+  {
+    "id": "106-connecting-to-postgres#custom-zero-roles",
+    "title": "Connecting to Postgres",
+    "searchTitle": "Custom Zero roles",
+    "sectionTitle": "Custom Zero roles",
+    "sectionId": "custom-zero-roles",
+    "url": "/docs/connecting-to-postgres",
+    "content": "You can use PlanetScale's default role for Zero if you want the simplest setup. For production, a dedicated zero role is usually better because it separates Zero from the rest of your application for credential rotation and role-scoped IP restrictions. A dedicated Zero role needs three things: LOGIN and REPLICATION so it can connect and read the replication stream read access to the application tables it replicates, because initial sync copies rows with COPY (SELECT ...) ownership or write access to Zero's internal z_% metadata schemas, because tables like replicas track Zero state Zero's internal schema names are not fixed. Current deployments commonly use schemas named like z_abcd1234 and z_abcd1234_0. If those metadata privileges are missing, Zero can still connect and read app tables but later fail with errors such as permission denied for table replicas.",
+    "kind": "section"
+  },
+  {
+    "id": "107-connecting-to-postgres#recommended-role-setup",
+    "title": "Connecting to Postgres",
+    "searchTitle": "Recommended role setup",
+    "sectionTitle": "Recommended role setup",
+    "sectionId": "recommended-role-setup",
+    "url": "/docs/connecting-to-postgres",
+    "content": "If you want the low-maintenance setup, give the dedicated role replication access, broad read access for app tables, and the ability to create future internal schemas. pg_read_all_data is the simplest option because publication changes keep working without table-grant churn. pg_read_all_settings and pg_read_all_stats give Zero read-only visibility into the upstream database state it inspects during setup and operation. This is the best first setup. Get it working before you add IP restrictions or tighter app-data grants. CREATE ROLE zero WITH LOGIN REPLICATION PASSWORD 'replace-me'; GRANT CONNECT ON DATABASE \"app\" TO zero; GRANT CREATE ON DATABASE \"app\" TO zero; GRANT pg_read_all_data TO zero; GRANT pg_read_all_settings TO zero; GRANT pg_read_all_stats TO zero; If the role already exists, use ALTER ROLE instead: ALTER ROLE zero WITH LOGIN REPLICATION PASSWORD 'replace-me';",
+    "kind": "section"
+  },
+  {
+    "id": "108-connecting-to-postgres#existing-z_-schemas",
+    "title": "Connecting to Postgres",
+    "searchTitle": "Existing z_% schemas",
+    "sectionTitle": "Existing z_% schemas",
+    "sectionId": "existing-z_-schemas",
+    "url": "/docs/connecting-to-postgres",
+    "content": "If Zero has already run against this database and z_% schemas already exist, grant the role access to those current schemas and tables too. This gives Zero write access to existing metadata tables such as replicas. If the schemas do not exist yet, zero can create them later because it has database CREATE, but any existing z_% schemas still need this retroactive grant loop. DO $$ DECLARE schema_name text; BEGIN FOR schema_name IN SELECT nspname FROM pg_namespace WHERE nspname LIKE 'z\\_%' ESCAPE '\\' ORDER BY nspname LOOP EXECUTE format('GRANT USAGE, CREATE ON SCHEMA %I TO zero', schema_name); EXECUTE format( 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I TO zero', schema_name ); EXECUTE format( 'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO zero', schema_name ); END LOOP; END $$; If Zero creates future z_% schemas itself, it owns them. If an admin role creates a future z_% schema instead, rerun the block. The publication-scoped helper below only manages app-table SELECT. It does not replace REPLICATION, database CREATE, pg_read_all_settings, pg_read_all_stats, or these retroactive z_% metadata grants.",
+    "kind": "section"
+  },
+  {
+    "id": "109-connecting-to-postgres#optional-keep-app-data-grants-publication-scoped",
+    "title": "Connecting to Postgres",
+    "searchTitle": "Optional: keep app data grants publication-scoped",
+    "sectionTitle": "Optional: keep app data grants publication-scoped",
+    "sectionId": "optional-keep-app-data-grants-publication-scoped",
+    "url": "/docs/connecting-to-postgres",
+    "content": "If you want tighter app-table reads than pg_read_all_data, grant SELECT only on the tables currently exposed by your app publications. PostgreSQL does not have a native GRANT ... ON PUBLICATION, so this path is generated from pg_publication_tables and must be rerun when publication membership changes. Treat this as a later hardening step after the recommended setup already works. DO $$ DECLARE publication_names text[] := ARRAY[ 'replace_with_app_publication', 'replace_with_another_publication' ]; r record; BEGIN FOR r IN SELECT DISTINCT schemaname FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT USAGE ON SCHEMA %I TO zero', r.schemaname); END LOOP; FOR r IN SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT SELECT ON TABLE %I.%I TO zero', r.schemaname, r.tablename); END LOOP; END $$; If you are migrating away from pg_read_all_data, the safe order is: generate the explicit publication grants first, validate that zero can still read the published app tables, then revoke pg_read_all_data in the same transaction. If you want to keep those grants in sync automatically, wrap the same logic in admin-owned automation. The helper must be owned by an admin or table-owner role with grant authority, not by zero, and SECURITY DEFINER should pin search_path to pg_catalog. A practical shape is to keep the helper in a dedicated admin-owned schema, track which table grants it manages, and revoke SELECT from tables that leave the publication later. CREATE SCHEMA IF NOT EXISTS zero_publication_grants; CREATE TABLE IF NOT EXISTS zero_publication_grants.synced_tables ( schemaname text NOT NULL, tablename text NOT NULL, PRIMARY KEY (schemaname, tablename) ); CREATE OR REPLACE FUNCTION zero_publication_grants.sync_zero_publication_read_grants() RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog AS $$ DECLARE publication_names text[] := ARRAY[ 'replace_with_app_publication', 'replace_with_another_publication' ]; r record; BEGIN FOR r IN SELECT DISTINCT schemaname FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT USAGE ON SCHEMA %I TO zero', r.schemaname); END LOOP; FOR r IN SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) LOOP EXECUTE format('GRANT SELECT ON TABLE %I.%I TO zero', r.schemaname, r.tablename); END LOOP; FOR r IN WITH current_tables AS ( SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) ) SELECT st.schemaname, st.tablename, EXISTS ( SELECT 1 FROM pg_catalog.pg_class AS c JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE n.nspname = st.schemaname AND c.relname = st.tablename AND c.relkind IN ('r', 'p') ) AS table_exists FROM zero_publication_grants.synced_tables AS st LEFT JOIN current_tables AS ct ON ct.schemaname = st.schemaname AND ct.tablename = st.tablename WHERE ct.tablename IS NULL LOOP IF r.table_exists THEN EXECUTE format('REVOKE SELECT ON TABLE %I.%I FROM zero', r.schemaname, r.tablename); END IF; END LOOP; DELETE FROM zero_publication_grants.synced_tables AS st WHERE NOT EXISTS ( SELECT 1 FROM pg_catalog.pg_publication_tables AS pt WHERE pt.pubname = ANY (publication_names) AND pt.schemaname = st.schemaname AND pt.tablename = st.tablename ); INSERT INTO zero_publication_grants.synced_tables (schemaname, tablename) SELECT DISTINCT schemaname, tablename FROM pg_catalog.pg_publication_tables WHERE pubname = ANY (publication_names) ON CONFLICT DO NOTHING; END; $$; SELECT zero_publication_grants.sync_zero_publication_read_grants(); CREATE OR REPLACE FUNCTION zero_publication_grants.sync_zero_publication_read_grants_event() RETURNS event_trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog AS $$ BEGIN PERFORM zero_publication_grants.sync_zero_publication_read_grants(); END; $$; CREATE EVENT TRIGGER sync_zero_publication_read_grants_trigger ON ddl_command_end WHEN TAG IN ( 'CREATE TABLE', 'ALTER TABLE', 'DROP TABLE', 'CREATE PUBLICATION', 'ALTER PUBLICATION', 'DROP PUBLICATION', 'DROP SCHEMA' ) EXECUTE FUNCTION zero_publication_grants.sync_zero_publication_read_grants_event(); This is optional operational machinery for teams that want tighter app-data reads than pg_read_all_data. The recommended default stays pg_read_all_data. Verify that your provider permits event triggers. If it does not, rerun the helper after publication changes from your deployment or migration step instead. If you use this path, revoke EXECUTE from PUBLIC on the helper functions. Also audit for existing grants to PUBLIC: those apply to every role, including zero, and sit outside this role-specific grant model.",
+    "kind": "section"
+  },
+  {
+    "id": "110-connecting-to-postgres#how-planetscale-ip-restrictions-behave",
+    "title": "Connecting to Postgres",
+    "searchTitle": "How PlanetScale IP restrictions behave",
+    "sectionTitle": "How PlanetScale IP restrictions behave",
+    "sectionId": "how-planetscale-ip-restrictions-behave",
+    "url": "/docs/connecting-to-postgres",
+    "content": "Once the role and grants work, you can add network restrictions. PlanetScale Postgres IP restrictions are allow rules. Once a branch has any IP restriction, new connections must match at least one rule. A blank-role 0.0.0.0/0 rule allows every role, including zero, so it defeats a restricted Zero role while it exists. To keep existing application access unchanged while restricting only zero, add explicit role-scoped 0.0.0.0/0 rules for the app and user roles that should stay public, then add narrow CIDR rules only for zero. In PlanetScale, go to Settings → IP restrictions and create or edit rules there. Use the role username, not a descriptive label, and enter IPv4 addresses as /32 CIDRs such as 203.0.113.10/32. If PlanetScale shows a username like pscale_api_<suffix>.<branch_id>, use only the first part, pscale_api_<suffix>. If you are using Cloud Zero, you can find the current egress IPs in the Cloud Zero dashboard under Instances → Cluster → Egress IPs. Use those addresses as /32 CIDRs. This applies both to hosted Cloud Zero and AWS-managed instances. Keep that console-provided list current. During an egress IP change, temporarily allowing both the old and new listed addresses can prevent accidental breakage while you validate fresh connections. If you are self-hosting, use the public egress IPs of your own deployment. PlanetScale internal service roles are not usually part of your app role model. Do not add custom rules for internal pscale_* roles unless PlanetScale tells you to. The exception is app or automation roles you actually use, such as a pscale_api_* role that backs production automation. One common final rule layout looks like this:",
+    "kind": "section"
+  },
+  {
+    "id": "111-connecting-to-postgres#safe-rollout-for-role-scoped-restrictions",
+    "title": "Connecting to Postgres",
+    "searchTitle": "Safe rollout for role-scoped restrictions",
+    "sectionTitle": "Safe rollout for role-scoped restrictions",
+    "sectionId": "safe-rollout-for-role-scoped-restrictions",
+    "url": "/docs/connecting-to-postgres",
+    "content": "Use this order to avoid accidental lockouts: Inventory the roles that still need public access, including any pscale_api_* roles your automation actually uses. If the branch currently has no IP rules and you want a bridge while assembling the final rules, add a temporary blank-role 0.0.0.0/0. Add explicit role-scoped 0.0.0.0/0 rules for the existing app and user roles that should stay public, then validate fresh connections for those roles. Create or update the dedicated zero role and grants. Add the zero IP rule with only the Cloud Zero egress CIDRs. If you need to test from your laptop, temporarily append your operator /32 to that same zero rule, validate, then remove it. Remove the temporary blank-role catchall last, then validate fresh app connections again and confirm that zero is blocked from a non-allowlisted IP. PlanetScale may reject a second IP restriction record for the same database and role. If you need to temporarily allow an operator IP for testing, edit the existing Zero rule and add one more CIDR, then remove it after testing.",
+    "kind": "section"
+  },
+  {
+    "id": "112-connecting-to-postgres#practical-validation-checks",
+    "title": "Connecting to Postgres",
+    "searchTitle": "Practical validation checks",
+    "sectionTitle": "Practical validation checks",
+    "sectionId": "practical-validation-checks",
+    "url": "/docs/connecting-to-postgres",
+    "content": "After creating the role and applying the IP rule, validate it with a fresh psql connection as the zero role. Supply one replicated app table and check that the role can read app data, perform a no-op write against replicas inside a transaction, and create a temporary logical replication slot. export ZERO_PROBE_DSN='postgres://zero:<password>@db.example.com:5432/app' export ZERO_PROBE_SCHEMA='public' export ZERO_PROBE_TABLE='some_replicated_table' slot_name=\"zero_probe_$(date +%s)\" psql \"$ZERO_PROBE_DSN\" \\ -X \\ -v ON_ERROR_STOP=1 \\ -v zero_probe_schema=\"$ZERO_PROBE_SCHEMA\" \\ -v zero_probe_table=\"$ZERO_PROBE_TABLE\" \\ -v zero_probe_slot=\"$slot_name\" <<'SQL' SELECT current_user, inet_client_addr(); SELECT has_database_privilege(current_user, current_database(), 'CREATE'); SELECT format( 'SELECT 1 FROM %I.%I LIMIT 1', :'zero_probe_schema', :'zero_probe_table' ) WHERE :'zero_probe_schema' <> '' AND :'zero_probe_table' <> '' \\gexec BEGIN; SELECT format( 'UPDATE %I.%I SET version = version WHERE false', n.nspname, c.relname ) FROM pg_class AS c JOIN pg_namespace AS n ON n.oid = c.relnamespace WHERE n.nspname LIKE 'z\\_%' ESCAPE '\\' AND c.relname = 'replicas' AND c.relkind IN ('r', 'p') ORDER BY n.nspname LIMIT 1 \\gexec ROLLBACK; SELECT * FROM pg_create_logical_replication_slot( :'zero_probe_slot', 'pgoutput', true ); SQL PlanetScale currently supports PostgreSQL 17 and 18, so the third argument true form shown here is supported there. It requests a temporary logical replication slot. Choose a unique slot name. The no-op UPDATE ... WHERE false runs inside a transaction and rolls back, so it validates replicas write access without changing data. If no z_% schemas exist yet, that UPDATE check does nothing. Let Zero start once so it can create its own internal schemas, then rerun the script. Cleanup is automatic: the replication slot is temporary, so PostgreSQL drops it when the psql session ends. If you need to validate from a laptop, temporarily append your operator /32 to the existing Zero role rule, run the script, then remove that /32 and rerun the connection. The second run should fail before any SQL executes, which is the expected negative control.",
+    "kind": "section"
+  },
+  {
+    "id": "113-connecting-to-postgres#common-pitfalls",
+    "title": "Connecting to Postgres",
+    "searchTitle": "Common pitfalls",
+    "sectionTitle": "Common pitfalls",
+    "sectionId": "common-pitfalls",
+    "url": "/docs/connecting-to-postgres",
+    "content": "App-table SELECT alone is not enough. Zero also needs write access to its internal z_% schemas or you may see errors like permission denied for table replicas. A blank-role 0.0.0.0/0 rule defeats a restricted zero role while it exists. Preserve existing app and user roles with explicit role-scoped 0.0.0.0/0 rules before narrowing zero. PlanetScale may reject duplicate restriction records for the same database and role. Edit the existing zero rule instead. Validate fresh connections after each change. Long-lived existing connections are not enough to prove the rollout is safe.",
+    "kind": "section"
+  },
+  {
+    "id": "114-connecting-to-postgres#neon",
     "title": "Connecting to Postgres",
     "searchTitle": "Neon",
     "sectionTitle": "Neon",
@@ -569,7 +685,7 @@
     "kind": "section"
   },
   {
-    "id": "106-connecting-to-postgres#logical-replication",
+    "id": "115-connecting-to-postgres#logical-replication",
     "title": "Connecting to Postgres",
     "searchTitle": "Logical Replication",
     "sectionTitle": "Logical Replication",
@@ -579,7 +695,7 @@
     "kind": "section"
   },
   {
-    "id": "107-connecting-to-postgres#branching",
+    "id": "116-connecting-to-postgres#branching",
     "title": "Connecting to Postgres",
     "searchTitle": "Branching",
     "sectionTitle": "Branching",
@@ -589,7 +705,7 @@
     "kind": "section"
   },
   {
-    "id": "108-connecting-to-postgres#flyio",
+    "id": "117-connecting-to-postgres#flyio",
     "title": "Connecting to Postgres",
     "searchTitle": "Fly.io",
     "sectionTitle": "Fly.io",
@@ -599,7 +715,7 @@
     "kind": "section"
   },
   {
-    "id": "109-connecting-to-postgres#networking",
+    "id": "118-connecting-to-postgres#networking",
     "title": "Connecting to Postgres",
     "searchTitle": "Networking",
     "sectionTitle": "Networking",
@@ -609,7 +725,7 @@
     "kind": "section"
   },
   {
-    "id": "110-connecting-to-postgres#permissions",
+    "id": "119-connecting-to-postgres#permissions",
     "title": "Connecting to Postgres",
     "searchTitle": "Permissions",
     "sectionTitle": "Permissions",
@@ -619,7 +735,7 @@
     "kind": "section"
   },
   {
-    "id": "111-connecting-to-postgres#pooling",
+    "id": "120-connecting-to-postgres#pooling",
     "title": "Connecting to Postgres",
     "searchTitle": "Pooling",
     "sectionTitle": "Pooling",
@@ -629,27 +745,27 @@
     "kind": "section"
   },
   {
-    "id": "112-connecting-to-postgres#supabase",
+    "id": "121-connecting-to-postgres#supabase",
     "title": "Connecting to Postgres",
     "searchTitle": "Supabase",
     "sectionTitle": "Supabase",
     "sectionId": "supabase",
     "url": "/docs/connecting-to-postgres",
-    "content": "Supabase requires at least 15.8.1.083 for event trigger support. If you have a lower 15.x, Zero will still work but schema updates will be slower. See Supabase's docs for upgrading your Postgres version. Zero must use the \"Direct Connection\" string: This is because Zero sets up a logical replication slot, which is only supported with a direct connection. For ZERO_CVR_DB and ZERO_CHANGE_DB, prefer Supabase's session pooler. The transaction pooler can break prepared statements and cause errors like 26000 prepared statement ... does not exist. Publication Changes Supabase does not fire DDL event triggers for ALTER PUBLICATION. Starting in Zero >=v1.0, you can work around this by bookending each ALTER PUBLICATION statement with COMMENT ON PUBLICATION statements in the same transaction: BEGIN; COMMENT ON PUBLICATION zero_pub IS 'anything'; ALTER PUBLICATION zero_pub ADD TABLE ...; COMMENT ON PUBLICATION zero_pub IS 'anything'; -- ... other statements ... COMMIT; Both COMMENT ON PUBLICATION statements must target the publication being modified. All three statements must be in the same transaction, and the comment value can be anything. On non-Supabase Postgres, these COMMENT ON PUBLICATION statements are harmless when publication event triggers already work. Also, the event trigger messages emitted for this workaround are backwards compatible with the previous minor version of the processing code, so rolling back one minor version is safe. IPv4 You may also need to assign an IPv4 address to your Supabase instance: This will be required if you cannot use IPv6 from wherever zero-cache is running. Most cloud providers support IPv6, but some do not. For example, if you are running zero-cache in AWS, it is possible to use IPv6 but difficult. Hetzner offers cheap hosted VPS that supports IPv6. IPv4 addresses are only supported on the Pro plan and are an extra $4/month.",
+    "content": "Supabase requires at least 15.8.1.083 for event trigger support. If you have a lower 15.x, Zero will still work but schema updates will be slower. See Supabase's docs for upgrading your Postgres version. Zero must use the \"Direct Connection\" string: This is because Zero sets up a logical replication slot, which is only supported with a direct connection. For ZERO_CVR_DB and ZERO_CHANGE_DB, prefer Supabase's session pooler. The transaction pooler can break prepared statements and cause errors like 26000 prepared statement ... does not exist. Publication Changes Supabase does not fire DDL event triggers for ALTER PUBLICATION. Call a schema change hook after the ALTER PUBLICATION to replicate the change. IPv4 You may also need to assign an IPv4 address to your Supabase instance: This will be required if you cannot use IPv6 from wherever zero-cache is running. Most cloud providers support IPv6, but some do not. For example, if you are running zero-cache in AWS, it is possible to use IPv6 but difficult. Hetzner offers cheap hosted VPS that supports IPv6. IPv4 addresses are only supported on the Pro plan and are an extra $4/month.",
     "kind": "section"
   },
   {
-    "id": "113-connecting-to-postgres#publication-changes",
+    "id": "122-connecting-to-postgres#publication-changes",
     "title": "Connecting to Postgres",
     "searchTitle": "Publication Changes",
     "sectionTitle": "Publication Changes",
     "sectionId": "publication-changes",
     "url": "/docs/connecting-to-postgres",
-    "content": "Supabase does not fire DDL event triggers for ALTER PUBLICATION. Starting in Zero >=v1.0, you can work around this by bookending each ALTER PUBLICATION statement with COMMENT ON PUBLICATION statements in the same transaction: BEGIN; COMMENT ON PUBLICATION zero_pub IS 'anything'; ALTER PUBLICATION zero_pub ADD TABLE ...; COMMENT ON PUBLICATION zero_pub IS 'anything'; -- ... other statements ... COMMIT; Both COMMENT ON PUBLICATION statements must target the publication being modified. All three statements must be in the same transaction, and the comment value can be anything. On non-Supabase Postgres, these COMMENT ON PUBLICATION statements are harmless when publication event triggers already work. Also, the event trigger messages emitted for this workaround are backwards compatible with the previous minor version of the processing code, so rolling back one minor version is safe.",
+    "content": "Supabase does not fire DDL event triggers for ALTER PUBLICATION. Call a schema change hook after the ALTER PUBLICATION to replicate the change.",
     "kind": "section"
   },
   {
-    "id": "114-connecting-to-postgres#ipv4",
+    "id": "123-connecting-to-postgres#ipv4",
     "title": "Connecting to Postgres",
     "searchTitle": "IPv4",
     "sectionTitle": "IPv4",
@@ -659,23 +775,33 @@
     "kind": "section"
   },
   {
-    "id": "115-connecting-to-postgres#render",
+    "id": "124-connecting-to-postgres#render",
     "title": "Connecting to Postgres",
     "searchTitle": "Render",
     "sectionTitle": "Render",
     "sectionId": "render",
     "url": "/docs/connecting-to-postgres",
-    "content": "Render can work with Zero, but requires admin/support-side setup, and does not support a few core Zero features. App roles can't create event triggers, so schema changes will fall back to full resets. You also must ensure wal_level=logical by creating a Render support ticket. Render does not provide superuser access, but you can submit another support ticket to ask Render to create a publication with FOR ALL TABLES for you, and then set that publication in App Publications.",
+    "content": "Render can work with Zero, but requires admin/support-side setup, and does not support a few core Zero features. App roles can't create event triggers, so schema changes will fall back to full resets unless you use schema change hooks. You also must ensure wal_level=logical by creating a Render support ticket. Render does not provide superuser access, but you can submit another support ticket to ask Render to create a publication with FOR ALL TABLES for you, and then set that publication in App Publications.",
     "kind": "section"
   },
   {
-    "id": "116-connecting-to-postgres#google-cloud-sql",
+    "id": "125-connecting-to-postgres#google-cloud-sql",
     "title": "Connecting to Postgres",
     "searchTitle": "Google Cloud SQL",
     "sectionTitle": "Google Cloud SQL",
     "sectionId": "google-cloud-sql",
     "url": "/docs/connecting-to-postgres",
     "content": "Zero works with Google Cloud SQL out of the box. In many configurations, when you connect with a user that has sufficient privileges, zero-cache will create its default publication automatically. If your Cloud SQL user does not have permission to create publications, you can still use Zero by creating a publication manually and then specifying that publication name in App Publications when running zero-cache. On Google Cloud SQL for PostgreSQL, enable logical decoding by turning on the instance flag cloudsql.logical_decoding. You do not set wal_level directly on Cloud SQL. See Google's documentation for details: Configure logical replication.",
+    "kind": "section"
+  },
+  {
+    "id": "126-connecting-to-postgres#schema-change-hooks",
+    "title": "Connecting to Postgres",
+    "searchTitle": "Schema Change Hooks",
+    "sectionTitle": "Schema Change Hooks",
+    "sectionId": "schema-change-hooks",
+    "url": "/docs/connecting-to-postgres",
+    "content": "For providers that don't support or allow event triggers, Zero provides a manual hook you can call after a schema change to avoid a full reset. To enable the hook, first opt into manual DDL detection by setting ddlDetection to true in Zero's upstream shard config. With the default app id of zero and the default shard 0, that looks like: UPDATE zero_0.\"shardConfig\" SET \"ddlDetection\" = true; Then call update_schemas() after any DDL statements: SELECT zero_0.update_schemas(); It is important to call update_schemas() after the DDL statements but before any dependent data changes. A good way to do this is to wrap the DDL and the update_schemas() call in a single transaction: BEGIN; ALTER TABLE foo ADD COLUMN bar TEXT; CREATE INDEX foo_bar_idx ON foo(bar); SELECT zero_0.update_schemas(); COMMIT; You can also tell Zero about publication changes specifically by following the ALTER PUBLICATION with a COMMENT ON PUBLICATION statement: ALTER PUBLICATION zero_pub ADD TABLE ...; COMMENT ON PUBLICATION zero_pub IS 'anything'; It is still supported, but was replaced by update_schemas() because the latter is catches changes to any DDL, not just publication changes.",
     "kind": "section"
   },
   {
@@ -749,7 +875,7 @@
     "kind": "page"
   },
   {
-    "id": "117-connection#overview",
+    "id": "127-connection#overview",
     "title": "Connection Status",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -759,7 +885,7 @@
     "kind": "section"
   },
   {
-    "id": "118-connection#usage",
+    "id": "128-connection#usage",
     "title": "Connection Status",
     "searchTitle": "Usage",
     "sectionTitle": "Usage",
@@ -769,7 +895,7 @@
     "kind": "section"
   },
   {
-    "id": "119-connection#offline",
+    "id": "129-connection#offline",
     "title": "Connection Status",
     "searchTitle": "Offline",
     "sectionTitle": "Offline",
@@ -779,7 +905,7 @@
     "kind": "section"
   },
   {
-    "id": "120-connection#offline-ui",
+    "id": "130-connection#offline-ui",
     "title": "Connection Status",
     "searchTitle": "Offline UI",
     "sectionTitle": "Offline UI",
@@ -789,7 +915,7 @@
     "kind": "section"
   },
   {
-    "id": "121-connection#details",
+    "id": "131-connection#details",
     "title": "Connection Status",
     "searchTitle": "Details",
     "sectionTitle": "Details",
@@ -799,7 +925,7 @@
     "kind": "section"
   },
   {
-    "id": "122-connection#connecting",
+    "id": "132-connection#connecting",
     "title": "Connection Status",
     "searchTitle": "Connecting",
     "sectionTitle": "Connecting",
@@ -809,7 +935,7 @@
     "kind": "section"
   },
   {
-    "id": "123-connection#connected",
+    "id": "133-connection#connected",
     "title": "Connection Status",
     "searchTitle": "Connected",
     "sectionTitle": "Connected",
@@ -819,7 +945,7 @@
     "kind": "section"
   },
   {
-    "id": "124-connection#disconnected",
+    "id": "134-connection#disconnected",
     "title": "Connection Status",
     "searchTitle": "Disconnected",
     "sectionTitle": "Disconnected",
@@ -829,7 +955,7 @@
     "kind": "section"
   },
   {
-    "id": "125-connection#error",
+    "id": "135-connection#error",
     "title": "Connection Status",
     "searchTitle": "Error",
     "sectionTitle": "Error",
@@ -839,7 +965,7 @@
     "kind": "section"
   },
   {
-    "id": "126-connection#needs-auth",
+    "id": "136-connection#needs-auth",
     "title": "Connection Status",
     "searchTitle": "Needs-Auth",
     "sectionTitle": "Needs-Auth",
@@ -849,7 +975,7 @@
     "kind": "section"
   },
   {
-    "id": "127-connection#closed",
+    "id": "137-connection#closed",
     "title": "Connection Status",
     "searchTitle": "Closed",
     "sectionTitle": "Closed",
@@ -859,7 +985,7 @@
     "kind": "section"
   },
   {
-    "id": "128-connection#why-zero-doesnt-support-offline-writes",
+    "id": "138-connection#why-zero-doesnt-support-offline-writes",
     "title": "Connection Status",
     "searchTitle": "Why Zero Doesn't Support Offline Writes",
     "sectionTitle": "Why Zero Doesn't Support Offline Writes",
@@ -869,7 +995,7 @@
     "kind": "section"
   },
   {
-    "id": "129-connection#example",
+    "id": "139-connection#example",
     "title": "Connection Status",
     "searchTitle": "Example",
     "sectionTitle": "Example",
@@ -879,7 +1005,7 @@
     "kind": "section"
   },
   {
-    "id": "130-connection#tradeoffs",
+    "id": "140-connection#tradeoffs",
     "title": "Connection Status",
     "searchTitle": "Tradeoffs",
     "sectionTitle": "Tradeoffs",
@@ -889,7 +1015,7 @@
     "kind": "section"
   },
   {
-    "id": "131-connection#zeros-position",
+    "id": "141-connection#zeros-position",
     "title": "Connection Status",
     "searchTitle": "Zero's Position",
     "sectionTitle": "Zero's Position",
@@ -937,7 +1063,7 @@
     "kind": "page"
   },
   {
-    "id": "132-debug/analyze-query-cli#set-up",
+    "id": "142-debug/analyze-query-cli#set-up",
     "title": "Analyze Query CLI",
     "searchTitle": "Set Up",
     "sectionTitle": "Set Up",
@@ -947,7 +1073,7 @@
     "kind": "section"
   },
   {
-    "id": "133-debug/analyze-query-cli#run-zql-queries",
+    "id": "143-debug/analyze-query-cli#run-zql-queries",
     "title": "Analyze Query CLI",
     "searchTitle": "Run ZQL Queries",
     "sectionTitle": "Run ZQL Queries",
@@ -957,7 +1083,7 @@
     "kind": "section"
   },
   {
-    "id": "134-debug/analyze-query-cli#production-use",
+    "id": "144-debug/analyze-query-cli#production-use",
     "title": "Analyze Query CLI",
     "searchTitle": "Production Use",
     "sectionTitle": "Production Use",
@@ -967,7 +1093,7 @@
     "kind": "section"
   },
   {
-    "id": "135-debug/analyze-query-cli#env-var-shorthand",
+    "id": "145-debug/analyze-query-cli#env-var-shorthand",
     "title": "Analyze Query CLI",
     "searchTitle": "Env Var Shorthand",
     "sectionTitle": "Env Var Shorthand",
@@ -977,7 +1103,7 @@
     "kind": "section"
   },
   {
-    "id": "136-debug/analyze-query-cli#other-input-modes",
+    "id": "146-debug/analyze-query-cli#other-input-modes",
     "title": "Analyze Query CLI",
     "searchTitle": "Other Input Modes",
     "sectionTitle": "Other Input Modes",
@@ -987,7 +1113,7 @@
     "kind": "section"
   },
   {
-    "id": "137-debug/analyze-query-cli#output",
+    "id": "147-debug/analyze-query-cli#output",
     "title": "Analyze Query CLI",
     "searchTitle": "Output",
     "sectionTitle": "Output",
@@ -997,7 +1123,7 @@
     "kind": "section"
   },
   {
-    "id": "138-debug/analyze-query-cli#optional-output",
+    "id": "148-debug/analyze-query-cli#optional-output",
     "title": "Analyze Query CLI",
     "searchTitle": "Optional Output",
     "sectionTitle": "Optional Output",
@@ -1057,7 +1183,7 @@
     "kind": "page"
   },
   {
-    "id": "139-debug/inspector#accessing-the-inspector",
+    "id": "149-debug/inspector#accessing-the-inspector",
     "title": "Inspector",
     "searchTitle": "Accessing the Inspector",
     "sectionTitle": "Accessing the Inspector",
@@ -1067,7 +1193,7 @@
     "kind": "section"
   },
   {
-    "id": "140-debug/inspector#clients-and-groups",
+    "id": "150-debug/inspector#clients-and-groups",
     "title": "Inspector",
     "searchTitle": "Clients and Groups",
     "sectionTitle": "Clients and Groups",
@@ -1077,7 +1203,7 @@
     "kind": "section"
   },
   {
-    "id": "141-debug/inspector#queries",
+    "id": "151-debug/inspector#queries",
     "title": "Inspector",
     "searchTitle": "Queries",
     "sectionTitle": "Queries",
@@ -1087,7 +1213,7 @@
     "kind": "section"
   },
   {
-    "id": "142-debug/inspector#analyzing-queries",
+    "id": "152-debug/inspector#analyzing-queries",
     "title": "Inspector",
     "searchTitle": "Analyzing Queries",
     "sectionTitle": "Analyzing Queries",
@@ -1097,7 +1223,7 @@
     "kind": "section"
   },
   {
-    "id": "143-debug/inspector#interpreting-query-analysis",
+    "id": "153-debug/inspector#interpreting-query-analysis",
     "title": "Inspector",
     "searchTitle": "Interpreting Query Analysis",
     "sectionTitle": "Interpreting Query Analysis",
@@ -1107,7 +1233,7 @@
     "kind": "section"
   },
   {
-    "id": "144-debug/inspector#viewing-sqlite-plans",
+    "id": "154-debug/inspector#viewing-sqlite-plans",
     "title": "Inspector",
     "searchTitle": "Viewing SQLite Plans",
     "sectionTitle": "Viewing SQLite Plans",
@@ -1117,7 +1243,7 @@
     "kind": "section"
   },
   {
-    "id": "145-debug/inspector#viewing-zero-plans",
+    "id": "155-debug/inspector#viewing-zero-plans",
     "title": "Inspector",
     "searchTitle": "Viewing Zero Plans",
     "sectionTitle": "Viewing Zero Plans",
@@ -1127,7 +1253,7 @@
     "kind": "section"
   },
   {
-    "id": "146-debug/inspector#analyzing-arbitrary-zql",
+    "id": "156-debug/inspector#analyzing-arbitrary-zql",
     "title": "Inspector",
     "searchTitle": "Analyzing Arbitrary ZQL",
     "sectionTitle": "Analyzing Arbitrary ZQL",
@@ -1137,7 +1263,7 @@
     "kind": "section"
   },
   {
-    "id": "147-debug/inspector#table-data",
+    "id": "157-debug/inspector#table-data",
     "title": "Inspector",
     "searchTitle": "Table Data",
     "sectionTitle": "Table Data",
@@ -1147,7 +1273,7 @@
     "kind": "section"
   },
   {
-    "id": "148-debug/inspector#server-version",
+    "id": "158-debug/inspector#server-version",
     "title": "Inspector",
     "searchTitle": "Server Version",
     "sectionTitle": "Server Version",
@@ -1188,7 +1314,7 @@
     "kind": "page"
   },
   {
-    "id": "149-debug/replication#resetting",
+    "id": "159-debug/replication#resetting",
     "title": "Replication",
     "searchTitle": "Resetting",
     "sectionTitle": "Resetting",
@@ -1198,7 +1324,7 @@
     "kind": "section"
   },
   {
-    "id": "150-debug/replication#inspecting",
+    "id": "160-debug/replication#inspecting",
     "title": "Replication",
     "searchTitle": "Inspecting",
     "sectionTitle": "Inspecting",
@@ -1208,7 +1334,7 @@
     "kind": "section"
   },
   {
-    "id": "151-debug/replication#miscellaneous",
+    "id": "161-debug/replication#miscellaneous",
     "title": "Replication",
     "searchTitle": "Miscellaneous",
     "sectionTitle": "Miscellaneous",
@@ -1248,7 +1374,7 @@
     "kind": "page"
   },
   {
-    "id": "152-debug/slow-queries#analyze-queries",
+    "id": "162-debug/slow-queries#analyze-queries",
     "title": "Slow Queries",
     "searchTitle": "Analyze Queries",
     "sectionTitle": "Analyze Queries",
@@ -1258,7 +1384,7 @@
     "kind": "section"
   },
   {
-    "id": "153-debug/slow-queries#check-ttl",
+    "id": "163-debug/slow-queries#check-ttl",
     "title": "Slow Queries",
     "searchTitle": "Check ttl",
     "sectionTitle": "Check ttl",
@@ -1268,7 +1394,7 @@
     "kind": "section"
   },
   {
-    "id": "154-debug/slow-queries#locality",
+    "id": "164-debug/slow-queries#locality",
     "title": "Slow Queries",
     "searchTitle": "Locality",
     "sectionTitle": "Locality",
@@ -1278,7 +1404,7 @@
     "kind": "section"
   },
   {
-    "id": "155-debug/slow-queries#check-storage",
+    "id": "165-debug/slow-queries#check-storage",
     "title": "Slow Queries",
     "searchTitle": "Check Storage",
     "sectionTitle": "Check Storage",
@@ -1288,7 +1414,7 @@
     "kind": "section"
   },
   {
-    "id": "156-debug/slow-queries#statz",
+    "id": "166-debug/slow-queries#statz",
     "title": "Slow Queries",
     "searchTitle": "/statz",
     "sectionTitle": "/statz",
@@ -1321,7 +1447,7 @@
     "kind": "page"
   },
   {
-    "id": "157-deprecated/ad-hoc-queries#overview",
+    "id": "167-deprecated/ad-hoc-queries#overview",
     "title": "Ad-Hoc Queries (Deprecated)",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -1345,7 +1471,7 @@
     "kind": "page"
   },
   {
-    "id": "158-deprecated/crud-mutators#overview",
+    "id": "168-deprecated/crud-mutators#overview",
     "title": "CRUD Mutators (Deprecated)",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -1417,7 +1543,7 @@
     "kind": "page"
   },
   {
-    "id": "159-deprecated/rls-permissions#define-permissions",
+    "id": "169-deprecated/rls-permissions#define-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Define Permissions",
     "sectionTitle": "Define Permissions",
@@ -1427,7 +1553,7 @@
     "kind": "section"
   },
   {
-    "id": "160-deprecated/rls-permissions#access-is-denied-by-default",
+    "id": "170-deprecated/rls-permissions#access-is-denied-by-default",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Access is Denied by Default",
     "sectionTitle": "Access is Denied by Default",
@@ -1437,7 +1563,7 @@
     "kind": "section"
   },
   {
-    "id": "161-deprecated/rls-permissions#permission-evaluation",
+    "id": "171-deprecated/rls-permissions#permission-evaluation",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Permission Evaluation",
     "sectionTitle": "Permission Evaluation",
@@ -1447,7 +1573,7 @@
     "kind": "section"
   },
   {
-    "id": "162-deprecated/rls-permissions#permission-deployment",
+    "id": "172-deprecated/rls-permissions#permission-deployment",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Permission Deployment",
     "sectionTitle": "Permission Deployment",
@@ -1457,7 +1583,7 @@
     "kind": "section"
   },
   {
-    "id": "163-deprecated/rls-permissions#rules",
+    "id": "173-deprecated/rls-permissions#rules",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Rules",
     "sectionTitle": "Rules",
@@ -1467,7 +1593,7 @@
     "kind": "section"
   },
   {
-    "id": "164-deprecated/rls-permissions#select-permissions",
+    "id": "174-deprecated/rls-permissions#select-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Select Permissions",
     "sectionTitle": "Select Permissions",
@@ -1477,7 +1603,7 @@
     "kind": "section"
   },
   {
-    "id": "165-deprecated/rls-permissions#insert-permissions",
+    "id": "175-deprecated/rls-permissions#insert-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Insert Permissions",
     "sectionTitle": "Insert Permissions",
@@ -1487,7 +1613,7 @@
     "kind": "section"
   },
   {
-    "id": "166-deprecated/rls-permissions#update-permissions",
+    "id": "176-deprecated/rls-permissions#update-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Update Permissions",
     "sectionTitle": "Update Permissions",
@@ -1497,7 +1623,7 @@
     "kind": "section"
   },
   {
-    "id": "167-deprecated/rls-permissions#delete-permissions",
+    "id": "177-deprecated/rls-permissions#delete-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Delete Permissions",
     "sectionTitle": "Delete Permissions",
@@ -1507,7 +1633,7 @@
     "kind": "section"
   },
   {
-    "id": "168-deprecated/rls-permissions#permissions-based-on-auth-data",
+    "id": "178-deprecated/rls-permissions#permissions-based-on-auth-data",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Permissions Based on Auth Data",
     "sectionTitle": "Permissions Based on Auth Data",
@@ -1517,7 +1643,7 @@
     "kind": "section"
   },
   {
-    "id": "169-deprecated/rls-permissions#debugging",
+    "id": "179-deprecated/rls-permissions#debugging",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Debugging",
     "sectionTitle": "Debugging",
@@ -1527,7 +1653,7 @@
     "kind": "section"
   },
   {
-    "id": "170-deprecated/rls-permissions#read-permissions",
+    "id": "180-deprecated/rls-permissions#read-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Read Permissions",
     "sectionTitle": "Read Permissions",
@@ -1537,7 +1663,7 @@
     "kind": "section"
   },
   {
-    "id": "171-deprecated/rls-permissions#write-permissions",
+    "id": "181-deprecated/rls-permissions#write-permissions",
     "title": "RLS Permissions (Deprecated)",
     "searchTitle": "Write Permissions",
     "sectionTitle": "Write Permissions",
@@ -1551,7 +1677,7 @@
     "title": "Install Zero",
     "searchTitle": "Install Zero",
     "url": "/docs/install",
-    "content": "This guide shows how to add Zero to an existing TypeScript-based web app. For a concrete end-to-end walkthrough, build the music app in the tutorial. Integrate Zero Set Up Your Database You'll need a Postgres database with logical replication enabled for development. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Provider Support and make sure wal_level is logical. Create a .env file so your app server and zero-cache-dev use the same Postgres connection: # Update to your app's database connection URL ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install Zero Add Zero and the validator used in these examples: npm install @rocicorp/zero zodpnpm add @rocicorp/zero zod # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # } pnpm rebuild @rocicorp/zero-sqlite3bun add @rocicorp/zero zod # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero zod # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json, then rebuild the native packages: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } yarn rebuild @rocicorp/zero-sqlite3 These examples use Zod; any Standard Schema-compatible validator works. Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate the schema automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generate --output src/zero/schema.tspnpm add -D drizzle-zero pnpm exec drizzle-zero generate --output src/zero/schema.tsbun add -D drizzle-zero bunx drizzle-zero generate --output src/zero/schema.tsyarn add -D drizzle-zero yarn exec drizzle-zero generate --output src/zero/schema.tsnpm install -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } yarn prisma generate// src/zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Set Up the Zero Client Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. Choose the tab that most closely matches where your app creates its root layout or client instance. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero App</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero} Sync Data Define Query Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// src/api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries' import {schema} from '../zero/schema' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero' import {queries} from './zero/queries' const users = await zero.run(queries.allUsers()) More about Queries Filters, sorting, relationships, preloading, and more Server-driven authentication Mutate Data Define Mutators Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack. These examples assume the selected database client is already installed in your app. // src/zero/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from './schema' import * as drizzleSchema from '../drizzle/schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from './schema' import type {Database} from '../kysely/database' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const sql = postgres(connectionString) export const dbProvider = zeroPostgresJS(schema, sql) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// src/api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {dbProvider} from '../zero/db-provider' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Start your app server in another terminal, then run zero-cache locally with ZERO_QUERY_URL and ZERO_MUTATE_URL configured. If your app uses a different origin, update localhost:3000. ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev Invoke Mutators You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero' import {mutators} from './zero/mutators' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients. More about Mutators CRUD, server-specific code, permissions, and more Server-driven auth and Context Learn how to deploy your app to production",
+    "content": "This guide shows how to add Zero to an existing TypeScript-based web app. For a concrete end-to-end walkthrough, build the music app in the tutorial. Integrate Zero Set Up Your Database You'll need a Postgres database with logical replication enabled for development. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Provider Support and make sure wal_level is logical. Create a .env file so your app server and zero-cache-dev use the same Postgres connection: # Update to your app's database connection URL ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install Zero Add Zero and the validator used in these examples: npm install @rocicorp/zero zodpnpm add @rocicorp/zero zod # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then reinstall and rebuild the native package: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # } pnpm rebuild @rocicorp/zero-sqlite3bun add @rocicorp/zero zod # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero zod # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json, then rebuild the native packages: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } yarn rebuild @rocicorp/zero-sqlite3 These examples use Zod; any Standard Schema-compatible validator works. Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate the schema automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generate --output src/zero/schema.tspnpm add -D drizzle-zero pnpm exec drizzle-zero generate --output src/zero/schema.tsbun add -D drizzle-zero bunx drizzle-zero generate --output src/zero/schema.tsyarn add -D drizzle-zero yarn exec drizzle-zero generate --output src/zero/schema.tsnpm install -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } yarn prisma generate// src/zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Set Up the Zero Client Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. Choose the tab that most closely matches where your app creates its root layout or client instance. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero App</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero} Sync Data Define Query Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. This prevents clients from reading arbitrary data and is the basis of permissions. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(request: Request) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: event.request, userID: null }) return Response.json(result) }// src/api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries' import {schema} from '../zero/schema' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: c.req.raw, userID: null }) return c.json(result) }) Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero' import {queries} from './zero/queries' const users = await zero.run(queries.allUsers()) More about Queries Filters, sorting, relationships, preloading, and more Server-driven authentication Mutate Data Define Mutators Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack. These examples assume the selected database client is already installed in your app. // src/zero/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from './schema' import * as drizzleSchema from '../drizzle/schema' // If your app uses a different Drizzle driver, reuse your existing client. const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from './schema' import type {Database} from '../kysely/database' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const sql = postgres(connectionString) export const dbProvider = zeroPostgresJS(schema, sql) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(request: Request) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: event.request, userID: null }) return Response.json(result) }// src/api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {dbProvider} from '../zero/db-provider' app.post('/api/mutate', async c => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: c.req.raw, userID: null }) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Start your app server in another terminal, then run zero-cache locally with ZERO_QUERY_URL and ZERO_MUTATE_URL configured. If your app uses a different origin, update localhost:3000. ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev Invoke Mutators You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero' import {mutators} from './zero/mutators' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients. More about Mutators CRUD, server-specific code, permissions, and more Server-driven auth and Context Learn how to deploy your app to production",
     "headings": [
       {
         "text": "Integrate Zero",
@@ -1617,17 +1743,17 @@
     "kind": "page"
   },
   {
-    "id": "172-install#integrate-zero",
+    "id": "182-install#integrate-zero",
     "title": "Install Zero",
     "searchTitle": "Integrate Zero",
     "sectionTitle": "Integrate Zero",
     "sectionId": "integrate-zero",
     "url": "/docs/install",
-    "content": "Set Up Your Database You'll need a Postgres database with logical replication enabled for development. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Provider Support and make sure wal_level is logical. Create a .env file so your app server and zero-cache-dev use the same Postgres connection: # Update to your app's database connection URL ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install Zero Add Zero and the validator used in these examples: npm install @rocicorp/zero zodpnpm add @rocicorp/zero zod # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # } pnpm rebuild @rocicorp/zero-sqlite3bun add @rocicorp/zero zod # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero zod # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json, then rebuild the native packages: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } yarn rebuild @rocicorp/zero-sqlite3 These examples use Zod; any Standard Schema-compatible validator works. Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate the schema automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generate --output src/zero/schema.tspnpm add -D drizzle-zero pnpm exec drizzle-zero generate --output src/zero/schema.tsbun add -D drizzle-zero bunx drizzle-zero generate --output src/zero/schema.tsyarn add -D drizzle-zero yarn exec drizzle-zero generate --output src/zero/schema.tsnpm install -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } yarn prisma generate// src/zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Set Up the Zero Client Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. Choose the tab that most closely matches where your app creates its root layout or client instance. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero App</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero}",
+    "content": "Set Up Your Database You'll need a Postgres database with logical replication enabled for development. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Provider Support and make sure wal_level is logical. Create a .env file so your app server and zero-cache-dev use the same Postgres connection: # Update to your app's database connection URL ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install Zero Add Zero and the validator used in these examples: npm install @rocicorp/zero zodpnpm add @rocicorp/zero zod # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then reinstall and rebuild the native package: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # } pnpm rebuild @rocicorp/zero-sqlite3bun add @rocicorp/zero zod # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero zod # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json, then rebuild the native packages: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } yarn rebuild @rocicorp/zero-sqlite3 These examples use Zod; any Standard Schema-compatible validator works. Set Up Your Zero Schema Zero uses a file called schema.ts to provide a type-safe query API. If you use Drizzle or Prisma, you can generate the schema automatically. Otherwise, you can create it manually. npm install -D drizzle-zero npx drizzle-zero generate --output src/zero/schema.tspnpm add -D drizzle-zero pnpm exec drizzle-zero generate --output src/zero/schema.tsbun add -D drizzle-zero bunx drizzle-zero generate --output src/zero/schema.tsyarn add -D drizzle-zero yarn exec drizzle-zero generate --output src/zero/schema.tsnpm install -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } npx prisma generatepnpm add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } pnpx prisma generatebun add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } bunx prisma generateyarn add -D prisma-zero # Add this to prisma/schema.prisma: # generator zero { # provider = \"prisma-zero\" # output = \"../src/zero\" # } yarn prisma generate// src/zero/schema.ts import { boolean, createBuilder, createSchema, string, table } from '@rocicorp/zero' const user = table('user') .columns({ id: string(), name: string(), active: boolean() }) .primaryKey('id') export const schema = createSchema({ tables: [user] }) export const zql = createBuilder(schema) declare module '@rocicorp/zero' { interface DefaultTypes { schema: typeof schema } } Set Up the Zero Client Zero has first-class support for React and SolidJS, and there is also a low-level API you can use in any TypeScript-based project. Choose the tab that most closely matches where your app creates its root layout or client instance. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero App</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero}",
     "kind": "section"
   },
   {
-    "id": "173-install#set-up-your-database",
+    "id": "183-install#set-up-your-database",
     "title": "Install Zero",
     "searchTitle": "Set Up Your Database",
     "sectionTitle": "Set Up Your Database",
@@ -1637,17 +1763,17 @@
     "kind": "section"
   },
   {
-    "id": "174-install#install-zero",
+    "id": "184-install#install-zero",
     "title": "Install Zero",
     "searchTitle": "Install Zero",
     "sectionTitle": "Install Zero",
     "sectionId": "install-zero",
     "url": "/docs/install",
-    "content": "Add Zero and the validator used in these examples: npm install @rocicorp/zero zodpnpm add @rocicorp/zero zod # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # } pnpm rebuild @rocicorp/zero-sqlite3bun add @rocicorp/zero zod # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero zod # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json, then rebuild the native packages: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } yarn rebuild @rocicorp/zero-sqlite3 These examples use Zod; any Standard Schema-compatible validator works.",
+    "content": "Add Zero and the validator used in these examples: npm install @rocicorp/zero zodpnpm add @rocicorp/zero zod # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then reinstall and rebuild the native package: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # } pnpm rebuild @rocicorp/zero-sqlite3bun add @rocicorp/zero zod # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"]yarn add @rocicorp/zero zod # Note: Modern Yarn doesn't run postinstall scripts by default. # Add to package.json, then rebuild the native packages: # \"dependenciesMeta\": { # \"@rocicorp/zero-sqlite3\": { # \"built\": true # } # } yarn rebuild @rocicorp/zero-sqlite3 These examples use Zod; any Standard Schema-compatible validator works.",
     "kind": "section"
   },
   {
-    "id": "175-install#set-up-your-zero-schema",
+    "id": "185-install#set-up-your-zero-schema",
     "title": "Install Zero",
     "searchTitle": "Set Up Your Zero Schema",
     "sectionTitle": "Set Up Your Zero Schema",
@@ -1657,7 +1783,7 @@
     "kind": "section"
   },
   {
-    "id": "176-install#set-up-the-zero-client",
+    "id": "186-install#set-up-the-zero-client",
     "title": "Install Zero",
     "searchTitle": "Set Up the Zero Client",
     "sectionTitle": "Set Up the Zero Client",
@@ -1667,17 +1793,17 @@
     "kind": "section"
   },
   {
-    "id": "177-install#sync-data",
+    "id": "187-install#sync-data",
     "title": "Install Zero",
     "searchTitle": "Sync Data",
     "sectionTitle": "Sync Data",
     "sectionId": "sync-data",
     "url": "/docs/install",
-    "content": "Define Query Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// src/api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries' import {schema} from '../zero/schema' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero' import {queries} from './zero/queries' const users = await zero.run(queries.allUsers()) More about Queries Filters, sorting, relationships, preloading, and more Server-driven authentication",
+    "content": "Define Query Shared reads are conventionally stored in queries.ts. Use zql from schema.ts to construct and return a ZQL query: // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {zql} from './schema' export const queries = defineQueries({ allUsers: defineQuery(() => zql.user) }) See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. This prevents clients from reading arbitrary data and is the basis of permissions. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(request: Request) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: event.request, userID: null }) return Response.json(result) }// src/api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries' import {schema} from '../zero/schema' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: c.req.raw, userID: null }) return c.json(result) }) Invoke Query Querying for data is framework-specific. Most of the time, you will use a helper like useQuery that integrates into your framework's rendering model: import {useQuery} from '@rocicorp/zero/react' import {queries} from './zero/queries' const [users] = useQuery(queries.allUsers())import {useQuery} from '@rocicorp/zero/solid' import {queries} from './zero/queries' const [users] = useQuery(() => queries.allUsers())import {zero} from './zero' import {queries} from './zero/queries' const users = await zero.run(queries.allUsers()) More about Queries Filters, sorting, relationships, preloading, and more Server-driven authentication",
     "kind": "section"
   },
   {
-    "id": "178-install#define-query",
+    "id": "188-install#define-query",
     "title": "Install Zero",
     "searchTitle": "Define Query",
     "sectionTitle": "Define Query",
@@ -1687,17 +1813,17 @@
     "kind": "section"
   },
   {
-    "id": "179-install#add-query-endpoint",
+    "id": "189-install#add-query-endpoint",
     "title": "Install Zero",
     "searchTitle": "Add Query Endpoint",
     "sectionTitle": "Add Query Endpoint",
     "sectionId": "add-query-endpoint",
     "url": "/docs/install",
-    "content": "Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// src/api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries' import {schema} from '../zero/schema' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) })",
+    "content": "Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. This prevents clients from reading arbitrary data and is the basis of permissions. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(request: Request) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: event.request, userID: null }) return Response.json(result) }// src/api/app.ts import {Hono} from 'hono' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../zero/queries' import {schema} from '../zero/schema' const app = new Hono() app.post('/api/query', async c => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: c.req.raw, userID: null }) return c.json(result) })",
     "kind": "section"
   },
   {
-    "id": "180-install#invoke-query",
+    "id": "190-install#invoke-query",
     "title": "Install Zero",
     "searchTitle": "Invoke Query",
     "sectionTitle": "Invoke Query",
@@ -1707,7 +1833,7 @@
     "kind": "section"
   },
   {
-    "id": "181-install#more-about-queries",
+    "id": "191-install#more-about-queries",
     "title": "Install Zero",
     "searchTitle": "More about Queries",
     "sectionTitle": "More about Queries",
@@ -1717,17 +1843,17 @@
     "kind": "section"
   },
   {
-    "id": "182-install#mutate-data",
+    "id": "192-install#mutate-data",
     "title": "Install Zero",
     "searchTitle": "Mutate Data",
     "sectionTitle": "Mutate Data",
     "sectionId": "mutate-data",
     "url": "/docs/install",
-    "content": "Define Mutators Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack. These examples assume the selected database client is already installed in your app. // src/zero/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from './schema' import * as drizzleSchema from '../drizzle/schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from './schema' import type {Database} from '../kysely/database' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const sql = postgres(connectionString) export const dbProvider = zeroPostgresJS(schema, sql) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// src/api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {dbProvider} from '../zero/db-provider' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Start your app server in another terminal, then run zero-cache locally with ZERO_QUERY_URL and ZERO_MUTATE_URL configured. If your app uses a different origin, update localhost:3000. ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev Invoke Mutators You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero' import {mutators} from './zero/mutators' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients. More about Mutators CRUD, server-specific code, permissions, and more Server-driven auth and Context Learn how to deploy your app to production",
+    "content": "Define Mutators Data is written in Zero apps using mutators. Similar to queries, shared writes usually live in mutators.ts: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ activateUser: defineMutator( z.object({id: z.string()}), async ({args: {id}, tx}) => { await tx.mutate.user.update({id, active: true}) } ) }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack. These examples assume the selected database client is already installed in your app. // src/zero/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from './schema' import * as drizzleSchema from '../drizzle/schema' // If your app uses a different Drizzle driver, reuse your existing client. const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from './schema' import type {Database} from '../kysely/database' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const sql = postgres(connectionString) export const dbProvider = zeroPostgresJS(schema, sql) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(request: Request) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: event.request, userID: null }) return Response.json(result) }// src/api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {dbProvider} from '../zero/db-provider' app.post('/api/mutate', async c => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: c.req.raw, userID: null }) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Start your app server in another terminal, then run zero-cache locally with ZERO_QUERY_URL and ZERO_MUTATE_URL configured. If your app uses a different origin, update localhost:3000. ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev Invoke Mutators You can call a mutator with zero.mutate: import {useZero} from '@rocicorp/zero/react' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero.mutate(mutators.activateUser({id: '1'})) }import {useZero} from '@rocicorp/zero/solid' import {mutators} from './zero/mutators' const zero = useZero() const onClick = () => { zero().mutate(mutators.activateUser({id: '1'})) }import {zero} from './zero' import {mutators} from './zero/mutators' await zero.mutate(mutators.activateUser({id: '1'})) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients. More about Mutators CRUD, server-specific code, permissions, and more Server-driven auth and Context Learn how to deploy your app to production",
     "kind": "section"
   },
   {
-    "id": "183-install#define-mutators",
+    "id": "193-install#define-mutators",
     "title": "Install Zero",
     "searchTitle": "Define Mutators",
     "sectionTitle": "Define Mutators",
@@ -1737,17 +1863,17 @@
     "kind": "section"
   },
   {
-    "id": "184-install#add-mutate-endpoint",
+    "id": "194-install#add-mutate-endpoint",
     "title": "Install Zero",
     "searchTitle": "Add Mutate Endpoint",
     "sectionTitle": "Add Mutate Endpoint",
     "sectionId": "add-mutate-endpoint",
     "url": "/docs/install",
-    "content": "Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack. These examples assume the selected database client is already installed in your app. // src/zero/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from './schema' import * as drizzleSchema from '../drizzle/schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from './schema' import type {Database} from '../kysely/database' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const sql = postgres(connectionString) export const dbProvider = zeroPostgresJS(schema, sql) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// src/api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {dbProvider} from '../zero/db-provider' app.post('/api/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), c.req.raw ) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Start your app server in another terminal, then run zero-cache locally with ZERO_QUERY_URL and ZERO_MUTATE_URL configured. If your app uses a different origin, update localhost:3000. ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev",
+    "content": "Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. First, create a dbProvider with the Postgres adapter that matches your stack. These examples assume the selected database client is already installed in your app. // src/zero/db-provider.ts import {zeroDrizzle} from '@rocicorp/zero/server/adapters/drizzle' import {drizzle} from 'drizzle-orm/node-postgres' import {Pool} from 'pg' import {schema} from './schema' import * as drizzleSchema from '../drizzle/schema' // If your app uses a different Drizzle driver, reuse your existing client. const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const drizzleClient = drizzle(pool, { schema: drizzleSchema }) export const dbProvider = zeroDrizzle(schema, drizzleClient) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {Kysely, PostgresDialect} from 'kysely' import {zeroKysely} from '@rocicorp/zero/server/adapters/kysely' import {Pool} from 'pg' import {schema} from './schema' import type {Database} from '../kysely/database' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const kysely = new Kysely<Database>({ dialect: new PostgresDialect({ pool: new Pool({ connectionString }) }) }) export const dbProvider = zeroKysely(schema, kysely) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {PrismaPg} from '@prisma/adapter-pg' import {PrismaClient} from '@prisma/client' import {zeroPrisma} from '@rocicorp/zero/server/adapters/prisma' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) }) export const dbProvider = zeroPrisma(schema, prisma) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } }// src/zero/db-provider.ts import {zeroPostgresJS} from '@rocicorp/zero/server/adapters/postgresjs' import postgres from 'postgres' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const sql = postgres(connectionString) export const dbProvider = zeroPostgresJS(schema, sql) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Then use the dbProvider and helpers to define the mutate endpoint: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(request: Request) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: event.request, userID: null }) return Response.json(result) }// src/api/app.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {dbProvider} from '../zero/db-provider' app.post('/api/mutate', async c => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: c.req.raw, userID: null }) return c.json(result) }) Mutators on the server allow for write permissions and can be different from the client implementation. You can also do work after a mutation runs on the server, like send notifications. These examples have only public queries and mutators, so they do not pass a context. In authenticated apps, you should validate auth in the request, derive context from the session, and pass the context to the mutate and query handlers. See Authentication. Start your app server in another terminal, then run zero-cache locally with ZERO_QUERY_URL and ZERO_MUTATE_URL configured. If your app uses a different origin, update localhost:3000. ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ yarn exec zero-cache-dev",
     "kind": "section"
   },
   {
-    "id": "185-install#invoke-mutators",
+    "id": "195-install#invoke-mutators",
     "title": "Install Zero",
     "searchTitle": "Invoke Mutators",
     "sectionTitle": "Invoke Mutators",
@@ -1757,7 +1883,7 @@
     "kind": "section"
   },
   {
-    "id": "186-install#more-about-mutators",
+    "id": "196-install#more-about-mutators",
     "title": "Install Zero",
     "searchTitle": "More about Mutators",
     "sectionTitle": "More about Mutators",
@@ -1771,31 +1897,16 @@
     "title": "Welcome to Zero",
     "searchTitle": "Welcome to Zero",
     "url": "/docs/introduction",
-    "content": "Zero makes web apps feel instant by syncing the data your UI needs into a local, normalized client datastore. Reads and writes hit that local store first, then sync continuously with your server in the background. You control what syncs by writing normal queries in your app code, instead of syncing whole tables or maintaining static sync rules. Zero reuses cached data when it can and automatically falls back to the server when it needs more. Ready to get started? Build a new app with the tutorial Install Zero into an existing project Clone a starter app Play with a full-featured sample",
-    "headings": [
-      {
-        "text": "Ready to get started?",
-        "id": "ready-to-get-started"
-      }
-    ],
+    "content": "Zero makes web apps feel instant by syncing the data your UI needs into a local, normalized client datastore. Reads and writes hit that local store first, then sync continuously with your server in the background. You control what syncs by writing normal queries in your app code, instead of syncing whole tables or maintaining static sync rules. Zero reuses cached data when it can and automatically falls back to the server when it needs more.",
+    "headings": [],
     "kind": "page"
-  },
-  {
-    "id": "187-introduction#ready-to-get-started",
-    "title": "Welcome to Zero",
-    "searchTitle": "Ready to get started?",
-    "sectionTitle": "Ready to get started?",
-    "sectionId": "ready-to-get-started",
-    "url": "/docs/introduction",
-    "content": "Build a new app with the tutorial Install Zero into an existing project Clone a starter app Play with a full-featured sample",
-    "kind": "section"
   },
   {
     "id": "17-mutators",
     "title": "Mutators",
     "searchTitle": "Mutators",
     "url": "/docs/mutators",
-    "content": "Mutators are how you write data with Zero. Here's a simple example: // src/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ updateIssue: defineMutator( z.object({ id: z.string(), title: z.string() }), async ({tx, args: {id, title}}) => { if (title.length > 100) { throw new Error(`Title is too long`) } await tx.mutate.issue.update({ id, title }) } ) }) Architecture A copy of each mutator exists on both the client and on your server: Often the implementations will be the same, and you can just share their code. This is easy with full-stack frameworks like TanStack Start or Next.js. But the implementations don't have to be the same, or even compute the same result. For example, the server can add extra checks to enforce permissions, or send notifications or interact with other systems. Life of a Mutation When a mutator is invoked, it initially runs on the client, against the client-side datastore. Any changes are immediately applied to open queries and the user sees the changes. In the background, Zero sends a mutation (a record of the mutator having run with certain arguments) to your server's push endpoint. Your push endpoint runs the push protocol, executing the server-side mutator in a transaction against your database and recording the fact that the mutation ran. The @rocicorp/zero package contains utilities to make it easy to implement this endpoint in TypeScript. The changes to the database are then replicated to zero-cache using logical replication. zero-cache calculates the updates to active queries and sends rows that have changed to each client. It also sends information about the mutations that have been applied to the database. Clients receive row updates and apply them to their local cache. Any pending mutations which have been applied to the server have their local effects rolled back. Client-side queries are updated and the user sees the changes. Defining Mutators Basics Create a mutator using defineMutator. The only required argument is a MutatorFn, which must be async: import {defineMutator} from '@rocicorp/zero' const myMutator = defineMutator(async () => { // ... }) Mutators almost always complete in the same frame on the client, within milliseconds. The reason they are marked async is because on the server, reading from the tx object goes over the network to Postgres. Writing Data The MutatorFn receives a tx parameter which can be used to write data with a CRUD-style API. Each table in your Zero schema has a corresponding field on tx.mutate: const myMutator = defineMutator(async ({tx}) => { // This is here because there's a `user` table in your schema. await tx.mutate.user.insert(...) }) Mutators almost always run in the same frame on the client, against local data. The reason mutators are marked async is because on the server, reading from the tx object goes over the network to Postgres. Also, in edge cases on the client, reads and writes can go to local storage (IndexedDB or SQLite). Insert Create new records with insert: tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: 'js' }) Optional fields can be set to null to explicitly set the new field to null. They can also be set to undefined to take the default value (which is often null but can also be some generated value server-side): // Sets language to `null` specifically tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: null }) // Sets language to the default server-side value. // Could be null, or some generated or constant default value too. tx.mutate.user.insert({ id: 'user-123', username: 'sam' }) // Same as above tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: undefined }) Upsert Create new records or update existing ones with upsert: tx.mutate.user.upsert({ id: samID, username: 'sam', language: 'ts' }) upsert supports the same null / undefined semantics for optional fields that insert does (see above). Update Update an existing record. Does nothing if the specified record (by PK) does not exist. You can pass a partial object, leaving fields out that you don’t want to change. For example here we leave the username the same: // Leaves username field to previous value. tx.mutate.user.update({ id: samID, language: 'golang' }) // Same as above tx.mutate.user.update({ id: samID, username: undefined, language: 'haskell' }) // Reset language field to `null` tx.mutate.user.update({ id: samID, language: null }) Delete Delete an existing record. Does nothing if specified record does not exist. tx.mutate.user.delete({ id: samID }) Arguments The MutatorFn can take a single args parameter. To enable this, pass a validator to defineMutator: import {defineMutator} from '@rocicorp/zero' const initStats = defineMutator( z.object({issueCount: z.number()}), async ({tx, args: {issueCount}}) => { if (issueCount < 0) { throw new Error(`issueCount cannot be negative`) } await tx.mutate.stats.insert({ id: 'global', issueCount }) } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. It's most common for mutators to be a pure function of the database state plus arguments. But it's not required. Impure mutators can be useful, e.g., to consult some external system on the server for authorization or validation. Reading Data You can read data within a mutator by passing ZQL to tx.run: const updateIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { const issue = await tx.run( zql.issue.where('id', id).one() ) if (issue?.status === 'closed') { throw new Error(`Cannot update closed issue`) } await tx.mutate.issue.update({ id, title }) } ) You have the full power of ZQL at your disposal, including relationships, filters, ordering, and limits. Reads and writes within a mutator are transactional, meaning that the datastore is guaranteed to not change while your mutator is running. And if the mutator throws, the entire mutation is rolled back. Unlike zero.run(), there is no type parameter that can be used to wait for server results inside mutators. This is because waiting for server results in mutators makes no sense – it would defeat the purpose of running optimistically to begin with. When a mutator runs on the client (tx.location === \"client\"), ZQL reads only return data already cached on the client. When mutators run on the server (tx.location === \"server\"), ZQL reads always return all data. Context Mutator parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero mutators also support the concept of a context object. Access your context with the ctx parameter to your mutator: const createIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, ctx: {userID}, args: {id, title}}) => { // Note: User cannot control ctx.userID, so this // enforces authorship of created issue. await tx.mutate.issue.insert({ id, title, authorID: userID }) } ) If you don't want to register your Context and Schema types globally, you can use defineMutatorWithType and defineMutatorsWithType: import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {DrizzleTransaction} from '@rocicorp/zero/server/adapters/drizzle' import type {drizzleClient} from 'db-provider.ts' const defineMutator = defineMutatorWithType< Schema, ZeroContext, DrizzleTransaction<typeof drizzleClient> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {KyselyTransaction} from '@rocicorp/zero/server/adapters/kysely' import type {Database} from 'db-provider.ts' const defineMutator = defineMutatorWithType< Schema, ZeroContext, KyselyTransaction<Database> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {PrismaTransaction} from '@rocicorp/zero/server/adapters/prisma' import type {PrismaClient} from '@prisma/client' const defineMutator = defineMutatorWithType< Schema, ZeroContext, PrismaTransaction<PrismaClient> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {NodePgTransaction} from '@rocicorp/zero/server/adapters/pg' const defineMutator = defineMutatorWithType< Schema, ZeroContext, NodePgTransaction >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {PostgresJsTransaction} from '@rocicorp/zero/server/adapters/postgresjs' const defineMutator = defineMutatorWithType< Schema, ZeroContext, PostgresJsTransaction >() const defineMutators = defineMutatorsWithType<Schema>() Mutator Registries The result of defineMutator is a MutatorDefinition. By itself this isn't super useful. You need to register it using defineMutators: export const mutators = defineMutators({ issue: { update: updateIssue } }) Typically these are done together in one step: export const mutators = defineMutators({ issue: { update: defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { await tx.mutate.issue.update({ id, title }) } ) } }) The result of defineMutators is called a MutatorRegistry. Each field in the registry is a callable Mutator that you can use to perform mutations: import {mutators} from 'mutators.ts' zero.mutate( mutators.issue.update({ id: 'issue-123', title: 'New title' }) ) Mutator Names Each Mutator has a mutatorName which is computed by defineMutators. When you run a mutator, Zero sends this name along with the arguments to your server to execute the server-side mutation. console.log(mutators.issue.update.mutatorName) // \"issue.update\" mutators.ts By convention, mutators are listed in a central mutators.ts file. This allows them to be easily used on both the client and server: import {defineMutators, defineMutator} from '@rocicorp/zero' import {zql} from './schema.ts' import {z} from 'zod' export const mutators = defineMutators({ posts: { create: defineMutator( z.object({ id: z.string(), title: z.string() }), async ({ tx, context: {userID}, args: {id, title} }) => { await tx.mutate.post.insert({ id, title, authorID: userID }) } ), update: defineMutator( z.object({ id: z.string(), title: z.string().optional() }), async ({ tx, context: {userID}, args: {id, title} }) => { const prev = await tx.run( zql.post.where('id', id).one() ) if (prev?.authorID !== userID) { throw new Error(`Access denied`) } await tx.mutate.post.update({ id, title, authorID: userID }) } ) } }) You can use as many levels of nesting as you want to organize your mutators. As your application grows, you can move mutators to different files to keep them organized: // posts.ts export const postMutators = { create: defineMutator( z.object({ id: z.string(), title: z.string(), }), async ({tx, context: {userID}, args: {id, title}}) => { await tx.mutate.post.insert({ id, title, authorID: userID, }) }, ), } // user.ts export const userMutators = { updateRole: defineMutator( z.object({ role: z.string(), }), async ({tx, ctx: {userID}, args: {role}}) => { await tx.mutate.user.update({ id: userID, role, }) }, ), } // mutators.ts import {postMutators} from 'zero/mutators/posts.ts' import {userMutators} from 'zero/mutators/users.ts' export const mutators = defineMutators{{ posts: postMutators, users: userMutators, }) defineMutators establishes the full name for each mutator (i.e., posts.create, users.updateRole), which is later sent to the server. So this should only be used once at the top level of your mutators.ts file. Registration Before you can use your mutators, you need to register them with Zero: import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } const zero = new Zero(opts) Mutators need to be registered with Zero because Zero calls them during sync for conflict resolution. If you invoke a mutator that is not registered, Zero will throw an error. Server Setup In order for mutations to sync, you must provide an implementation of the mutate endpoint on your server. zero-cache calls this endpoint to process each mutation. Registering the Endpoint Use ZERO_MUTATE_URL to tell zero-cache where to find your mutate implementation: export ZERO_MUTATE_URL=\"http://localhost:3000/api/zero/mutate\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleMutateRequest and mustGetMutator functions to implement the endpoint. Plug in whatever dbProvider you set up (see server-zql or the install guide). // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), c.req.raw ) return c.json(result) }) Zero includes several built-in database adapters. You can also easily create your own. See ZQL on the Server for more information. handleMutateRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetMutator looks up the mutator in the registry and throws an error if not found. The mutator.fn function is your mutator implementation wrapped in the validator you provided. These examples have only public mutators, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the mutate handler. See Authentication. Handling Errors The handleMutateRequest function skips any mutations that throw: const result = await handleMutateRequest( dbProvider, transact => transact(async (tx, name, args) => { // The mutation is skipped and the next mutation runs as normal. // The optimistic mutation on the client will be reverted. throw new Error('bonk') }), c.req.raw ) handleMutateRequest catches such errors and turns them into a structured response that gets sent back to the client. You can recover the errors and show UI if you want. It is also of course possible for the entire push endpoint to return an HTTP error, or to not reply at all: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async () => { throw new Error('zonk') // will trigger resend } } } })export async function POST() { throw new Error('zonk') // will trigger resend }export async function POST() { throw new Error('zonk') // will trigger resend }app.post('/api/zero/mutate', async c => { // This will cause the client to resend all queued mutations. throw new Error('zonk') }) If Zero receives any response from the mutate endpoint other than HTTP 200, 401, or 403, it will disconnect and enter the error state. If Zero receives HTTP 401 or 403, the client will enter the needs auth state and require a manual reconnect. Use zero.connection.connect() for cookie auth or zero.connection.connect({auth: newToken}) for token auth, then Zero will retry all queued mutations. If you want a different behavior, it is possible to implement the mutate endpoint yourself and handle errors differently. Custom Mutate URL By default, Zero sends mutations to the URL specified in the ZERO_MUTATE_URL parameter. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in the ZERO_MUTATE_URL parameter: export ZERO_MUTATE_URL=\"https://api.example.com/mutate,https://api.staging.example.com/mutate\" Then choose one of those URLs by passing it to mutateURL on the Zero constructor: const opts: ZeroOptions = { // ... mutateURL: 'https://api.staging.example.com/mutate' } URL Patterns The strings listed in ZERO_MUTATE_URL can also be URLPatterns: export ZERO_MUTATE_URL=\"https://mybranch-*.preview.myapp.com/mutate\" For more information, see the URLPattern section of the Queries docs. It works the same way for mutations. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints. Server-Specific Code To implement server-specific code, just run different mutators in your mutate endpoint. Server authority to the rescue! defineMutators accepts a baseMutators parameter that makes this easy. The returned mutator registry will contain all the mutators from baseMutators, plus any new ones you define or override: // server-mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' import {zql} from 'schema.ts' import {mutators as sharedMutators} from 'mutators.ts' export const serverMutators = defineMutators( sharedMutators, { posts: { // Overrides the shared mutator definition with same name. update: defineMutator( z.object({ id: z.string(), title: z.string().optional(), priority: z.number().optional() }), async ({ tx, ctx: {userID}, args: {id, title, priority} }) => { // Run the shared mutator first. await sharedMutators.posts.update.fn({ tx, ctx, args }) // Record a history of this operation happening in an audit log table. await tx.mutate.auditLog.insert({ issueId: id, action: 'update-title', timestamp: Date.getTime() }) } ) } } ) For simple things, we also expose a location field on the transaction object that you can use to branch your code: const myMutator = defineMutator(async ({tx}) => { if (tx.location === 'client') { // Client-side code } else { // Server-side code } }) Running Mutators Once you have registered your mutators, you can invoke them with zero.mutate: import {mutators} from 'mutators.ts' zero.mutate( mutators.issue.update({ id: crypto.randomUUID(), title: 'New title' }) ) Client-generated random IDs from crypto.randomUUID(), uuid, ulid, or nanoid work much better with sync engines like Zero. See IDs for more details. Waiting for Results We typically recommend that you \"fire and forget\" mutators. Optimistic mutations make sense when the common case is that a mutation succeeds. If a mutation frequently fails, then showing the user an optimistic result isn't very useful, because it will likely be wrong. That said there are cases where it is nice to know when a write succeeded on either the client or server. One example is if you need to read a row directly after writing it. Zero's local writes are very fast (almost always < 1 frame), but because Zero is backed by IndexedDB, writes are still technically asynchronous and reads directly after a write may not return the new data. You can use the .client promise in this case to wait for a write to complete on the client side: const write = zero.mutate( mutators.issue.insert({ id: crypto.randomUUID(), title: 'New title' }) ) // issue-123 not guaranteed to be present here. read1 may be undefined. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await client write – almost always less than 1 frame, and same // macrotask, so no browser paint will occur here. const res = await write.client if (res.type === 'error') { console.error('Mutator failed on client', res.error) } // issue-123 definitely can be read now. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) You can also wait for the server write to succeed: const write = zero.mutate( mutators.issue.insert({ id: crypto.randomUUID(), title: 'New title' }) ) const clientRes = await write.client if (clientRes.type === 'error') { throw new Error( `Mutator failed on client`, clientRes.error ) } // optimistic write guaranteed to be present here, but not // server write. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await server write – this involves a round-trip. const serverRes = await write.server if (serverRes.type === 'error') { throw new Error( `Mutator failed on server`, serverRes.error ) } // issue-123 is written to server and any results are // synced to this client. // read2 could potentially be undefined here, for example if the // server mutator rejected the write. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) If the client-side mutator fails, the .server promise is also rejected with the same error. You don't have to listen to both promises, the server promise covers both cases. There is not yet a way to return data from mutators in the success case. Let us know if you need this. Permissions Because mutators are just normal TypeScript functions that run server-side, there is no need for a special permissions system. You can implement whatever permission checks you want using plain TypeScript code. See Permissions for more information. Dropping Down to Raw SQL The ServerTransaction interface has a dbTransaction property that exposes the underlying database connection. This allows you to run raw SQL queries directly against the database. This is useful for complex queries, or for using Postgres features that Zero doesn't support yet: const markAllAsRead = defineMutator( z.object({ userId: z.string() }), async ({tx, args: {userId}}) => { // shared stuff ... if (tx.location === 'server') { // `tx` is now narrowed to `ServerTransaction`. // Do special server-only stuff with raw SQL. await tx.dbTransaction.query( ` UPDATE notification SET read = true WHERE user_id = $1 `, [userId] ) } } ) See ZQL on the Server for more information. Notifications and Async Work The best way to handle notifications and async work is a transactional outbox. This ensures that notifications actually do eventually get sent, without holding open database transactions to talk over the network. This can be implemented very easily in Zero by writing notifications to an outbox table as part of your mutator, then processing that table periodically with a background job. However sometimes it's still nice to do a quick and dirty async send as part of a mutation, for example early on in development, or to record metrics. For this, the createMutators pattern is useful: // server-mutators.ts import {defineMutator} from '@rocicorp/zero' import z from 'zod' import {zql} from 'schema.ts' import {mutators as clientMutators} from 'mutators.ts' // Instead of defining server mutators as a constant, // define them as a function of a list of async tasks. export function createMutators( asyncTasks: Array<() => Promise<void>> ) { return defineMutators(clientMutators, { issue: { update: defineMutator( z.object({ id: z.string(), title: z.string() }), async (tx, {id, title}) => { await tx.mutate.issue.update({id, title}) asyncTasks.push(() => sendEmailToSubscribers(id)) } ) } }) } Then in your mutate handler: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), request ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled( asyncTasks.map(task => task()) ) return Response.json(result) } } } })export async function POST(req: Request) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), req ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }export async function POST(event: APIEvent) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), event.request ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }app.post('/api/zero/mutate', async c => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), c.req.raw ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return c.json(result) }) Custom Mutate Implementation You can manually implement the mutate endpoint in any programming language. This will be documented in the future, but you can refer to the handleMutateRequest source code for an example for now.",
+    "content": "Mutators are how you write data with Zero. Here's a simple example: // src/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ updateIssue: defineMutator( z.object({ id: z.string(), title: z.string() }), async ({tx, args: {id, title}}) => { if (title.length > 100) { throw new Error(`Title is too long`) } await tx.mutate.issue.update({ id, title }) } ) }) Architecture A copy of each mutator exists on both the client and on your server: Often the implementations will be the same, and you can just share their code. This is easy with full-stack frameworks like TanStack Start or Next.js. But the implementations don't have to be the same, or even compute the same result. For example, the server can add extra checks to enforce permissions, or send notifications or interact with other systems. Life of a Mutation When a mutator is invoked, it initially runs on the client, against the client-side datastore. Any changes are immediately applied to open queries and the user sees the changes. In the background, Zero sends a mutation (a record of the mutator having run with certain arguments) to your server's push endpoint. Your push endpoint runs the push protocol, executing the server-side mutator in a transaction against your database and recording the fact that the mutation ran. The @rocicorp/zero package contains utilities to make it easy to implement this endpoint in TypeScript. The changes to the database are then replicated to zero-cache using logical replication. zero-cache calculates the updates to active queries and sends rows that have changed to each client. It also sends information about the mutations that have been applied to the database. Clients receive row updates and apply them to their local cache. Any pending mutations which have been applied to the server have their local effects rolled back. Client-side queries are updated and the user sees the changes. Defining Mutators Basics Create a mutator using defineMutator. The only required argument is a MutatorFn, which must be async: import {defineMutator} from '@rocicorp/zero' const myMutator = defineMutator(async () => { // ... }) Mutators almost always complete in the same frame on the client, within milliseconds. The reason they are marked async is because on the server, reading from the tx object goes over the network to Postgres. Writing Data The MutatorFn receives a tx parameter which can be used to write data with a CRUD-style API. Each table in your Zero schema has a corresponding field on tx.mutate: const myMutator = defineMutator(async ({tx}) => { // This is here because there's a `user` table in your schema. await tx.mutate.user.insert(...) }) Mutators almost always run in the same frame on the client, against local data. The reason mutators are marked async is because on the server, reading from the tx object goes over the network to Postgres. Also, in edge cases on the client, reads and writes can go to local storage (IndexedDB or SQLite). Insert Create new records with insert: tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: 'js' }) Optional fields can be set to null to explicitly set the new field to null. They can also be set to undefined to take the default value (which is often null but can also be some generated value server-side): // Sets language to `null` specifically tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: null }) // Sets language to the default server-side value. // Could be null, or some generated or constant default value too. tx.mutate.user.insert({ id: 'user-123', username: 'sam' }) // Same as above tx.mutate.user.insert({ id: 'user-123', username: 'sam', language: undefined }) Upsert Create new records or update existing ones with upsert: tx.mutate.user.upsert({ id: samID, username: 'sam', language: 'ts' }) upsert supports the same null / undefined semantics for optional fields that insert does (see above). Update Update an existing record. Does nothing if the specified record (by PK) does not exist. You can pass a partial object, leaving fields out that you don’t want to change. For example here we leave the username the same: // Leaves username field to previous value. tx.mutate.user.update({ id: samID, language: 'golang' }) // Same as above tx.mutate.user.update({ id: samID, username: undefined, language: 'haskell' }) // Reset language field to `null` tx.mutate.user.update({ id: samID, language: null }) Delete Delete an existing record. Does nothing if specified record does not exist. tx.mutate.user.delete({ id: samID }) Arguments The MutatorFn can take a single args parameter. To enable this, pass a validator to defineMutator: import {defineMutator} from '@rocicorp/zero' const initStats = defineMutator( z.object({issueCount: z.number()}), async ({tx, args: {issueCount}}) => { if (issueCount < 0) { throw new Error(`issueCount cannot be negative`) } await tx.mutate.stats.insert({ id: 'global', issueCount }) } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. It's most common for mutators to be a pure function of the database state plus arguments. But it's not required. Impure mutators can be useful, e.g., to consult some external system on the server for authorization or validation. Reading Data You can read data within a mutator by passing ZQL to tx.run: const updateIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { const issue = await tx.run( zql.issue.where('id', id).one() ) if (issue?.status === 'closed') { throw new Error(`Cannot update closed issue`) } await tx.mutate.issue.update({ id, title }) } ) You have the full power of ZQL at your disposal, including relationships, filters, ordering, and limits. Reads and writes within a mutator are transactional, meaning that the datastore is guaranteed to not change while your mutator is running. And if the mutator throws, the entire mutation is rolled back. Unlike zero.run(), there is no type parameter that can be used to wait for server results inside mutators. This is because waiting for server results in mutators makes no sense – it would defeat the purpose of running optimistically to begin with. When a mutator runs on the client (tx.location === \"client\"), ZQL reads only return data already cached on the client. When mutators run on the server (tx.location === \"server\"), ZQL reads always return all data. Context Mutator parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero mutators also support the concept of a context object. Access your context with the ctx parameter to your mutator: const createIssue = defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, ctx: {userID}, args: {id, title}}) => { // Note: User cannot control ctx.userID, so this // enforces authorship of created issue. await tx.mutate.issue.insert({ id, title, authorID: userID }) } ) If you don't want to register your Context and Schema types globally, you can use defineMutatorWithType and defineMutatorsWithType: import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {DrizzleTransaction} from '@rocicorp/zero/server/adapters/drizzle' import type {drizzleClient} from 'db-provider.ts' const defineMutator = defineMutatorWithType< Schema, ZeroContext, DrizzleTransaction<typeof drizzleClient> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {KyselyTransaction} from '@rocicorp/zero/server/adapters/kysely' import type {Database} from 'db-provider.ts' const defineMutator = defineMutatorWithType< Schema, ZeroContext, KyselyTransaction<Database> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {PrismaTransaction} from '@rocicorp/zero/server/adapters/prisma' import type {PrismaClient} from '@prisma/client' const defineMutator = defineMutatorWithType< Schema, ZeroContext, PrismaTransaction<PrismaClient> >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {NodePgTransaction} from '@rocicorp/zero/server/adapters/pg' const defineMutator = defineMutatorWithType< Schema, ZeroContext, NodePgTransaction >() const defineMutators = defineMutatorsWithType<Schema>()import { defineMutatorWithType, defineMutatorsWithType } from '@rocicorp/zero' import type {ZeroContext} from 'context.ts' import type {Schema} from 'schema.ts' import type {PostgresJsTransaction} from '@rocicorp/zero/server/adapters/postgresjs' const defineMutator = defineMutatorWithType< Schema, ZeroContext, PostgresJsTransaction >() const defineMutators = defineMutatorsWithType<Schema>() Mutator Registries The result of defineMutator is a MutatorDefinition. By itself this isn't super useful. You need to register it using defineMutators: export const mutators = defineMutators({ issue: { update: updateIssue } }) Typically these are done together in one step: export const mutators = defineMutators({ issue: { update: defineMutator( z.object({id: z.string(), title: z.string()}), async ({tx, args: {id, title}}) => { await tx.mutate.issue.update({ id, title }) } ) } }) The result of defineMutators is called a MutatorRegistry. Each field in the registry is a callable Mutator that you can use to perform mutations: import {mutators} from 'mutators.ts' zero.mutate( mutators.issue.update({ id: 'issue-123', title: 'New title' }) ) Mutator Names Each Mutator has a mutatorName which is computed by defineMutators. When you run a mutator, Zero sends this name along with the arguments to your server to execute the server-side mutation. console.log(mutators.issue.update.mutatorName) // \"issue.update\" mutators.ts By convention, mutators are listed in a central mutators.ts file. This allows them to be easily used on both the client and server: import {defineMutators, defineMutator} from '@rocicorp/zero' import {zql} from './schema.ts' import {z} from 'zod' export const mutators = defineMutators({ posts: { create: defineMutator( z.object({ id: z.string(), title: z.string() }), async ({ tx, context: {userID}, args: {id, title} }) => { await tx.mutate.post.insert({ id, title, authorID: userID }) } ), update: defineMutator( z.object({ id: z.string(), title: z.string().optional() }), async ({ tx, context: {userID}, args: {id, title} }) => { const prev = await tx.run( zql.post.where('id', id).one() ) if (prev?.authorID !== userID) { throw new Error(`Access denied`) } await tx.mutate.post.update({ id, title, authorID: userID }) } ) } }) You can use as many levels of nesting as you want to organize your mutators. As your application grows, you can move mutators to different files to keep them organized: // posts.ts export const postMutators = { create: defineMutator( z.object({ id: z.string(), title: z.string(), }), async ({tx, context: {userID}, args: {id, title}}) => { await tx.mutate.post.insert({ id, title, authorID: userID, }) }, ), } // user.ts export const userMutators = { updateRole: defineMutator( z.object({ role: z.string(), }), async ({tx, ctx: {userID}, args: {role}}) => { await tx.mutate.user.update({ id: userID, role, }) }, ), } // mutators.ts import {postMutators} from 'zero/mutators/posts.ts' import {userMutators} from 'zero/mutators/users.ts' export const mutators = defineMutators{{ posts: postMutators, users: userMutators, }) defineMutators establishes the full name for each mutator (i.e., posts.create, users.updateRole), which is later sent to the server. So this should only be used once at the top level of your mutators.ts file. Registration Before you can use your mutators, you need to register them with Zero: import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } return ( <ZeroProvider {...opts}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from 'zero/mutators.ts' const opts: ZeroOptions = { // ... cacheURL, schema, etc. mutators } const zero = new Zero(opts) Mutators need to be registered with Zero because Zero calls them during sync for conflict resolution. If you invoke a mutator that is not registered, Zero will throw an error. Server Setup In order for mutations to sync, you must provide an implementation of the mutate endpoint on your server. zero-cache calls this endpoint to process each mutation. Registering the Endpoint Use ZERO_MUTATE_URL to tell zero-cache where to find your mutate implementation: export ZERO_MUTATE_URL=\"http://localhost:3000/api/zero/mutate\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleMutateRequest and mustGetMutator functions to implement the endpoint. Plug in whatever dbProvider you set up (see server-zql or the install guide). // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request, userID: null }) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(request: Request) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: event.request, userID: null }) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request: c.req.raw, userID: null }) return c.json(result) }) Zero includes several built-in database adapters. You can also easily create your own. See ZQL on the Server for more information. handleMutateRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetMutator looks up the mutator in the registry and throws an error if not found. The mutator.fn function is your mutator implementation wrapped in the validator you provided. These examples have only public mutators, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the mutate handler. See Authentication. Handling Errors The handleMutateRequest function skips any mutations that throw: const result = await handleMutateRequest({ dbProvider, handler: transact => transact(async (tx, name, args) => { // The mutation is skipped and the next mutation runs as normal. // The optimistic mutation on the client will be reverted. throw new Error('bonk') }), request: c.req.raw, userID: null }) handleMutateRequest catches such errors and turns them into a structured response that gets sent back to the client. You can recover the errors and show UI if you want. It is also of course possible for the entire push endpoint to return an HTTP error, or to not reply at all: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async () => { throw new Error('zonk') // will trigger resend } } } })export async function POST() { throw new Error('zonk') // will trigger resend }export async function POST() { throw new Error('zonk') // will trigger resend }app.post('/api/zero/mutate', async c => { // This will cause the client to resend all queued mutations. throw new Error('zonk') }) If Zero receives any response from the mutate endpoint other than HTTP 200, 401, or 403, it will disconnect and enter the error state. If Zero receives HTTP 401 or 403, the client will enter the needs auth state and require a manual reconnect. Use zero.connection.connect() for cookie auth or zero.connection.connect({auth: newToken}) for token auth, then Zero will retry all queued mutations. If you want a different behavior, it is possible to implement the mutate endpoint yourself and handle errors differently. Custom Mutate URL By default, Zero sends mutations to the URL specified in the ZERO_MUTATE_URL parameter. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in the ZERO_MUTATE_URL parameter: export ZERO_MUTATE_URL=\"https://api.example.com/mutate,https://api.staging.example.com/mutate\" Then choose one of those URLs by passing it to mutateURL on the Zero constructor: const opts: ZeroOptions = { // ... mutateURL: 'https://api.staging.example.com/mutate' } URL Patterns The strings listed in ZERO_MUTATE_URL can also be URLPatterns: export ZERO_MUTATE_URL=\"https://mybranch-*.preview.myapp.com/mutate\" For more information, see the URLPattern section of the Queries docs. It works the same way for mutations. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints. Server-Specific Code To implement server-specific code, just run different mutators in your mutate endpoint. Server authority to the rescue! defineMutators accepts a baseMutators parameter that makes this easy. The returned mutator registry will contain all the mutators from baseMutators, plus any new ones you define or override: // server-mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' import {zql} from 'schema.ts' import {mutators as sharedMutators} from 'mutators.ts' export const serverMutators = defineMutators( sharedMutators, { posts: { // Overrides the shared mutator definition with same name. update: defineMutator( z.object({ id: z.string(), title: z.string().optional(), priority: z.number().optional() }), async ({ tx, ctx: {userID}, args: {id, title, priority} }) => { // Run the shared mutator first. await sharedMutators.posts.update.fn({ tx, ctx, args }) // Record a history of this operation happening in an audit log table. await tx.mutate.auditLog.insert({ issueId: id, action: 'update-title', timestamp: Date.getTime() }) } ) } } ) For simple things, we also expose a location field on the transaction object that you can use to branch your code: const myMutator = defineMutator(async ({tx}) => { if (tx.location === 'client') { // Client-side code } else { // Server-side code } }) Running Mutators Once you have registered your mutators, you can invoke them with zero.mutate: import {mutators} from 'mutators.ts' zero.mutate( mutators.issue.update({ id: crypto.randomUUID(), title: 'New title' }) ) Client-generated random IDs from crypto.randomUUID(), uuid, ulid, or nanoid work much better with sync engines like Zero. See IDs for more details. Waiting for Results We typically recommend that you \"fire and forget\" mutators. Optimistic mutations make sense when the common case is that a mutation succeeds. If a mutation frequently fails, then showing the user an optimistic result isn't very useful, because it will likely be wrong. That said there are cases where it is nice to know when a write succeeded on either the client or server. One example is if you need to read a row directly after writing it. Zero's local writes are very fast (almost always < 1 frame), but because Zero is backed by IndexedDB, writes are still technically asynchronous and reads directly after a write may not return the new data. You can use the .client promise in this case to wait for a write to complete on the client side: const write = zero.mutate( mutators.issue.insert({ id: crypto.randomUUID(), title: 'New title' }) ) // issue-123 not guaranteed to be present here. read1 may be undefined. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await client write – almost always less than 1 frame, and same // macrotask, so no browser paint will occur here. const res = await write.client if (res.type === 'error') { console.error('Mutator failed on client', res.error) } // issue-123 definitely can be read now. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) You can also wait for the server write to succeed: const write = zero.mutate( mutators.issue.insert({ id: crypto.randomUUID(), title: 'New title' }) ) const clientRes = await write.client if (clientRes.type === 'error') { throw new Error( `Mutator failed on client`, clientRes.error ) } // optimistic write guaranteed to be present here, but not // server write. const read1 = await zero.run( queries.issue.byId('issue-123').one() ) // Await server write – this involves a round-trip. const serverRes = await write.server if (serverRes.type === 'error') { throw new Error( `Mutator failed on server`, serverRes.error ) } // issue-123 is written to server and any results are // synced to this client. // read2 could potentially be undefined here, for example if the // server mutator rejected the write. const read2 = await zero.run( queries.issue.byId('issue-123').one() ) If the client-side mutator fails, the .server promise is also rejected with the same error. You don't have to listen to both promises, the server promise covers both cases. There is not yet a way to return data from mutators in the success case. Let us know if you need this. Permissions Because mutators are just normal TypeScript functions that run server-side, there is no need for a special permissions system. You can implement whatever permission checks you want using plain TypeScript code. See Permissions for more information. Dropping Down to Raw SQL The ServerTransaction interface has a dbTransaction property that exposes the underlying database connection. This allows you to run raw SQL queries directly against the database. This is useful for complex queries, or for using Postgres features that Zero doesn't support yet: const markAllAsRead = defineMutator( z.object({ userId: z.string() }), async ({tx, args: {userId}}) => { // shared stuff ... if (tx.location === 'server') { // `tx` is now narrowed to `ServerTransaction`. // Do special server-only stuff with raw SQL. await tx.dbTransaction.query( ` UPDATE notification SET read = true WHERE user_id = $1 `, [userId] ) } } ) See ZQL on the Server for more information. Notifications and Async Work The best way to handle notifications and async work is a transactional outbox. This ensures that notifications actually do eventually get sent, without holding open database transactions to talk over the network. This can be implemented very easily in Zero by writing notifications to an outbox table as part of your mutator, then processing that table periodically with a background job. However sometimes it's still nice to do a quick and dirty async send as part of a mutation, for example early on in development, or to record metrics. For this, the createMutators pattern is useful: // server-mutators.ts import {defineMutator} from '@rocicorp/zero' import z from 'zod' import {zql} from 'schema.ts' import {mutators as clientMutators} from 'mutators.ts' // Instead of defining server mutators as a constant, // define them as a function of a list of async tasks. export function createMutators( asyncTasks: Array<() => Promise<void>> ) { return defineMutators(clientMutators, { issue: { update: defineMutator( z.object({ id: z.string(), title: z.string() }), async (tx, {id, title}) => { await tx.mutate.issue.update({id, title}) asyncTasks.push(() => sendEmailToSubscribers(id)) } ) } }) } Then in your mutate handler: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), request, userID: null }) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled( asyncTasks.map(task => task()) ) return Response.json(result) } } } })export async function POST(request: Request) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), request, userID: null }) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }export async function POST(event: APIEvent) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), request: event.request, userID: null }) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }app.post('/api/zero/mutate', async c => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), request: c.req.raw, userID: null }) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return c.json(result) }) Custom Mutate Implementation You can manually implement the mutate endpoint in any programming language. This will be documented in the future, but you can refer to the handleMutateRequest source code for an example for now.",
     "headings": [
       {
         "text": "Architecture",
@@ -1917,7 +2028,7 @@
     "kind": "page"
   },
   {
-    "id": "188-mutators#architecture",
+    "id": "197-mutators#architecture",
     "title": "Mutators",
     "searchTitle": "Architecture",
     "sectionTitle": "Architecture",
@@ -1927,7 +2038,7 @@
     "kind": "section"
   },
   {
-    "id": "189-mutators#life-of-a-mutation",
+    "id": "198-mutators#life-of-a-mutation",
     "title": "Mutators",
     "searchTitle": "Life of a Mutation",
     "sectionTitle": "Life of a Mutation",
@@ -1937,7 +2048,7 @@
     "kind": "section"
   },
   {
-    "id": "190-mutators#defining-mutators",
+    "id": "199-mutators#defining-mutators",
     "title": "Mutators",
     "searchTitle": "Defining Mutators",
     "sectionTitle": "Defining Mutators",
@@ -1947,7 +2058,7 @@
     "kind": "section"
   },
   {
-    "id": "191-mutators#basics",
+    "id": "200-mutators#basics",
     "title": "Mutators",
     "searchTitle": "Basics",
     "sectionTitle": "Basics",
@@ -1957,7 +2068,7 @@
     "kind": "section"
   },
   {
-    "id": "192-mutators#writing-data",
+    "id": "201-mutators#writing-data",
     "title": "Mutators",
     "searchTitle": "Writing Data",
     "sectionTitle": "Writing Data",
@@ -1967,7 +2078,7 @@
     "kind": "section"
   },
   {
-    "id": "193-mutators#insert",
+    "id": "202-mutators#insert",
     "title": "Mutators",
     "searchTitle": "Insert",
     "sectionTitle": "Insert",
@@ -1977,7 +2088,7 @@
     "kind": "section"
   },
   {
-    "id": "194-mutators#upsert",
+    "id": "203-mutators#upsert",
     "title": "Mutators",
     "searchTitle": "Upsert",
     "sectionTitle": "Upsert",
@@ -1987,7 +2098,7 @@
     "kind": "section"
   },
   {
-    "id": "195-mutators#update",
+    "id": "204-mutators#update",
     "title": "Mutators",
     "searchTitle": "Update",
     "sectionTitle": "Update",
@@ -1997,7 +2108,7 @@
     "kind": "section"
   },
   {
-    "id": "196-mutators#delete",
+    "id": "205-mutators#delete",
     "title": "Mutators",
     "searchTitle": "Delete",
     "sectionTitle": "Delete",
@@ -2007,7 +2118,7 @@
     "kind": "section"
   },
   {
-    "id": "197-mutators#arguments",
+    "id": "206-mutators#arguments",
     "title": "Mutators",
     "searchTitle": "Arguments",
     "sectionTitle": "Arguments",
@@ -2017,7 +2128,7 @@
     "kind": "section"
   },
   {
-    "id": "198-mutators#reading-data",
+    "id": "207-mutators#reading-data",
     "title": "Mutators",
     "searchTitle": "Reading Data",
     "sectionTitle": "Reading Data",
@@ -2027,7 +2138,7 @@
     "kind": "section"
   },
   {
-    "id": "199-mutators#context",
+    "id": "208-mutators#context",
     "title": "Mutators",
     "searchTitle": "Context",
     "sectionTitle": "Context",
@@ -2037,7 +2148,7 @@
     "kind": "section"
   },
   {
-    "id": "200-mutators#mutator-registries",
+    "id": "209-mutators#mutator-registries",
     "title": "Mutators",
     "searchTitle": "Mutator Registries",
     "sectionTitle": "Mutator Registries",
@@ -2047,7 +2158,7 @@
     "kind": "section"
   },
   {
-    "id": "201-mutators#mutator-names",
+    "id": "210-mutators#mutator-names",
     "title": "Mutators",
     "searchTitle": "Mutator Names",
     "sectionTitle": "Mutator Names",
@@ -2057,7 +2168,7 @@
     "kind": "section"
   },
   {
-    "id": "202-mutators#mutatorsts",
+    "id": "211-mutators#mutatorsts",
     "title": "Mutators",
     "searchTitle": "mutators.ts",
     "sectionTitle": "mutators.ts",
@@ -2067,7 +2178,7 @@
     "kind": "section"
   },
   {
-    "id": "203-mutators#registration",
+    "id": "212-mutators#registration",
     "title": "Mutators",
     "searchTitle": "Registration",
     "sectionTitle": "Registration",
@@ -2077,17 +2188,17 @@
     "kind": "section"
   },
   {
-    "id": "204-mutators#server-setup",
+    "id": "213-mutators#server-setup",
     "title": "Mutators",
     "searchTitle": "Server Setup",
     "sectionTitle": "Server Setup",
     "sectionId": "server-setup",
     "url": "/docs/mutators",
-    "content": "In order for mutations to sync, you must provide an implementation of the mutate endpoint on your server. zero-cache calls this endpoint to process each mutation. Registering the Endpoint Use ZERO_MUTATE_URL to tell zero-cache where to find your mutate implementation: export ZERO_MUTATE_URL=\"http://localhost:3000/api/zero/mutate\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleMutateRequest and mustGetMutator functions to implement the endpoint. Plug in whatever dbProvider you set up (see server-zql or the install guide). // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), c.req.raw ) return c.json(result) }) Zero includes several built-in database adapters. You can also easily create your own. See ZQL on the Server for more information. handleMutateRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetMutator looks up the mutator in the registry and throws an error if not found. The mutator.fn function is your mutator implementation wrapped in the validator you provided. These examples have only public mutators, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the mutate handler. See Authentication. Handling Errors The handleMutateRequest function skips any mutations that throw: const result = await handleMutateRequest( dbProvider, transact => transact(async (tx, name, args) => { // The mutation is skipped and the next mutation runs as normal. // The optimistic mutation on the client will be reverted. throw new Error('bonk') }), c.req.raw ) handleMutateRequest catches such errors and turns them into a structured response that gets sent back to the client. You can recover the errors and show UI if you want. It is also of course possible for the entire push endpoint to return an HTTP error, or to not reply at all: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async () => { throw new Error('zonk') // will trigger resend } } } })export async function POST() { throw new Error('zonk') // will trigger resend }export async function POST() { throw new Error('zonk') // will trigger resend }app.post('/api/zero/mutate', async c => { // This will cause the client to resend all queued mutations. throw new Error('zonk') }) If Zero receives any response from the mutate endpoint other than HTTP 200, 401, or 403, it will disconnect and enter the error state. If Zero receives HTTP 401 or 403, the client will enter the needs auth state and require a manual reconnect. Use zero.connection.connect() for cookie auth or zero.connection.connect({auth: newToken}) for token auth, then Zero will retry all queued mutations. If you want a different behavior, it is possible to implement the mutate endpoint yourself and handle errors differently. Custom Mutate URL By default, Zero sends mutations to the URL specified in the ZERO_MUTATE_URL parameter. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in the ZERO_MUTATE_URL parameter: export ZERO_MUTATE_URL=\"https://api.example.com/mutate,https://api.staging.example.com/mutate\" Then choose one of those URLs by passing it to mutateURL on the Zero constructor: const opts: ZeroOptions = { // ... mutateURL: 'https://api.staging.example.com/mutate' } URL Patterns The strings listed in ZERO_MUTATE_URL can also be URLPatterns: export ZERO_MUTATE_URL=\"https://mybranch-*.preview.myapp.com/mutate\" For more information, see the URLPattern section of the Queries docs. It works the same way for mutations. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints. Server-Specific Code To implement server-specific code, just run different mutators in your mutate endpoint. Server authority to the rescue! defineMutators accepts a baseMutators parameter that makes this easy. The returned mutator registry will contain all the mutators from baseMutators, plus any new ones you define or override: // server-mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' import {zql} from 'schema.ts' import {mutators as sharedMutators} from 'mutators.ts' export const serverMutators = defineMutators( sharedMutators, { posts: { // Overrides the shared mutator definition with same name. update: defineMutator( z.object({ id: z.string(), title: z.string().optional(), priority: z.number().optional() }), async ({ tx, ctx: {userID}, args: {id, title, priority} }) => { // Run the shared mutator first. await sharedMutators.posts.update.fn({ tx, ctx, args }) // Record a history of this operation happening in an audit log table. await tx.mutate.auditLog.insert({ issueId: id, action: 'update-title', timestamp: Date.getTime() }) } ) } } ) For simple things, we also expose a location field on the transaction object that you can use to branch your code: const myMutator = defineMutator(async ({tx}) => { if (tx.location === 'client') { // Client-side code } else { // Server-side code } })",
+    "content": "In order for mutations to sync, you must provide an implementation of the mutate endpoint on your server. zero-cache calls this endpoint to process each mutation. Registering the Endpoint Use ZERO_MUTATE_URL to tell zero-cache where to find your mutate implementation: export ZERO_MUTATE_URL=\"http://localhost:3000/api/zero/mutate\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleMutateRequest and mustGetMutator functions to implement the endpoint. Plug in whatever dbProvider you set up (see server-zql or the install guide). // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request, userID: null }) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(request: Request) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: event.request, userID: null }) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request: c.req.raw, userID: null }) return c.json(result) }) Zero includes several built-in database adapters. You can also easily create your own. See ZQL on the Server for more information. handleMutateRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetMutator looks up the mutator in the registry and throws an error if not found. The mutator.fn function is your mutator implementation wrapped in the validator you provided. These examples have only public mutators, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the mutate handler. See Authentication. Handling Errors The handleMutateRequest function skips any mutations that throw: const result = await handleMutateRequest({ dbProvider, handler: transact => transact(async (tx, name, args) => { // The mutation is skipped and the next mutation runs as normal. // The optimistic mutation on the client will be reverted. throw new Error('bonk') }), request: c.req.raw, userID: null }) handleMutateRequest catches such errors and turns them into a structured response that gets sent back to the client. You can recover the errors and show UI if you want. It is also of course possible for the entire push endpoint to return an HTTP error, or to not reply at all: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async () => { throw new Error('zonk') // will trigger resend } } } })export async function POST() { throw new Error('zonk') // will trigger resend }export async function POST() { throw new Error('zonk') // will trigger resend }app.post('/api/zero/mutate', async c => { // This will cause the client to resend all queued mutations. throw new Error('zonk') }) If Zero receives any response from the mutate endpoint other than HTTP 200, 401, or 403, it will disconnect and enter the error state. If Zero receives HTTP 401 or 403, the client will enter the needs auth state and require a manual reconnect. Use zero.connection.connect() for cookie auth or zero.connection.connect({auth: newToken}) for token auth, then Zero will retry all queued mutations. If you want a different behavior, it is possible to implement the mutate endpoint yourself and handle errors differently. Custom Mutate URL By default, Zero sends mutations to the URL specified in the ZERO_MUTATE_URL parameter. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in the ZERO_MUTATE_URL parameter: export ZERO_MUTATE_URL=\"https://api.example.com/mutate,https://api.staging.example.com/mutate\" Then choose one of those URLs by passing it to mutateURL on the Zero constructor: const opts: ZeroOptions = { // ... mutateURL: 'https://api.staging.example.com/mutate' } URL Patterns The strings listed in ZERO_MUTATE_URL can also be URLPatterns: export ZERO_MUTATE_URL=\"https://mybranch-*.preview.myapp.com/mutate\" For more information, see the URLPattern section of the Queries docs. It works the same way for mutations. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints. Server-Specific Code To implement server-specific code, just run different mutators in your mutate endpoint. Server authority to the rescue! defineMutators accepts a baseMutators parameter that makes this easy. The returned mutator registry will contain all the mutators from baseMutators, plus any new ones you define or override: // server-mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' import {zql} from 'schema.ts' import {mutators as sharedMutators} from 'mutators.ts' export const serverMutators = defineMutators( sharedMutators, { posts: { // Overrides the shared mutator definition with same name. update: defineMutator( z.object({ id: z.string(), title: z.string().optional(), priority: z.number().optional() }), async ({ tx, ctx: {userID}, args: {id, title, priority} }) => { // Run the shared mutator first. await sharedMutators.posts.update.fn({ tx, ctx, args }) // Record a history of this operation happening in an audit log table. await tx.mutate.auditLog.insert({ issueId: id, action: 'update-title', timestamp: Date.getTime() }) } ) } } ) For simple things, we also expose a location field on the transaction object that you can use to branch your code: const myMutator = defineMutator(async ({tx}) => { if (tx.location === 'client') { // Client-side code } else { // Server-side code } })",
     "kind": "section"
   },
   {
-    "id": "205-mutators#registering-the-endpoint",
+    "id": "214-mutators#registering-the-endpoint",
     "title": "Mutators",
     "searchTitle": "Registering the Endpoint",
     "sectionTitle": "Registering the Endpoint",
@@ -2097,27 +2208,27 @@
     "kind": "section"
   },
   {
-    "id": "206-mutators#implementing-the-endpoint",
+    "id": "215-mutators#implementing-the-endpoint",
     "title": "Mutators",
     "searchTitle": "Implementing the Endpoint",
     "sectionTitle": "Implementing the Endpoint",
     "sectionId": "implementing-the-endpoint",
     "url": "/docs/mutators",
-    "content": "You can use the handleMutateRequest and mustGetMutator functions to implement the endpoint. Plug in whatever dbProvider you set up (see server-zql or the install guide). // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request ) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), c.req.raw ) return c.json(result) }) Zero includes several built-in database adapters. You can also easily create your own. See ZQL on the Server for more information. handleMutateRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetMutator looks up the mutator in the registry and throws an error if not found. The mutator.fn function is your mutator implementation wrapped in the validator you provided. These examples have only public mutators, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the mutate handler. See Authentication.",
+    "content": "You can use the handleMutateRequest and mustGetMutator functions to implement the endpoint. Plug in whatever dbProvider you set up (see server-zql or the install guide). // src/routes/api/zero/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request, userID: null }) return Response.json(result) } } } })// app/api/zero/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(request: Request) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) }// src/routes/api/zero/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from 'db-provider.ts' export async function POST(event: APIEvent) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: event.request, userID: null }) return Response.json(result) }// api/app.ts import {Hono} from 'hono' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from 'mutators.ts' import {dbProvider} from './db-provider.ts' const app = new Hono() app.post('/api/zero/mutate', async c => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ args, tx }) }), request: c.req.raw, userID: null }) return c.json(result) }) Zero includes several built-in database adapters. You can also easily create your own. See ZQL on the Server for more information. handleMutateRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetMutator looks up the mutator in the registry and throws an error if not found. The mutator.fn function is your mutator implementation wrapped in the validator you provided. These examples have only public mutators, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the mutate handler. See Authentication.",
     "kind": "section"
   },
   {
-    "id": "207-mutators#handling-errors",
+    "id": "216-mutators#handling-errors",
     "title": "Mutators",
     "searchTitle": "Handling Errors",
     "sectionTitle": "Handling Errors",
     "sectionId": "handling-errors",
     "url": "/docs/mutators",
-    "content": "The handleMutateRequest function skips any mutations that throw: const result = await handleMutateRequest( dbProvider, transact => transact(async (tx, name, args) => { // The mutation is skipped and the next mutation runs as normal. // The optimistic mutation on the client will be reverted. throw new Error('bonk') }), c.req.raw ) handleMutateRequest catches such errors and turns them into a structured response that gets sent back to the client. You can recover the errors and show UI if you want. It is also of course possible for the entire push endpoint to return an HTTP error, or to not reply at all: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async () => { throw new Error('zonk') // will trigger resend } } } })export async function POST() { throw new Error('zonk') // will trigger resend }export async function POST() { throw new Error('zonk') // will trigger resend }app.post('/api/zero/mutate', async c => { // This will cause the client to resend all queued mutations. throw new Error('zonk') }) If Zero receives any response from the mutate endpoint other than HTTP 200, 401, or 403, it will disconnect and enter the error state. If Zero receives HTTP 401 or 403, the client will enter the needs auth state and require a manual reconnect. Use zero.connection.connect() for cookie auth or zero.connection.connect({auth: newToken}) for token auth, then Zero will retry all queued mutations. If you want a different behavior, it is possible to implement the mutate endpoint yourself and handle errors differently.",
+    "content": "The handleMutateRequest function skips any mutations that throw: const result = await handleMutateRequest({ dbProvider, handler: transact => transact(async (tx, name, args) => { // The mutation is skipped and the next mutation runs as normal. // The optimistic mutation on the client will be reverted. throw new Error('bonk') }), request: c.req.raw, userID: null }) handleMutateRequest catches such errors and turns them into a structured response that gets sent back to the client. You can recover the errors and show UI if you want. It is also of course possible for the entire push endpoint to return an HTTP error, or to not reply at all: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async () => { throw new Error('zonk') // will trigger resend } } } })export async function POST() { throw new Error('zonk') // will trigger resend }export async function POST() { throw new Error('zonk') // will trigger resend }app.post('/api/zero/mutate', async c => { // This will cause the client to resend all queued mutations. throw new Error('zonk') }) If Zero receives any response from the mutate endpoint other than HTTP 200, 401, or 403, it will disconnect and enter the error state. If Zero receives HTTP 401 or 403, the client will enter the needs auth state and require a manual reconnect. Use zero.connection.connect() for cookie auth or zero.connection.connect({auth: newToken}) for token auth, then Zero will retry all queued mutations. If you want a different behavior, it is possible to implement the mutate endpoint yourself and handle errors differently.",
     "kind": "section"
   },
   {
-    "id": "208-mutators#custom-mutate-url",
+    "id": "217-mutators#custom-mutate-url",
     "title": "Mutators",
     "searchTitle": "Custom Mutate URL",
     "sectionTitle": "Custom Mutate URL",
@@ -2127,7 +2238,7 @@
     "kind": "section"
   },
   {
-    "id": "209-mutators#url-patterns",
+    "id": "218-mutators#url-patterns",
     "title": "Mutators",
     "searchTitle": "URL Patterns",
     "sectionTitle": "URL Patterns",
@@ -2137,7 +2248,7 @@
     "kind": "section"
   },
   {
-    "id": "210-mutators#server-specific-code",
+    "id": "219-mutators#server-specific-code",
     "title": "Mutators",
     "searchTitle": "Server-Specific Code",
     "sectionTitle": "Server-Specific Code",
@@ -2147,7 +2258,7 @@
     "kind": "section"
   },
   {
-    "id": "211-mutators#running-mutators",
+    "id": "220-mutators#running-mutators",
     "title": "Mutators",
     "searchTitle": "Running Mutators",
     "sectionTitle": "Running Mutators",
@@ -2157,7 +2268,7 @@
     "kind": "section"
   },
   {
-    "id": "212-mutators#waiting-for-results",
+    "id": "221-mutators#waiting-for-results",
     "title": "Mutators",
     "searchTitle": "Waiting for Results",
     "sectionTitle": "Waiting for Results",
@@ -2167,7 +2278,7 @@
     "kind": "section"
   },
   {
-    "id": "213-mutators#permissions",
+    "id": "222-mutators#permissions",
     "title": "Mutators",
     "searchTitle": "Permissions",
     "sectionTitle": "Permissions",
@@ -2177,7 +2288,7 @@
     "kind": "section"
   },
   {
-    "id": "214-mutators#dropping-down-to-raw-sql",
+    "id": "223-mutators#dropping-down-to-raw-sql",
     "title": "Mutators",
     "searchTitle": "Dropping Down to Raw SQL",
     "sectionTitle": "Dropping Down to Raw SQL",
@@ -2187,17 +2298,17 @@
     "kind": "section"
   },
   {
-    "id": "215-mutators#notifications-and-async-work",
+    "id": "224-mutators#notifications-and-async-work",
     "title": "Mutators",
     "searchTitle": "Notifications and Async Work",
     "sectionTitle": "Notifications and Async Work",
     "sectionId": "notifications-and-async-work",
     "url": "/docs/mutators",
-    "content": "The best way to handle notifications and async work is a transactional outbox. This ensures that notifications actually do eventually get sent, without holding open database transactions to talk over the network. This can be implemented very easily in Zero by writing notifications to an outbox table as part of your mutator, then processing that table periodically with a background job. However sometimes it's still nice to do a quick and dirty async send as part of a mutation, for example early on in development, or to record metrics. For this, the createMutators pattern is useful: // server-mutators.ts import {defineMutator} from '@rocicorp/zero' import z from 'zod' import {zql} from 'schema.ts' import {mutators as clientMutators} from 'mutators.ts' // Instead of defining server mutators as a constant, // define them as a function of a list of async tasks. export function createMutators( asyncTasks: Array<() => Promise<void>> ) { return defineMutators(clientMutators, { issue: { update: defineMutator( z.object({ id: z.string(), title: z.string() }), async (tx, {id, title}) => { await tx.mutate.issue.update({id, title}) asyncTasks.push(() => sendEmailToSubscribers(id)) } ) } }) } Then in your mutate handler: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), request ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled( asyncTasks.map(task => task()) ) return Response.json(result) } } } })export async function POST(req: Request) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), req ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }export async function POST(event: APIEvent) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), event.request ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }app.post('/api/zero/mutate', async c => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), c.req.raw ) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return c.json(result) })",
+    "content": "The best way to handle notifications and async work is a transactional outbox. This ensures that notifications actually do eventually get sent, without holding open database transactions to talk over the network. This can be implemented very easily in Zero by writing notifications to an outbox table as part of your mutator, then processing that table periodically with a background job. However sometimes it's still nice to do a quick and dirty async send as part of a mutation, for example early on in development, or to record metrics. For this, the createMutators pattern is useful: // server-mutators.ts import {defineMutator} from '@rocicorp/zero' import z from 'zod' import {zql} from 'schema.ts' import {mutators as clientMutators} from 'mutators.ts' // Instead of defining server mutators as a constant, // define them as a function of a list of async tasks. export function createMutators( asyncTasks: Array<() => Promise<void>> ) { return defineMutators(clientMutators, { issue: { update: defineMutator( z.object({ id: z.string(), title: z.string() }), async (tx, {id, title}) => { await tx.mutate.issue.update({id, title}) asyncTasks.push(() => sendEmailToSubscribers(id)) } ) } }) } Then in your mutate handler: export const Route = createFileRoute('/api/zero/mutate')({ server: { handlers: { POST: async ({request}) => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), request, userID: null }) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled( asyncTasks.map(task => task()) ) return Response.json(result) } } } })export async function POST(request: Request) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), request, userID: null }) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }export async function POST(event: APIEvent) { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({tx, args}) }), request: event.request, userID: null }) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return Response.json(result) }app.post('/api/zero/mutate', async c => { const asyncTasks: Array<() => Promise<void>> = [] const mutators = createMutators(asyncTasks) const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({ tx, args }) }), request: c.req.raw, userID: null }) // Run all async tasks // If any fail, do not block the response, since the // mutation result has already been written to the database. await Promise.allSettled(asyncTasks.map(task => task())) return c.json(result) })",
     "kind": "section"
   },
   {
-    "id": "216-mutators#custom-mutate-implementation",
+    "id": "225-mutators#custom-mutate-implementation",
     "title": "Mutators",
     "searchTitle": "Custom Mutate Implementation",
     "sectionTitle": "Custom Mutate Implementation",
@@ -2221,7 +2332,7 @@
     "kind": "page"
   },
   {
-    "id": "217-open-source#business-model",
+    "id": "226-open-source#business-model",
     "title": "Zero is Open Source Software",
     "searchTitle": "Business Model",
     "sectionTitle": "Business Model",
@@ -2273,7 +2384,7 @@
     "kind": "page"
   },
   {
-    "id": "218-otel#grafana-cloud-walkthrough",
+    "id": "227-otel#grafana-cloud-walkthrough",
     "title": "OpenTelemetry",
     "searchTitle": "Grafana Cloud Walkthrough",
     "sectionTitle": "Grafana Cloud Walkthrough",
@@ -2283,7 +2394,7 @@
     "kind": "section"
   },
   {
-    "id": "219-otel#distributed-tracing",
+    "id": "228-otel#distributed-tracing",
     "title": "OpenTelemetry",
     "searchTitle": "Distributed Tracing",
     "sectionTitle": "Distributed Tracing",
@@ -2293,7 +2404,7 @@
     "kind": "section"
   },
   {
-    "id": "220-otel#metrics-reference",
+    "id": "229-otel#metrics-reference",
     "title": "OpenTelemetry",
     "searchTitle": "Metrics Reference",
     "sectionTitle": "Metrics Reference",
@@ -2303,7 +2414,7 @@
     "kind": "section"
   },
   {
-    "id": "221-otel#zeroserver",
+    "id": "230-otel#zeroserver",
     "title": "OpenTelemetry",
     "searchTitle": "zero.server",
     "sectionTitle": "zero.server",
@@ -2313,7 +2424,7 @@
     "kind": "section"
   },
   {
-    "id": "222-otel#zeroreplica",
+    "id": "231-otel#zeroreplica",
     "title": "OpenTelemetry",
     "searchTitle": "zero.replica",
     "sectionTitle": "zero.replica",
@@ -2323,7 +2434,7 @@
     "kind": "section"
   },
   {
-    "id": "223-otel#zeroreplication",
+    "id": "232-otel#zeroreplication",
     "title": "OpenTelemetry",
     "searchTitle": "zero.replication",
     "sectionTitle": "zero.replication",
@@ -2333,7 +2444,7 @@
     "kind": "section"
   },
   {
-    "id": "224-otel#zerosync",
+    "id": "233-otel#zerosync",
     "title": "OpenTelemetry",
     "searchTitle": "zero.sync",
     "sectionTitle": "zero.sync",
@@ -2343,7 +2454,7 @@
     "kind": "section"
   },
   {
-    "id": "225-otel#zeromutation",
+    "id": "234-otel#zeromutation",
     "title": "OpenTelemetry",
     "searchTitle": "zero.mutation",
     "sectionTitle": "zero.mutation",
@@ -2403,7 +2514,7 @@
     "kind": "page"
   },
   {
-    "id": "226-postgres-support#object-names",
+    "id": "235-postgres-support#object-names",
     "title": "Supported Postgres Features",
     "searchTitle": "Object Names",
     "sectionTitle": "Object Names",
@@ -2413,7 +2524,7 @@
     "kind": "section"
   },
   {
-    "id": "227-postgres-support#object-types",
+    "id": "236-postgres-support#object-types",
     "title": "Supported Postgres Features",
     "searchTitle": "Object Types",
     "sectionTitle": "Object Types",
@@ -2423,7 +2534,7 @@
     "kind": "section"
   },
   {
-    "id": "228-postgres-support#column-types",
+    "id": "237-postgres-support#column-types",
     "title": "Supported Postgres Features",
     "searchTitle": "Column Types",
     "sectionTitle": "Column Types",
@@ -2433,7 +2544,7 @@
     "kind": "section"
   },
   {
-    "id": "229-postgres-support#column-defaults",
+    "id": "238-postgres-support#column-defaults",
     "title": "Supported Postgres Features",
     "searchTitle": "Column Defaults",
     "sectionTitle": "Column Defaults",
@@ -2443,7 +2554,7 @@
     "kind": "section"
   },
   {
-    "id": "230-postgres-support#ids",
+    "id": "239-postgres-support#ids",
     "title": "Supported Postgres Features",
     "searchTitle": "IDs",
     "sectionTitle": "IDs",
@@ -2453,7 +2564,7 @@
     "kind": "section"
   },
   {
-    "id": "231-postgres-support#primary-keys",
+    "id": "240-postgres-support#primary-keys",
     "title": "Supported Postgres Features",
     "searchTitle": "Primary Keys",
     "sectionTitle": "Primary Keys",
@@ -2463,7 +2574,7 @@
     "kind": "section"
   },
   {
-    "id": "232-postgres-support#limiting-replication",
+    "id": "241-postgres-support#limiting-replication",
     "title": "Supported Postgres Features",
     "searchTitle": "Limiting Replication",
     "sectionTitle": "Limiting Replication",
@@ -2473,7 +2584,7 @@
     "kind": "section"
   },
   {
-    "id": "233-postgres-support#zero-cache-replication",
+    "id": "242-postgres-support#zero-cache-replication",
     "title": "Supported Postgres Features",
     "searchTitle": "zero-cache replication",
     "sectionTitle": "zero-cache replication",
@@ -2483,7 +2594,7 @@
     "kind": "section"
   },
   {
-    "id": "234-postgres-support#browser-client-replication",
+    "id": "243-postgres-support#browser-client-replication",
     "title": "Supported Postgres Features",
     "searchTitle": "Browser client replication",
     "sectionTitle": "Browser client replication",
@@ -2493,7 +2604,7 @@
     "kind": "section"
   },
   {
-    "id": "235-postgres-support#schema-changes",
+    "id": "244-postgres-support#schema-changes",
     "title": "Supported Postgres Features",
     "searchTitle": "Schema changes",
     "sectionTitle": "Schema changes",
@@ -2529,7 +2640,7 @@
     "kind": "page"
   },
   {
-    "id": "236-previews#overview",
+    "id": "245-previews#overview",
     "title": "Previews",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -2539,7 +2650,7 @@
     "kind": "section"
   },
   {
-    "id": "237-previews#configure-allowed-endpoint-patterns",
+    "id": "246-previews#configure-allowed-endpoint-patterns",
     "title": "Previews",
     "searchTitle": "Configure Allowed Endpoint Patterns",
     "sectionTitle": "Configure Allowed Endpoint Patterns",
@@ -2549,7 +2660,7 @@
     "kind": "section"
   },
   {
-    "id": "238-previews#choose-endpoint-urls-in-the-client",
+    "id": "247-previews#choose-endpoint-urls-in-the-client",
     "title": "Previews",
     "searchTitle": "Choose Endpoint URLs in the Client",
     "sectionTitle": "Choose Endpoint URLs in the Client",
@@ -2559,7 +2670,7 @@
     "kind": "section"
   },
   {
-    "id": "239-previews#schema-changes-in-previews",
+    "id": "248-previews#schema-changes-in-previews",
     "title": "Previews",
     "searchTitle": "Schema Changes in Previews",
     "sectionTitle": "Schema Changes in Previews",
@@ -2573,7 +2684,7 @@
     "title": "Queries",
     "searchTitle": "Queries",
     "url": "/docs/queries",
-    "content": "Queries are how you read and sync data with Zero. Here's a simple example: // src/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from 'schema.ts' export const queries = defineQueries({ postsByAuthor: defineQuery( z.object({authorID: z.string()}), ({args: {authorID}}) => zql.post.where('authorID', authorID) ) }) Architecture A copy of each query exists on both the client and on your server: Often the implementations will be the same, and you can just share their code. This is easy with full-stack frameworks like TanStack Start or Next.js. But the implementations don't have to be the same, or even compute the same result. For example, the server can add extra filters to enforce permissions that the client query does not. Life of a Query When a query is invoked, it initially runs on the client, against the client-side datastore. Any matching data is returned immediately and the user sees instant results. In the background, the name and arguments for the query are sent to zero-cache. Zero-cache calls the queries endpoint on your server to get the ZQL for the query. Your server looks up its implementation of the query, invokes it, and returns the resulting ZQL expression to zero-cache. Zero-cache then runs this ZQL against the server-side data. The initial server result is sent back to the client and the client query updates in response. zero-cache receives updates from Postgres via logical replication. It updates affected queries and sends row changes back to the client, which updates the client query, and the user sees the changes. Defining Queries Basics Create a query using defineQuery. The only required argument is a QueryFn, which must return a ZQL expression: import {zql} from 'schema.ts' const allPostsQueryDef = defineQuery(() => zql.post) Arguments The QueryFn can take a single args parameter. To enable this, pass a validator to defineQuery: import {zql} from 'schema.ts' const postsByAuthor = defineQuery( z.object({authorID: z.string().optional()}), ({args: {authorID}}) => { let q = zql.post if (authorID !== undefined) { q = q.where('authorID', authorID) } return q } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. Zero queries run on both the client and on your server. In the server case, the parameters come from the client and are untrusted. The validator ensures the data passed to your query is of the expected type. Query Registries The result of defineQuery is a QueryDefinition. By itself this isn't super useful. You need to register it using defineQueries: export const queries = defineQueries({ posts: { all: allPostsQueryDef } }) Typically these are done together in one step: export const queries = defineQueries({ posts: { all: defineQuery(() => zql.post) } }) The result of defineQueries is called a QueryRegistry. Each field in the registry is a callable Query that you can use to read data: import {zero} from 'zero.ts' import {queries} from 'queries.ts' const allPosts = await zero.run(queries.posts.all()) Query Names Each Query has a queryName which is computed by defineQueries. This name is later sent to your server to identify the query to run: console.log(queries.posts.all.queryName) // \"posts.all\" Context Query parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero queries also support the concept of a context object. Access your context with the ctx parameter to your query: const myPostsQuery = defineQuery(({ctx: {userID}}) => { // User cannot control context.userID, so this safely // restricts the query to the user's own posts. return zql.post.where('authorID', userID) }) If you don't want to register your Context and Schema types globally, you can use defineQueryWithType and defineQueriesWithType: import { defineQueriesWithType, defineQueryWithType } from '@rocicorp/zero' import type {Schema} from 'schema.ts' import type {ZeroContext} from 'context.ts' const defineQuery = defineQueryWithType< Schema, ZeroContext >() const defineQueries = defineQueriesWithType<Schema>() queries.ts By convention, all queries for an application are listed in a central queries.ts file. This allows them to be easily used on both the client and server: import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema.ts' export const queries = defineQueries({ posts: { get: defineQuery(z.string(), id => zql.post.where('id', id) ), byAuthor: defineQuery( z.object({ authorID: z.string(), includeDrafts: z.boolean().optional() }), ({args: {authorID, includeDrafts}}) => { let q = zql.post.where('authorID', authorID) if (!includeDrafts) { q = q.where('isDraft', false) } return q } ) } }) You can use as many levels of nesting as you want to organize your queries. As your application grows, you can move queries to different files to keep them organized: // posts.ts export const postQueries = { get: defineQuery(z.string(), id => zql.post.where('id', id) ) // ... } // users.ts export const userQueries = { byRole: defineQuery(z.string(), role => zql.user.where('role', role) ) // ... } // queries.ts import {postQueries} from './posts.ts' import {userQueries} from './users.ts' export const queries = defineQueries({ posts: postQueries, users: userQueries }) Because defineQueries establishes the full name for each query (i.e., posts.get, users.byRole), it should only be used once at the top level of your queries.ts file. Server Setup In order for queries to sync, you must provide an implementation of the query endpoint on your server. zero-cache calls this endpoint to resolve each query to ZQL that it can run. Registering the Endpoint Use ZERO_QUERY_URL to tell zero-cache where to find your query implementation: export ZERO_QUERY_URL=\"http://localhost:3000/api/zero/query\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleQueryRequest and mustGetQuery functions to implement the endpoint. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' app.post('/api/zero/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) handleQueryRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetQuery looks up the query in the registry and throws an error if not found. The query.fn function is your query implementation wrapped in the validator you provided. These examples have only public queries, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the query handler. See Authentication. Custom Query URL By default, Zero sends queries to the URL specified in the ZERO_QUERY_URL parameter in the zero-cache config. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in ZERO_QUERY_URL: ZERO_QUERY_URL='https://api.example.com/query,https://api.staging.example.com/query' Then choose one of those URLs by passing it to queryURL on the Zero constructor: const zero = new Zero({ schema, queries, queryURL: 'https://api.staging.example.com/query' }) URL Patterns The strings listed in ZERO_QUERY_URL can also be URLPatterns: ZERO_QUERY_URL=\"https://mybranch-*.preview.myapp.com/query\" This queries URL will allow clients to choose URLs like: https://mybranch-aaa.preview.myapp.com/query ✅ https://mybranch-bbb.preview.myapp.com/query ✅ But rejects URLs like: https://preview.myapp.com/query ❌ (missing subdomain) https://malicious.com/query ❌ (different domain) https://mybranch-123.preview.myapp.com/query/extra ❌ (extra path) https://mybranch-123.preview.myapp.com/other ❌ (different path) Because URLPattern is a web standard, you can test them right in your browser: For more information, see the URLPattern docs. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints. Running Queries Reactively The most common way to use queries is with the useQuery reactive hooks from the React or SolidJS bindings (or the equivalent low-level API): import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(queries.posts.get('user123')) return posts.map(post => ( <div key={post.id}>{post.title}</div> )) }import {useQuery} from '@rocicorp/zero/solid' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(() => queries.posts.get('user123') ) return ( <For each={posts()}> {post => <div key={post.id}>{post.title}</div>} </For> ) }import {queries} from 'zero/queries.ts' import {zero} from 'zero.ts' const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) for (let post of postsView.data) { console.log(post.title) } // updates as the underlying data changes postsView.addListener(posts => { console.log('posts', posts) }) These functions allow you to automatically re-render UI when a query changes. Conditionally Sometimes the inputs needed to construct a query are not available on the first render. For example, auth state or a route param might still be loading after a page refresh. Both React and Solid support conditional queries by passing undefined until the query can be constructed: import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function Username({userID}: {userID: string | undefined}) { const [user] = useQuery( userID ? queries.users.getUser({ userID }) : undefined ) return user ? <div>{user.username}</div> : null }import {useQuery} from '@rocicorp/zero/solid' import {Show} from 'solid-js' import {queries} from 'zero/queries.ts' function Username(props: {userID: string | undefined}) { const [user] = useQuery(() => props.userID ? queries.users.getUser({ userID: props.userID }) : undefined ) return ( <Show when={user()}> {user => <div>{user().username}</div>} </Show> ) } Once You usually want to subscribe to a query in a reactive UI, but every so often you'll need to run a query just once. To do this, use zero.run(): const results = await zero.run( queries.issues.byPriority('high') ) By default, run() only returns results that are currently available on the client. That is, it returns the data that would be given for result.type === 'unknown'. If you want to wait for the server to return results, pass {type: 'complete'} to run: const results = await zero.run( queries.issues.byPriority('high'), {type: 'complete'} ) For Preloading Almost all Zero apps will want to preload some data in order to maximize the feel of instantaneous UI transitions. Because preload queries are often much larger than a screenful of UI, Zero provides a special zero.preload() method to avoid the overhead of materializing the result into JS objects: // Preload a large number of the inbox query results. zero.preload( queries.issues.inbox({ sort: 'created', sortDirection: 'desc', limit: 1000 }) ) Missing Data Because Zero returns local results immediately and server results asynchronously, displaying \"not found\" / 404 UI can be slightly tricky. If you just use a simple existence check, you will often see the 404 UI flicker while the server result loads: const [issue] = useQuery(queries.issues.get('some-id')) // ❌ This causes flickering of the UI if (!issue) { return <div>404 Not Found</div> } else { return <div>{issue.title}</div> }const [issue] = useQuery(() => queries.issues.get('some-id') ) return ( <Show when={issue()}> {resolved => ( <Show when={resolved} fallback={<div>404 Not Found</div>} > <div>{resolved.title}</div> </Show> )} </Show> )const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) postsView.addListener(posts => { // ❌ This is updated as data comes in console.log('posts', posts) }) To do this correctly, only display the \"not found\" UI when the result type is complete. This way the 404 page is slow but pages with data are still just as fast: const [issue, issueResult] = useQuery( queries.issues.get('some-id') ) if (!issue && issueResult.type === 'complete') { return <div>404 Not Found</div> } if (!issue) { return null } return <div>{issue.title}</div>const [issue, issueResult] = useQuery(() => queries.issues.get('some-id') ) return ( <Switch fallback={null}> <Match when={issue()}> {resolved => <div>{resolved.title}</div>} </Match> <Match when={issueResult().type === 'complete'}> <div>404 Not Found</div> </Match> </Switch> )const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) postsView.addListener((posts, resultType) => { if (resultType === 'complete') { console.log('posts', posts) } }) Partial Data Zero immediately returns the data for a query it has on the client, then falls back to the server for any missing data. Sometimes it's useful to know the difference between these two types of results. To do so, use the result from useQuery: const [issues, issuesResult] = useQuery( queries.issues.inbox() ) if (issuesResult.type === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') }const [issues, issuesResult] = useQuery(() => queries.issues.inbox() ) if (issuesResult().type === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') }const view = zero.materialize(queries.issues.inbox()) view.addListener((issues, resultType) => { if (resultType === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') } }) The possible values of result.type are currently complete and unknown. The complete value is currently only returned when Zero has received the server result. In the future, Zero will be able to return this result type when it knows that all possible data for this query is already available locally. Additionally, we plan to add a prefix result for when the data is known to be a prefix of the complete result. See Consistency for more information. Handling Errors If the queries endpoint throws an application or parse error, zero-cache will report it to the client using the type and error fields on the query details object: const [posts, postsResult] = useQuery( queries.posts.byAuthorID('user123') ) if (postsResult.type === 'error') { return ( <div> Error loading posts: {postsResult.error.message} </div> ) }const [posts, postsResult] = useQuery(() => queries.posts.byAuthorID('user123') ) return ( <Switch> <Match when={postsResult().type === 'error'}> <div> Error loading posts: {postsResult().error.message} </div> </Match> </Switch> )// Materialize a view of a query const postsView = queries.posts .byAuthorID('user123') .materialize() postsView.addListener((posts, resultType, error) => { if (resultType === 'error') { console.error('Error loading posts', error) } }) See Connection Status for how HTTP or network errors from the queries endpoint are handled. Granular Updates You can use the materialize() method to create a view that you can listen to for changes. However, this will only tell you when the view has changed and give you the complete new result. It won't tell you what changed. To know what changed, you can create your own custom View implementation: // Inside the View class // Instead of storing the change, we invoke some callback push(change: Change): void { switch (change.type) { case 'add': this.#onAdd?.(change) break case 'remove': this.#onRemove?.(change) break case 'edit': this.#onEdit?.(change) break case 'child': this.#onChild?.(change) break default: throw new Error(`Unknown change type: ${change['type']}`) } } For examples, see the View implementations in zero-vue or zero-solid. Query Caching Queries can be either active or cached. An active query is one that is currently being used by the application. Cached queries are not currently in use, but continue syncing in case they are needed again soon. Queries are deactivated according to how they were created: For useQuery(), the UI unmounts the component (which calls destroy() under the covers). For preload(), the UI calls cleanup() on the return value of preload(). For run(), queries are automatically deactivated immediately after the result is returned. For materialize() queries, the UI calls destroy() on the view. Additionally when a Zero instance closes, all active queries are automatically deactivated. This also happens when the containing page or script is unloaded. TTLs Each query has a ttl that controls how long it stays cached. If the user closes all tabs for your app, Zero stops running and the time that elapses doesn't count toward any TTLs. You do not need to account for such time when choosing a TTL – you only need to account for time your app is running without a query. TTL Defaults In most cases, the default TTL should work well: preload() queries default to ttl:'none', meaning they are not cached at all, and will stop syncing immediately when deactivated. But because preload() queries are typically registered at app startup and never shutdown, and because the ttl clock only ticks while Zero is running, this means that preload queries never get unregistered. Other queries have a default ttl of 5m (five minutes). Setting Different TTLs You can override the default TTL with the ttl parameter: const [user] = useQuery( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero.preload(queries.posts.byAuthorID('user123'), { ttl: '5m' })const [user] = useQuery( () => queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero().preload(queries.posts.byAuthorID('user123'), { ttl: '5m' })// run() const user = await zero.run( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // materialize() const view = zero.materialize( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero.preload(queries.posts.byAuthorID('user123'), { ttl: '5m' }) TTLs up to 10m (ten minutes) are currently supported. The following formats are allowed: Why Zero TTLs are Short Zero queries are not free. Just as in any database, queries consume resources on both the client and server. Memory is used to keep metadata about the query, and disk storage is used to keep the query's current state. We do drop this state after we haven't heard from a client for awhile, but this is only a partial improvement. If the client returns, we have to re-run the query to get the latest data. This means that we do not actually want to keep queries active unless there is a good chance they will be needed again soon. The default Zero TTL values might initially seem too short, but they are designed to work well with the way Zero's TTL clock works and strike a good balance between keeping queries alive long enough to be useful, while not keeping them alive so long that they consume resources unnecessarily. Local-Only Queries It can sometimes be useful to run queries only on the client. For example, to implement typeahead search, it really doesn't make sense to register a query with the server for every single keystroke. Zero doesn't yet have a way to run named queries local-only, but you can run ZQL expressions locally by passing them anywhere a query is supported. For example, to subscribe to a local-only query: // Queries the already synced data for issues, // without syncing more data. const [issues] = useQuery( zql.issue.orderBy('created', 'desc').limit(10) )// Queries the already synced data for issues, // without syncing more data. const [issues] = useQuery(() => zql.issue.orderBy('created', 'desc').limit(10) )// Queries the already synced data for issues, // without syncing more data. const view = z.materialize( zql.issue.orderBy('created', 'desc').limit(10) ) view.addListener(issues => { console.log('issues', issues) }) Custom Server Implementation It is possible to implement the ZERO_QUERY_URL endpoint without using Zero's TypeScript libraries, or even in a different language entirely. The endpoint receives a POST request with a JSON body of the form: type QueriesRequestBody = { id: string name: string args: readonly ReadonlyJSONValue[] }[] And responds with: type QueriesResponseBody = ( | { id: string name: string // See https://github.com/rocicorp/mono/blob/main/packages/zero-protocol/src/ast.ts ast: AST } | { error: 'app' id: string name: string details: ReadonlyJSONValue } | { error: 'zero' id: string name: string details: ReadonlyJSONValue } | { error: 'http' id: string name: string status: number details: ReadonlyJSONValue } )[] Consistency Zero always syncs a consistent partial replica of the backend database to the client. This avoids many common consistency issues that come up in classic web applications. But there are still some consistency issues to be aware of when using Zero. For example, imagine that you have a bug database w/ 10k issues. You preload the first 1k issues sorted by created. The user then does a query of issues assigned to themselves, sorted by created. Among the 1k issues that were preloaded imagine 100 are found that match the query. Since the data we preloaded is in the same order as this query, we are guaranteed that any local results found will be a prefix of the server results. The UX that result is nice: the user will see initial results to the query instantly. If more results are found server-side, those results are guaranteed to sort below the local results. There's no shuffling of results when the server response comes in. Now imagine that the user switches the sort to ‘sort by modified’. This new query will run locally, and will again find some local matches. But it is now unlikely that the local results found are a prefix of the server results. When the server result comes in, the user will probably see the results shuffle around. To avoid this annoying effect, what you should do in this example is also preload the first 1k issues sorted by modified desc. In general for any query shape you intend to do, you should preload the first n results for that query shape with no filters, in each sort you intend to use. Zero syncs the union of all active queries' results. You don't have to worry about syncing many sorts of the same query when it's likely the results will overlap heavily. In the future, we will be implementing a consistency model that fixes these issues automatically. We will prevent Zero from returning local data when that data is not known to be a prefix of the server result. Once the consistency model is implemented, preloading can be thought of as purely a performance thing, and not required to avoid unsightly flickering.",
+    "content": "Queries are how you read and sync data with Zero. Here's a simple example: // src/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from 'schema.ts' export const queries = defineQueries({ postsByAuthor: defineQuery( z.object({authorID: z.string()}), ({args: {authorID}}) => zql.post.where('authorID', authorID) ) }) Architecture A copy of each query exists on both the client and on your server: Often the implementations will be the same, and you can just share their code. This is easy with full-stack frameworks like TanStack Start or Next.js. But the implementations don't have to be the same, or even compute the same result. For example, the server can add extra filters to enforce permissions that the client query does not. Life of a Query When a query is invoked, it initially runs on the client, against the client-side datastore. Any matching data is returned immediately and the user sees instant results. In the background, the name and arguments for the query are sent to zero-cache. Zero-cache calls the queries endpoint on your server to get the ZQL for the query. Your server looks up its implementation of the query, invokes it, and returns the resulting ZQL expression to zero-cache. Zero-cache then runs this ZQL against the server-side data. The initial server result is sent back to the client and the client query updates in response. zero-cache receives updates from Postgres via logical replication. It updates affected queries and sends row changes back to the client, which updates the client query, and the user sees the changes. Defining Queries Basics Create a query using defineQuery. The only required argument is a QueryFn, which must return a ZQL expression: import {zql} from 'schema.ts' const allPostsQueryDef = defineQuery(() => zql.post) Arguments The QueryFn can take a single args parameter. To enable this, pass a validator to defineQuery: import {zql} from 'schema.ts' const postsByAuthor = defineQuery( z.object({authorID: z.string().optional()}), ({args: {authorID}}) => { let q = zql.post if (authorID !== undefined) { q = q.where('authorID', authorID) } return q } ) We use Zod in these examples, but you can use any validation library that implements Standard Schema. Zero queries run on both the client and on your server. In the server case, the parameters come from the client and are untrusted. The validator ensures the data passed to your query is of the expected type. Query Registries The result of defineQuery is a QueryDefinition. By itself this isn't super useful. You need to register it using defineQueries: export const queries = defineQueries({ posts: { all: allPostsQueryDef } }) Typically these are done together in one step: export const queries = defineQueries({ posts: { all: defineQuery(() => zql.post) } }) The result of defineQueries is called a QueryRegistry. Each field in the registry is a callable Query that you can use to read data: import {zero} from 'zero.ts' import {queries} from 'queries.ts' const allPosts = await zero.run(queries.posts.all()) Query Names Each Query has a queryName which is computed by defineQueries. This name is later sent to your server to identify the query to run: console.log(queries.posts.all.queryName) // \"posts.all\" Context Query parameters are supplied by the client application and passed to the server automatically by Zero. This makes them unsuitable for credentials, since the user could modify them. For this reason, Zero queries also support the concept of a context object. Access your context with the ctx parameter to your query: const myPostsQuery = defineQuery(({ctx: {userID}}) => { // User cannot control context.userID, so this safely // restricts the query to the user's own posts. return zql.post.where('authorID', userID) }) If you don't want to register your Context and Schema types globally, you can use defineQueryWithType and defineQueriesWithType: import { defineQueriesWithType, defineQueryWithType } from '@rocicorp/zero' import type {Schema} from 'schema.ts' import type {ZeroContext} from 'context.ts' const defineQuery = defineQueryWithType< Schema, ZeroContext >() const defineQueries = defineQueriesWithType<Schema>() queries.ts By convention, all queries for an application are listed in a central queries.ts file. This allows them to be easily used on both the client and server: import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema.ts' export const queries = defineQueries({ posts: { get: defineQuery(z.string(), id => zql.post.where('id', id) ), byAuthor: defineQuery( z.object({ authorID: z.string(), includeDrafts: z.boolean().optional() }), ({args: {authorID, includeDrafts}}) => { let q = zql.post.where('authorID', authorID) if (!includeDrafts) { q = q.where('isDraft', false) } return q } ) } }) You can use as many levels of nesting as you want to organize your queries. As your application grows, you can move queries to different files to keep them organized: // posts.ts export const postQueries = { get: defineQuery(z.string(), id => zql.post.where('id', id) ) // ... } // users.ts export const userQueries = { byRole: defineQuery(z.string(), role => zql.user.where('role', role) ) // ... } // queries.ts import {postQueries} from './posts.ts' import {userQueries} from './users.ts' export const queries = defineQueries({ posts: postQueries, users: userQueries }) Because defineQueries establishes the full name for each query (i.e., posts.get, users.byRole), it should only be used once at the top level of your queries.ts file. Server Setup In order for queries to sync, you must provide an implementation of the query endpoint on your server. zero-cache calls this endpoint to resolve each query to ZQL that it can run. Registering the Endpoint Use ZERO_QUERY_URL to tell zero-cache where to find your query implementation: export ZERO_QUERY_URL=\"http://localhost:3000/api/zero/query\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleQueryRequest and mustGetQuery functions to implement the endpoint. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(request: Request) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: event.request, userID: null }) return Response.json(result) }// api/app.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' app.post('/api/zero/query', async c => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: c.req.raw, userID: null }) return c.json(result) }) handleQueryRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetQuery looks up the query in the registry and throws an error if not found. The query.fn function is your query implementation wrapped in the validator you provided. These examples have only public queries, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the query handler. See Authentication. Custom Query URL By default, Zero sends queries to the URL specified in the ZERO_QUERY_URL parameter in the zero-cache config. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in ZERO_QUERY_URL: ZERO_QUERY_URL='https://api.example.com/query,https://api.staging.example.com/query' Then choose one of those URLs by passing it to queryURL on the Zero constructor: const zero = new Zero({ schema, queries, queryURL: 'https://api.staging.example.com/query' }) URL Patterns The strings listed in ZERO_QUERY_URL can also be URLPatterns: ZERO_QUERY_URL=\"https://mybranch-*.preview.myapp.com/query\" This queries URL will allow clients to choose URLs like: https://mybranch-aaa.preview.myapp.com/query ✅ https://mybranch-bbb.preview.myapp.com/query ✅ But rejects URLs like: https://preview.myapp.com/query ❌ (missing subdomain) https://malicious.com/query ❌ (different domain) https://mybranch-123.preview.myapp.com/query/extra ❌ (extra path) https://mybranch-123.preview.myapp.com/other ❌ (different path) Because URLPattern is a web standard, you can test them right in your browser: For more information, see the URLPattern docs. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints. Running Queries Reactively The most common way to use queries is with the useQuery reactive hooks from the React or SolidJS bindings (or the equivalent low-level API): import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(queries.posts.get('user123')) return posts.map(post => ( <div key={post.id}>{post.title}</div> )) }import {useQuery} from '@rocicorp/zero/solid' import {queries} from 'zero/queries.ts' function App() { const [posts] = useQuery(() => queries.posts.get('user123') ) return ( <For each={posts()}> {post => <div key={post.id}>{post.title}</div>} </For> ) }import {queries} from 'zero/queries.ts' import {zero} from 'zero.ts' const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) for (let post of postsView.data) { console.log(post.title) } // updates as the underlying data changes postsView.addListener(posts => { console.log('posts', posts) }) These functions allow you to automatically re-render UI when a query changes. Conditionally Sometimes the inputs needed to construct a query are not available on the first render. For example, auth state or a route param might still be loading after a page refresh. Both React and Solid support conditional queries by passing undefined until the query can be constructed: import {useQuery} from '@rocicorp/zero/react' import {queries} from 'zero/queries.ts' function Username({userID}: {userID: string | undefined}) { const [user] = useQuery( userID ? queries.users.getUser({ userID }) : undefined ) return user ? <div>{user.username}</div> : null }import {useQuery} from '@rocicorp/zero/solid' import {Show} from 'solid-js' import {queries} from 'zero/queries.ts' function Username(props: {userID: string | undefined}) { const [user] = useQuery(() => props.userID ? queries.users.getUser({ userID: props.userID }) : undefined ) return ( <Show when={user()}> {user => <div>{user().username}</div>} </Show> ) } Once You usually want to subscribe to a query in a reactive UI, but every so often you'll need to run a query just once. To do this, use zero.run(): const results = await zero.run( queries.issues.byPriority('high') ) By default, run() only returns results that are currently available on the client. That is, it returns the data that would be given for result.type === 'unknown'. If you want to wait for the server to return results, pass {type: 'complete'} to run: const results = await zero.run( queries.issues.byPriority('high'), {type: 'complete'} ) For Preloading Almost all Zero apps will want to preload some data in order to maximize the feel of instantaneous UI transitions. Because preload queries are often much larger than a screenful of UI, Zero provides a special zero.preload() method to avoid the overhead of materializing the result into JS objects: // Preload a large number of the inbox query results. zero.preload( queries.issues.inbox({ sort: 'created', sortDirection: 'desc', limit: 1000 }) ) Missing Data Because Zero returns local results immediately and server results asynchronously, displaying \"not found\" / 404 UI can be slightly tricky. If you just use a simple existence check, you will often see the 404 UI flicker while the server result loads: const [issue] = useQuery(queries.issues.get('some-id')) // ❌ This causes flickering of the UI if (!issue) { return <div>404 Not Found</div> } else { return <div>{issue.title}</div> }const [issue] = useQuery(() => queries.issues.get('some-id') ) return ( <Show when={issue()}> {resolved => ( <Show when={resolved} fallback={<div>404 Not Found</div>} > <div>{resolved.title}</div> </Show> )} </Show> )const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) postsView.addListener(posts => { // ❌ This is updated as data comes in console.log('posts', posts) }) To do this correctly, only display the \"not found\" UI when the result type is complete. This way the 404 page is slow but pages with data are still just as fast: const [issue, issueResult] = useQuery( queries.issues.get('some-id') ) if (!issue && issueResult.type === 'complete') { return <div>404 Not Found</div> } if (!issue) { return null } return <div>{issue.title}</div>const [issue, issueResult] = useQuery(() => queries.issues.get('some-id') ) return ( <Switch fallback={null}> <Match when={issue()}> {resolved => <div>{resolved.title}</div>} </Match> <Match when={issueResult().type === 'complete'}> <div>404 Not Found</div> </Match> </Switch> )const postsView = zero.materialize( queries.posts.byAuthorID('user123') ) postsView.addListener((posts, resultType) => { if (resultType === 'complete') { console.log('posts', posts) } }) Partial Data Zero immediately returns the data for a query it has on the client, then falls back to the server for any missing data. Sometimes it's useful to know the difference between these two types of results. To do so, use the result from useQuery: const [issues, issuesResult] = useQuery( queries.issues.inbox() ) if (issuesResult.type === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') }const [issues, issuesResult] = useQuery(() => queries.issues.inbox() ) if (issuesResult().type === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') }const view = zero.materialize(queries.issues.inbox()) view.addListener((issues, resultType) => { if (resultType === 'complete') { console.log('All data is present') } else { console.log('Some data is missing') } }) The possible values of result.type are currently complete and unknown. The complete value is currently only returned when Zero has received the server result. In the future, Zero will be able to return this result type when it knows that all possible data for this query is already available locally. Additionally, we plan to add a prefix result for when the data is known to be a prefix of the complete result. See Consistency for more information. Handling Errors If the queries endpoint throws an application or parse error, zero-cache will report it to the client using the type and error fields on the query details object: const [posts, postsResult] = useQuery( queries.posts.byAuthorID('user123') ) if (postsResult.type === 'error') { return ( <div> Error loading posts: {postsResult.error.message} </div> ) }const [posts, postsResult] = useQuery(() => queries.posts.byAuthorID('user123') ) return ( <Switch> <Match when={postsResult().type === 'error'}> <div> Error loading posts: {postsResult().error.message} </div> </Match> </Switch> )// Materialize a view of a query const postsView = queries.posts .byAuthorID('user123') .materialize() postsView.addListener((posts, resultType, error) => { if (resultType === 'error') { console.error('Error loading posts', error) } }) See Connection Status for how HTTP or network errors from the queries endpoint are handled. Granular Updates You can use the materialize() method to create a view that you can listen to for changes. However, this will only tell you when the view has changed and give you the complete new result. It won't tell you what changed. To know what changed, you can create your own custom View implementation: // Inside the View class // Instead of storing the change, we invoke some callback push(change: Change): void { switch (change.type) { case 'add': this.#onAdd?.(change) break case 'remove': this.#onRemove?.(change) break case 'edit': this.#onEdit?.(change) break case 'child': this.#onChild?.(change) break default: throw new Error(`Unknown change type: ${change['type']}`) } } For examples, see the View implementations in zero-vue or zero-solid. Query Caching Queries can be either active or cached. An active query is one that is currently being used by the application. Cached queries are not currently in use, but continue syncing in case they are needed again soon. Queries are deactivated according to how they were created: For useQuery(), the UI unmounts the component (which calls destroy() under the covers). For preload(), the UI calls cleanup() on the return value of preload(). For run(), queries are automatically deactivated immediately after the result is returned. For materialize() queries, the UI calls destroy() on the view. Additionally when a Zero instance closes, all active queries are automatically deactivated. This also happens when the containing page or script is unloaded. TTLs Each query has a ttl that controls how long it stays cached. If the user closes all tabs for your app, Zero stops running and the time that elapses doesn't count toward any TTLs. You do not need to account for such time when choosing a TTL – you only need to account for time your app is running without a query. TTL Defaults In most cases, the default TTL should work well: preload() queries default to ttl:'none', meaning they are not cached at all, and will stop syncing immediately when deactivated. But because preload() queries are typically registered at app startup and never shutdown, and because the ttl clock only ticks while Zero is running, this means that preload queries never get unregistered. Other queries have a default ttl of 5m (five minutes). Setting Different TTLs You can override the default TTL with the ttl parameter: const [user] = useQuery( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero.preload(queries.posts.byAuthorID('user123'), { ttl: '5m' })const [user] = useQuery( () => queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero().preload(queries.posts.byAuthorID('user123'), { ttl: '5m' })// run() const user = await zero.run( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // materialize() const view = zero.materialize( queries.posts.byAuthorID('user123'), {ttl: '5m'} ) // preload() zero.preload(queries.posts.byAuthorID('user123'), { ttl: '5m' }) TTLs up to 10m (ten minutes) are currently supported. The following formats are allowed: Why Zero TTLs are Short Zero queries are not free. Just as in any database, queries consume resources on both the client and server. Memory is used to keep metadata about the query, and disk storage is used to keep the query's current state. We do drop this state after we haven't heard from a client for awhile, but this is only a partial improvement. If the client returns, we have to re-run the query to get the latest data. This means that we do not actually want to keep queries active unless there is a good chance they will be needed again soon. The default Zero TTL values might initially seem too short, but they are designed to work well with the way Zero's TTL clock works and strike a good balance between keeping queries alive long enough to be useful, while not keeping them alive so long that they consume resources unnecessarily. Local-Only Queries It can sometimes be useful to run queries only on the client. For example, to implement typeahead search, it really doesn't make sense to register a query with the server for every single keystroke. Zero doesn't yet have a way to run named queries local-only, but you can run ZQL expressions locally by passing them anywhere a query is supported. For example, to subscribe to a local-only query: // Queries the already synced data for issues, // without syncing more data. const [issues] = useQuery( zql.issue.orderBy('created', 'desc').limit(10) )// Queries the already synced data for issues, // without syncing more data. const [issues] = useQuery(() => zql.issue.orderBy('created', 'desc').limit(10) )// Queries the already synced data for issues, // without syncing more data. const view = z.materialize( zql.issue.orderBy('created', 'desc').limit(10) ) view.addListener(issues => { console.log('issues', issues) }) Custom Server Implementation It is possible to implement the ZERO_QUERY_URL endpoint without using Zero's TypeScript libraries, or even in a different language entirely. The endpoint receives a POST request with a JSON body of the form: type QueriesRequestBody = { id: string name: string args: readonly ReadonlyJSONValue[] }[] And responds with: type QueriesResponseBody = ( | { id: string name: string // See https://github.com/rocicorp/mono/blob/main/packages/zero-protocol/src/ast.ts ast: AST } | { error: 'app' id: string name: string details: ReadonlyJSONValue } | { error: 'zero' id: string name: string details: ReadonlyJSONValue } | { error: 'http' id: string name: string status: number details: ReadonlyJSONValue } )[] Consistency Zero always syncs a consistent partial replica of the backend database to the client. This avoids many common consistency issues that come up in classic web applications. But there are still some consistency issues to be aware of when using Zero. For example, imagine that you have a bug database w/ 10k issues. You preload the first 1k issues sorted by created. The user then does a query of issues assigned to themselves, sorted by created. Among the 1k issues that were preloaded imagine 100 are found that match the query. Since the data we preloaded is in the same order as this query, we are guaranteed that any local results found will be a prefix of the server results. The UX that result is nice: the user will see initial results to the query instantly. If more results are found server-side, those results are guaranteed to sort below the local results. There's no shuffling of results when the server response comes in. Now imagine that the user switches the sort to ‘sort by modified’. This new query will run locally, and will again find some local matches. But it is now unlikely that the local results found are a prefix of the server results. When the server result comes in, the user will probably see the results shuffle around. To avoid this annoying effect, what you should do in this example is also preload the first 1k issues sorted by modified desc. In general for any query shape you intend to do, you should preload the first n results for that query shape with no filters, in each sort you intend to use. Zero syncs the union of all active queries' results. You don't have to worry about syncing many sorts of the same query when it's likely the results will overlap heavily. In the future, we will be implementing a consistency model that fixes these issues automatically. We will prevent Zero from returning local data when that data is not known to be a prefix of the server result. Once the consistency model is implemented, preloading can be thought of as purely a performance thing, and not required to avoid unsightly flickering.",
     "headings": [
       {
         "text": "Architecture",
@@ -2703,7 +2814,7 @@
     "kind": "page"
   },
   {
-    "id": "240-queries#architecture",
+    "id": "249-queries#architecture",
     "title": "Queries",
     "searchTitle": "Architecture",
     "sectionTitle": "Architecture",
@@ -2713,7 +2824,7 @@
     "kind": "section"
   },
   {
-    "id": "241-queries#life-of-a-query",
+    "id": "250-queries#life-of-a-query",
     "title": "Queries",
     "searchTitle": "Life of a Query",
     "sectionTitle": "Life of a Query",
@@ -2723,7 +2834,7 @@
     "kind": "section"
   },
   {
-    "id": "242-queries#defining-queries",
+    "id": "251-queries#defining-queries",
     "title": "Queries",
     "searchTitle": "Defining Queries",
     "sectionTitle": "Defining Queries",
@@ -2733,7 +2844,7 @@
     "kind": "section"
   },
   {
-    "id": "243-queries#basics",
+    "id": "252-queries#basics",
     "title": "Queries",
     "searchTitle": "Basics",
     "sectionTitle": "Basics",
@@ -2743,7 +2854,7 @@
     "kind": "section"
   },
   {
-    "id": "244-queries#arguments",
+    "id": "253-queries#arguments",
     "title": "Queries",
     "searchTitle": "Arguments",
     "sectionTitle": "Arguments",
@@ -2753,7 +2864,7 @@
     "kind": "section"
   },
   {
-    "id": "245-queries#query-registries",
+    "id": "254-queries#query-registries",
     "title": "Queries",
     "searchTitle": "Query Registries",
     "sectionTitle": "Query Registries",
@@ -2763,7 +2874,7 @@
     "kind": "section"
   },
   {
-    "id": "246-queries#query-names",
+    "id": "255-queries#query-names",
     "title": "Queries",
     "searchTitle": "Query Names",
     "sectionTitle": "Query Names",
@@ -2773,7 +2884,7 @@
     "kind": "section"
   },
   {
-    "id": "247-queries#context",
+    "id": "256-queries#context",
     "title": "Queries",
     "searchTitle": "Context",
     "sectionTitle": "Context",
@@ -2783,7 +2894,7 @@
     "kind": "section"
   },
   {
-    "id": "248-queries#queriests",
+    "id": "257-queries#queriests",
     "title": "Queries",
     "searchTitle": "queries.ts",
     "sectionTitle": "queries.ts",
@@ -2793,17 +2904,17 @@
     "kind": "section"
   },
   {
-    "id": "249-queries#server-setup",
+    "id": "258-queries#server-setup",
     "title": "Queries",
     "searchTitle": "Server Setup",
     "sectionTitle": "Server Setup",
     "sectionId": "server-setup",
     "url": "/docs/queries",
-    "content": "In order for queries to sync, you must provide an implementation of the query endpoint on your server. zero-cache calls this endpoint to resolve each query to ZQL that it can run. Registering the Endpoint Use ZERO_QUERY_URL to tell zero-cache where to find your query implementation: export ZERO_QUERY_URL=\"http://localhost:3000/api/zero/query\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleQueryRequest and mustGetQuery functions to implement the endpoint. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' app.post('/api/zero/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) handleQueryRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetQuery looks up the query in the registry and throws an error if not found. The query.fn function is your query implementation wrapped in the validator you provided. These examples have only public queries, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the query handler. See Authentication. Custom Query URL By default, Zero sends queries to the URL specified in the ZERO_QUERY_URL parameter in the zero-cache config. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in ZERO_QUERY_URL: ZERO_QUERY_URL='https://api.example.com/query,https://api.staging.example.com/query' Then choose one of those URLs by passing it to queryURL on the Zero constructor: const zero = new Zero({ schema, queries, queryURL: 'https://api.staging.example.com/query' }) URL Patterns The strings listed in ZERO_QUERY_URL can also be URLPatterns: ZERO_QUERY_URL=\"https://mybranch-*.preview.myapp.com/query\" This queries URL will allow clients to choose URLs like: https://mybranch-aaa.preview.myapp.com/query ✅ https://mybranch-bbb.preview.myapp.com/query ✅ But rejects URLs like: https://preview.myapp.com/query ❌ (missing subdomain) https://malicious.com/query ❌ (different domain) https://mybranch-123.preview.myapp.com/query/extra ❌ (extra path) https://mybranch-123.preview.myapp.com/other ❌ (different path) Because URLPattern is a web standard, you can test them right in your browser: For more information, see the URLPattern docs. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints.",
+    "content": "In order for queries to sync, you must provide an implementation of the query endpoint on your server. zero-cache calls this endpoint to resolve each query to ZQL that it can run. Registering the Endpoint Use ZERO_QUERY_URL to tell zero-cache where to find your query implementation: export ZERO_QUERY_URL=\"http://localhost:3000/api/zero/query\" # run zero-cache, e.g. `npx zero-cache-dev` Implementing the Endpoint You can use the handleQueryRequest and mustGetQuery functions to implement the endpoint. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(request: Request) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: event.request, userID: null }) return Response.json(result) }// api/app.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' app.post('/api/zero/query', async c => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: c.req.raw, userID: null }) return c.json(result) }) handleQueryRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetQuery looks up the query in the registry and throws an error if not found. The query.fn function is your query implementation wrapped in the validator you provided. These examples have only public queries, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the query handler. See Authentication. Custom Query URL By default, Zero sends queries to the URL specified in the ZERO_QUERY_URL parameter in the zero-cache config. However you can customize this on a per-client basis. To do so, list multiple comma-separated URLs in ZERO_QUERY_URL: ZERO_QUERY_URL='https://api.example.com/query,https://api.staging.example.com/query' Then choose one of those URLs by passing it to queryURL on the Zero constructor: const zero = new Zero({ schema, queries, queryURL: 'https://api.staging.example.com/query' }) URL Patterns The strings listed in ZERO_QUERY_URL can also be URLPatterns: ZERO_QUERY_URL=\"https://mybranch-*.preview.myapp.com/query\" This queries URL will allow clients to choose URLs like: https://mybranch-aaa.preview.myapp.com/query ✅ https://mybranch-bbb.preview.myapp.com/query ✅ But rejects URLs like: https://preview.myapp.com/query ❌ (missing subdomain) https://malicious.com/query ❌ (different domain) https://mybranch-123.preview.myapp.com/query/extra ❌ (extra path) https://mybranch-123.preview.myapp.com/other ❌ (different path) Because URLPattern is a web standard, you can test them right in your browser: For more information, see the URLPattern docs. If you're configuring per-branch preview URLs (for example on Vercel), see Preview Deployments for the complete setup across both query and mutate endpoints.",
     "kind": "section"
   },
   {
-    "id": "250-queries#registering-the-endpoint",
+    "id": "259-queries#registering-the-endpoint",
     "title": "Queries",
     "searchTitle": "Registering the Endpoint",
     "sectionTitle": "Registering the Endpoint",
@@ -2813,17 +2924,17 @@
     "kind": "section"
   },
   {
-    "id": "251-queries#implementing-the-endpoint",
+    "id": "260-queries#implementing-the-endpoint",
     "title": "Queries",
     "searchTitle": "Implementing the Endpoint",
     "sectionTitle": "Implementing the Endpoint",
     "sectionId": "implementing-the-endpoint",
     "url": "/docs/queries",
-    "content": "You can use the handleQueryRequest and mustGetQuery functions to implement the endpoint. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) }// api/app.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' app.post('/api/zero/query', async c => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, c.req.raw ) return c.json(result) }) handleQueryRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetQuery looks up the query in the registry and throws an error if not found. The query.fn function is your query implementation wrapped in the validator you provided. These examples have only public queries, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the query handler. See Authentication.",
+    "content": "You can use the handleQueryRequest and mustGetQuery functions to implement the endpoint. // src/routes/api/zero/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export const Route = createFileRoute('/api/zero/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) } } } })// app/api/zero/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(request: Request) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) }// src/routes/api/zero/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' export async function POST(event: APIEvent) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: event.request, userID: null }) return Response.json(result) }// api/app.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from 'queries.ts' import {schema} from 'schema.ts' app.post('/api/zero/query', async c => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: c.req.raw, userID: null }) return c.json(result) }) handleQueryRequest accepts a standard Request and returns a JSON object which can be serialized and returned by your server framework of choice. mustGetQuery looks up the query in the registry and throws an error if not found. The query.fn function is your query implementation wrapped in the validator you provided. These examples have only public queries, so they do not pass a context. In authenticated apps, validate auth in the request, derive context from the session, and pass it to the query handler. See Authentication.",
     "kind": "section"
   },
   {
-    "id": "252-queries#custom-query-url",
+    "id": "261-queries#custom-query-url",
     "title": "Queries",
     "searchTitle": "Custom Query URL",
     "sectionTitle": "Custom Query URL",
@@ -2833,7 +2944,7 @@
     "kind": "section"
   },
   {
-    "id": "253-queries#url-patterns",
+    "id": "262-queries#url-patterns",
     "title": "Queries",
     "searchTitle": "URL Patterns",
     "sectionTitle": "URL Patterns",
@@ -2843,7 +2954,7 @@
     "kind": "section"
   },
   {
-    "id": "254-queries#running-queries",
+    "id": "263-queries#running-queries",
     "title": "Queries",
     "searchTitle": "Running Queries",
     "sectionTitle": "Running Queries",
@@ -2853,7 +2964,7 @@
     "kind": "section"
   },
   {
-    "id": "255-queries#reactively",
+    "id": "264-queries#reactively",
     "title": "Queries",
     "searchTitle": "Reactively",
     "sectionTitle": "Reactively",
@@ -2863,7 +2974,7 @@
     "kind": "section"
   },
   {
-    "id": "256-queries#conditionally",
+    "id": "265-queries#conditionally",
     "title": "Queries",
     "searchTitle": "Conditionally",
     "sectionTitle": "Conditionally",
@@ -2873,7 +2984,7 @@
     "kind": "section"
   },
   {
-    "id": "257-queries#once",
+    "id": "266-queries#once",
     "title": "Queries",
     "searchTitle": "Once",
     "sectionTitle": "Once",
@@ -2883,7 +2994,7 @@
     "kind": "section"
   },
   {
-    "id": "258-queries#for-preloading",
+    "id": "267-queries#for-preloading",
     "title": "Queries",
     "searchTitle": "For Preloading",
     "sectionTitle": "For Preloading",
@@ -2893,7 +3004,7 @@
     "kind": "section"
   },
   {
-    "id": "259-queries#missing-data",
+    "id": "268-queries#missing-data",
     "title": "Queries",
     "searchTitle": "Missing Data",
     "sectionTitle": "Missing Data",
@@ -2903,7 +3014,7 @@
     "kind": "section"
   },
   {
-    "id": "260-queries#partial-data",
+    "id": "269-queries#partial-data",
     "title": "Queries",
     "searchTitle": "Partial Data",
     "sectionTitle": "Partial Data",
@@ -2913,7 +3024,7 @@
     "kind": "section"
   },
   {
-    "id": "261-queries#handling-errors",
+    "id": "270-queries#handling-errors",
     "title": "Queries",
     "searchTitle": "Handling Errors",
     "sectionTitle": "Handling Errors",
@@ -2923,7 +3034,7 @@
     "kind": "section"
   },
   {
-    "id": "262-queries#granular-updates",
+    "id": "271-queries#granular-updates",
     "title": "Queries",
     "searchTitle": "Granular Updates",
     "sectionTitle": "Granular Updates",
@@ -2933,7 +3044,7 @@
     "kind": "section"
   },
   {
-    "id": "263-queries#query-caching",
+    "id": "272-queries#query-caching",
     "title": "Queries",
     "searchTitle": "Query Caching",
     "sectionTitle": "Query Caching",
@@ -2943,7 +3054,7 @@
     "kind": "section"
   },
   {
-    "id": "264-queries#ttls",
+    "id": "273-queries#ttls",
     "title": "Queries",
     "searchTitle": "TTLs",
     "sectionTitle": "TTLs",
@@ -2953,7 +3064,7 @@
     "kind": "section"
   },
   {
-    "id": "265-queries#ttl-defaults",
+    "id": "274-queries#ttl-defaults",
     "title": "Queries",
     "searchTitle": "TTL Defaults",
     "sectionTitle": "TTL Defaults",
@@ -2963,7 +3074,7 @@
     "kind": "section"
   },
   {
-    "id": "266-queries#setting-different-ttls",
+    "id": "275-queries#setting-different-ttls",
     "title": "Queries",
     "searchTitle": "Setting Different TTLs",
     "sectionTitle": "Setting Different TTLs",
@@ -2973,7 +3084,7 @@
     "kind": "section"
   },
   {
-    "id": "267-queries#why-zero-ttls-are-short",
+    "id": "276-queries#why-zero-ttls-are-short",
     "title": "Queries",
     "searchTitle": "Why Zero TTLs are Short",
     "sectionTitle": "Why Zero TTLs are Short",
@@ -2983,7 +3094,7 @@
     "kind": "section"
   },
   {
-    "id": "268-queries#local-only-queries",
+    "id": "277-queries#local-only-queries",
     "title": "Queries",
     "searchTitle": "Local-Only Queries",
     "sectionTitle": "Local-Only Queries",
@@ -2993,7 +3104,7 @@
     "kind": "section"
   },
   {
-    "id": "269-queries#custom-server-implementation",
+    "id": "278-queries#custom-server-implementation",
     "title": "Queries",
     "searchTitle": "Custom Server Implementation",
     "sectionTitle": "Custom Server Implementation",
@@ -3003,7 +3114,7 @@
     "kind": "section"
   },
   {
-    "id": "270-queries#consistency",
+    "id": "279-queries#consistency",
     "title": "Queries",
     "searchTitle": "Consistency",
     "sectionTitle": "Consistency",
@@ -3035,7 +3146,7 @@
     "kind": "page"
   },
   {
-    "id": "271-quickstart#hello-zero-solid",
+    "id": "280-quickstart#hello-zero-solid",
     "title": "Quickstart",
     "searchTitle": "hello-zero-solid",
     "sectionTitle": "hello-zero-solid",
@@ -3045,7 +3156,7 @@
     "kind": "section"
   },
   {
-    "id": "272-quickstart#hello-zero-cf",
+    "id": "281-quickstart#hello-zero-cf",
     "title": "Quickstart",
     "searchTitle": "hello-zero-cf",
     "sectionTitle": "hello-zero-cf",
@@ -3055,7 +3166,7 @@
     "kind": "section"
   },
   {
-    "id": "273-quickstart#hello-zero",
+    "id": "282-quickstart#hello-zero",
     "title": "Quickstart",
     "searchTitle": "hello-zero",
     "sectionTitle": "hello-zero",
@@ -3100,7 +3211,7 @@
     "kind": "page"
   },
   {
-    "id": "274-react#setup",
+    "id": "283-react#setup",
     "title": "React",
     "searchTitle": "Setup",
     "sectionTitle": "Setup",
@@ -3110,7 +3221,7 @@
     "kind": "section"
   },
   {
-    "id": "275-react#usage",
+    "id": "284-react#usage",
     "title": "React",
     "searchTitle": "Usage",
     "sectionTitle": "Usage",
@@ -3120,7 +3231,7 @@
     "kind": "section"
   },
   {
-    "id": "276-react#suspense",
+    "id": "285-react#suspense",
     "title": "React",
     "searchTitle": "Suspense",
     "sectionTitle": "Suspense",
@@ -3130,7 +3241,7 @@
     "kind": "section"
   },
   {
-    "id": "277-react#examples",
+    "id": "286-react#examples",
     "title": "React",
     "searchTitle": "Examples",
     "sectionTitle": "Examples",
@@ -3162,7 +3273,7 @@
     "kind": "page"
   },
   {
-    "id": "278-release-notes/0.1#breaking-changes",
+    "id": "287-release-notes/0.1#breaking-changes",
     "title": "Zero 0.1",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
@@ -3172,7 +3283,7 @@
     "kind": "section"
   },
   {
-    "id": "279-release-notes/0.1#features",
+    "id": "288-release-notes/0.1#features",
     "title": "Zero 0.1",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3182,7 +3293,7 @@
     "kind": "section"
   },
   {
-    "id": "280-release-notes/0.1#source-tree-fixes",
+    "id": "289-release-notes/0.1#source-tree-fixes",
     "title": "Zero 0.1",
     "searchTitle": "Source tree fixes",
     "sectionTitle": "Source tree fixes",
@@ -3218,7 +3329,7 @@
     "kind": "page"
   },
   {
-    "id": "281-release-notes/0.10#install",
+    "id": "290-release-notes/0.10#install",
     "title": "Zero 0.10",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3228,7 +3339,7 @@
     "kind": "section"
   },
   {
-    "id": "282-release-notes/0.10#features",
+    "id": "291-release-notes/0.10#features",
     "title": "Zero 0.10",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3238,7 +3349,7 @@
     "kind": "section"
   },
   {
-    "id": "283-release-notes/0.10#fixes",
+    "id": "292-release-notes/0.10#fixes",
     "title": "Zero 0.10",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3248,7 +3359,7 @@
     "kind": "section"
   },
   {
-    "id": "284-release-notes/0.10#breaking-changes",
+    "id": "293-release-notes/0.10#breaking-changes",
     "title": "Zero 0.10",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3284,7 +3395,7 @@
     "kind": "page"
   },
   {
-    "id": "285-release-notes/0.11#install",
+    "id": "294-release-notes/0.11#install",
     "title": "Zero 0.11",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3294,7 +3405,7 @@
     "kind": "section"
   },
   {
-    "id": "286-release-notes/0.11#features",
+    "id": "295-release-notes/0.11#features",
     "title": "Zero 0.11",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3304,7 +3415,7 @@
     "kind": "section"
   },
   {
-    "id": "287-release-notes/0.11#fixes",
+    "id": "296-release-notes/0.11#fixes",
     "title": "Zero 0.11",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3314,7 +3425,7 @@
     "kind": "section"
   },
   {
-    "id": "288-release-notes/0.11#breaking-changes",
+    "id": "297-release-notes/0.11#breaking-changes",
     "title": "Zero 0.11",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3350,7 +3461,7 @@
     "kind": "page"
   },
   {
-    "id": "289-release-notes/0.12#install",
+    "id": "298-release-notes/0.12#install",
     "title": "Zero 0.12",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3360,7 +3471,7 @@
     "kind": "section"
   },
   {
-    "id": "290-release-notes/0.12#features",
+    "id": "299-release-notes/0.12#features",
     "title": "Zero 0.12",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3370,7 +3481,7 @@
     "kind": "section"
   },
   {
-    "id": "291-release-notes/0.12#fixes",
+    "id": "300-release-notes/0.12#fixes",
     "title": "Zero 0.12",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3380,7 +3491,7 @@
     "kind": "section"
   },
   {
-    "id": "292-release-notes/0.12#breaking-changes",
+    "id": "301-release-notes/0.12#breaking-changes",
     "title": "Zero 0.12",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3416,7 +3527,7 @@
     "kind": "page"
   },
   {
-    "id": "293-release-notes/0.13#install",
+    "id": "302-release-notes/0.13#install",
     "title": "Zero 0.13",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3426,7 +3537,7 @@
     "kind": "section"
   },
   {
-    "id": "294-release-notes/0.13#features",
+    "id": "303-release-notes/0.13#features",
     "title": "Zero 0.13",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3436,7 +3547,7 @@
     "kind": "section"
   },
   {
-    "id": "295-release-notes/0.13#fixes",
+    "id": "304-release-notes/0.13#fixes",
     "title": "Zero 0.13",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3446,7 +3557,7 @@
     "kind": "section"
   },
   {
-    "id": "296-release-notes/0.13#breaking-changes",
+    "id": "305-release-notes/0.13#breaking-changes",
     "title": "Zero 0.13",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3482,7 +3593,7 @@
     "kind": "page"
   },
   {
-    "id": "297-release-notes/0.14#install",
+    "id": "306-release-notes/0.14#install",
     "title": "Zero 0.14",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3492,7 +3603,7 @@
     "kind": "section"
   },
   {
-    "id": "298-release-notes/0.14#features",
+    "id": "307-release-notes/0.14#features",
     "title": "Zero 0.14",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3502,7 +3613,7 @@
     "kind": "section"
   },
   {
-    "id": "299-release-notes/0.14#fixes",
+    "id": "308-release-notes/0.14#fixes",
     "title": "Zero 0.14",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3512,7 +3623,7 @@
     "kind": "section"
   },
   {
-    "id": "300-release-notes/0.14#breaking-changes",
+    "id": "309-release-notes/0.14#breaking-changes",
     "title": "Zero 0.14",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3552,7 +3663,7 @@
     "kind": "page"
   },
   {
-    "id": "301-release-notes/0.15#install",
+    "id": "310-release-notes/0.15#install",
     "title": "Zero 0.15",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3562,7 +3673,7 @@
     "kind": "section"
   },
   {
-    "id": "302-release-notes/0.15#upgrade-guide",
+    "id": "311-release-notes/0.15#upgrade-guide",
     "title": "Zero 0.15",
     "searchTitle": "Upgrade Guide",
     "sectionTitle": "Upgrade Guide",
@@ -3572,7 +3683,7 @@
     "kind": "section"
   },
   {
-    "id": "303-release-notes/0.15#features",
+    "id": "312-release-notes/0.15#features",
     "title": "Zero 0.15",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3582,7 +3693,7 @@
     "kind": "section"
   },
   {
-    "id": "304-release-notes/0.15#fixes",
+    "id": "313-release-notes/0.15#fixes",
     "title": "Zero 0.15",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3592,7 +3703,7 @@
     "kind": "section"
   },
   {
-    "id": "305-release-notes/0.15#breaking-changes",
+    "id": "314-release-notes/0.15#breaking-changes",
     "title": "Zero 0.15",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3632,7 +3743,7 @@
     "kind": "page"
   },
   {
-    "id": "306-release-notes/0.16#install",
+    "id": "315-release-notes/0.16#install",
     "title": "Zero 0.16",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3642,7 +3753,7 @@
     "kind": "section"
   },
   {
-    "id": "307-release-notes/0.16#upgrading",
+    "id": "316-release-notes/0.16#upgrading",
     "title": "Zero 0.16",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -3652,7 +3763,7 @@
     "kind": "section"
   },
   {
-    "id": "308-release-notes/0.16#features",
+    "id": "317-release-notes/0.16#features",
     "title": "Zero 0.16",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3662,7 +3773,7 @@
     "kind": "section"
   },
   {
-    "id": "309-release-notes/0.16#fixes",
+    "id": "318-release-notes/0.16#fixes",
     "title": "Zero 0.16",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3672,7 +3783,7 @@
     "kind": "section"
   },
   {
-    "id": "310-release-notes/0.16#breaking-changes",
+    "id": "319-release-notes/0.16#breaking-changes",
     "title": "Zero 0.16",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3712,7 +3823,7 @@
     "kind": "page"
   },
   {
-    "id": "311-release-notes/0.17#install",
+    "id": "320-release-notes/0.17#install",
     "title": "Zero 0.17",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3722,7 +3833,7 @@
     "kind": "section"
   },
   {
-    "id": "312-release-notes/0.17#upgrading",
+    "id": "321-release-notes/0.17#upgrading",
     "title": "Zero 0.17",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -3732,7 +3843,7 @@
     "kind": "section"
   },
   {
-    "id": "313-release-notes/0.17#features",
+    "id": "322-release-notes/0.17#features",
     "title": "Zero 0.17",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3742,7 +3853,7 @@
     "kind": "section"
   },
   {
-    "id": "314-release-notes/0.17#fixes",
+    "id": "323-release-notes/0.17#fixes",
     "title": "Zero 0.17",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3752,7 +3863,7 @@
     "kind": "section"
   },
   {
-    "id": "315-release-notes/0.17#breaking-changes",
+    "id": "324-release-notes/0.17#breaking-changes",
     "title": "Zero 0.17",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3792,7 +3903,7 @@
     "kind": "page"
   },
   {
-    "id": "316-release-notes/0.18#install",
+    "id": "325-release-notes/0.18#install",
     "title": "Zero 0.18",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3802,7 +3913,7 @@
     "kind": "section"
   },
   {
-    "id": "317-release-notes/0.18#upgrading",
+    "id": "326-release-notes/0.18#upgrading",
     "title": "Zero 0.18",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -3812,7 +3923,7 @@
     "kind": "section"
   },
   {
-    "id": "318-release-notes/0.18#features",
+    "id": "327-release-notes/0.18#features",
     "title": "Zero 0.18",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3822,7 +3933,7 @@
     "kind": "section"
   },
   {
-    "id": "319-release-notes/0.18#fixes",
+    "id": "328-release-notes/0.18#fixes",
     "title": "Zero 0.18",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3832,7 +3943,7 @@
     "kind": "section"
   },
   {
-    "id": "320-release-notes/0.18#breaking-changes",
+    "id": "329-release-notes/0.18#breaking-changes",
     "title": "Zero 0.18",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3872,7 +3983,7 @@
     "kind": "page"
   },
   {
-    "id": "321-release-notes/0.19#install",
+    "id": "330-release-notes/0.19#install",
     "title": "Zero 0.19",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -3882,7 +3993,7 @@
     "kind": "section"
   },
   {
-    "id": "322-release-notes/0.19#upgrading",
+    "id": "331-release-notes/0.19#upgrading",
     "title": "Zero 0.19",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -3892,7 +4003,7 @@
     "kind": "section"
   },
   {
-    "id": "323-release-notes/0.19#features",
+    "id": "332-release-notes/0.19#features",
     "title": "Zero 0.19",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3902,7 +4013,7 @@
     "kind": "section"
   },
   {
-    "id": "324-release-notes/0.19#fixes",
+    "id": "333-release-notes/0.19#fixes",
     "title": "Zero 0.19",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3912,7 +4023,7 @@
     "kind": "section"
   },
   {
-    "id": "325-release-notes/0.19#breaking-changes",
+    "id": "334-release-notes/0.19#breaking-changes",
     "title": "Zero 0.19",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -3956,7 +4067,7 @@
     "kind": "page"
   },
   {
-    "id": "326-release-notes/0.2#breaking-changes",
+    "id": "335-release-notes/0.2#breaking-changes",
     "title": "Zero 0.2",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
@@ -3966,7 +4077,7 @@
     "kind": "section"
   },
   {
-    "id": "327-release-notes/0.2#features",
+    "id": "336-release-notes/0.2#features",
     "title": "Zero 0.2",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -3976,7 +4087,7 @@
     "kind": "section"
   },
   {
-    "id": "328-release-notes/0.2#fixes",
+    "id": "337-release-notes/0.2#fixes",
     "title": "Zero 0.2",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -3986,7 +4097,7 @@
     "kind": "section"
   },
   {
-    "id": "329-release-notes/0.2#docs",
+    "id": "338-release-notes/0.2#docs",
     "title": "Zero 0.2",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -3996,7 +4107,7 @@
     "kind": "section"
   },
   {
-    "id": "330-release-notes/0.2#source-tree-fixes",
+    "id": "339-release-notes/0.2#source-tree-fixes",
     "title": "Zero 0.2",
     "searchTitle": "Source tree fixes",
     "sectionTitle": "Source tree fixes",
@@ -4006,7 +4117,7 @@
     "kind": "section"
   },
   {
-    "id": "331-release-notes/0.2#zbugs",
+    "id": "340-release-notes/0.2#zbugs",
     "title": "Zero 0.2",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -4046,7 +4157,7 @@
     "kind": "page"
   },
   {
-    "id": "332-release-notes/0.20#install",
+    "id": "341-release-notes/0.20#install",
     "title": "Zero 0.20",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4056,7 +4167,7 @@
     "kind": "section"
   },
   {
-    "id": "333-release-notes/0.20#upgrading",
+    "id": "342-release-notes/0.20#upgrading",
     "title": "Zero 0.20",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -4066,7 +4177,7 @@
     "kind": "section"
   },
   {
-    "id": "334-release-notes/0.20#features",
+    "id": "343-release-notes/0.20#features",
     "title": "Zero 0.20",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4076,7 +4187,7 @@
     "kind": "section"
   },
   {
-    "id": "335-release-notes/0.20#fixes",
+    "id": "344-release-notes/0.20#fixes",
     "title": "Zero 0.20",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4086,7 +4197,7 @@
     "kind": "section"
   },
   {
-    "id": "336-release-notes/0.20#breaking-changes",
+    "id": "345-release-notes/0.20#breaking-changes",
     "title": "Zero 0.20",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4126,7 +4237,7 @@
     "kind": "page"
   },
   {
-    "id": "337-release-notes/0.21#install",
+    "id": "346-release-notes/0.21#install",
     "title": "Zero 0.21",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4136,7 +4247,7 @@
     "kind": "section"
   },
   {
-    "id": "338-release-notes/0.21#upgrading",
+    "id": "347-release-notes/0.21#upgrading",
     "title": "Zero 0.21",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -4146,7 +4257,7 @@
     "kind": "section"
   },
   {
-    "id": "339-release-notes/0.21#features",
+    "id": "348-release-notes/0.21#features",
     "title": "Zero 0.21",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4156,7 +4267,7 @@
     "kind": "section"
   },
   {
-    "id": "340-release-notes/0.21#fixes",
+    "id": "349-release-notes/0.21#fixes",
     "title": "Zero 0.21",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4166,7 +4277,7 @@
     "kind": "section"
   },
   {
-    "id": "341-release-notes/0.21#breaking-changes",
+    "id": "350-release-notes/0.21#breaking-changes",
     "title": "Zero 0.21",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4218,7 +4329,7 @@
     "kind": "page"
   },
   {
-    "id": "342-release-notes/0.22#install",
+    "id": "351-release-notes/0.22#install",
     "title": "Zero 0.22",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4228,7 +4339,7 @@
     "kind": "section"
   },
   {
-    "id": "343-release-notes/0.22#upgrading",
+    "id": "352-release-notes/0.22#upgrading",
     "title": "Zero 0.22",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -4238,7 +4349,7 @@
     "kind": "section"
   },
   {
-    "id": "344-release-notes/0.22#how-ttls-used-to-work",
+    "id": "353-release-notes/0.22#how-ttls-used-to-work",
     "title": "Zero 0.22",
     "searchTitle": "How TTLs Used to Work",
     "sectionTitle": "How TTLs Used to Work",
@@ -4248,7 +4359,7 @@
     "kind": "section"
   },
   {
-    "id": "345-release-notes/0.22#how-ttls-work-now",
+    "id": "354-release-notes/0.22#how-ttls-work-now",
     "title": "Zero 0.22",
     "searchTitle": "How TTLs Work Now",
     "sectionTitle": "How TTLs Work Now",
@@ -4258,7 +4369,7 @@
     "kind": "section"
   },
   {
-    "id": "346-release-notes/0.22#using-new-ttls",
+    "id": "355-release-notes/0.22#using-new-ttls",
     "title": "Zero 0.22",
     "searchTitle": "Using New TTLs",
     "sectionTitle": "Using New TTLs",
@@ -4268,7 +4379,7 @@
     "kind": "section"
   },
   {
-    "id": "347-release-notes/0.22#features",
+    "id": "356-release-notes/0.22#features",
     "title": "Zero 0.22",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4278,7 +4389,7 @@
     "kind": "section"
   },
   {
-    "id": "348-release-notes/0.22#fixes",
+    "id": "357-release-notes/0.22#fixes",
     "title": "Zero 0.22",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4288,7 +4399,7 @@
     "kind": "section"
   },
   {
-    "id": "349-release-notes/0.22#breaking-changes",
+    "id": "358-release-notes/0.22#breaking-changes",
     "title": "Zero 0.22",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4332,7 +4443,7 @@
     "kind": "page"
   },
   {
-    "id": "350-release-notes/0.23#install",
+    "id": "359-release-notes/0.23#install",
     "title": "Zero 0.23",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4342,7 +4453,7 @@
     "kind": "section"
   },
   {
-    "id": "351-release-notes/0.23#upgrading",
+    "id": "360-release-notes/0.23#upgrading",
     "title": "Zero 0.23",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -4352,7 +4463,7 @@
     "kind": "section"
   },
   {
-    "id": "352-release-notes/0.23#features",
+    "id": "361-release-notes/0.23#features",
     "title": "Zero 0.23",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4362,7 +4473,7 @@
     "kind": "section"
   },
   {
-    "id": "353-release-notes/0.23#fixes",
+    "id": "362-release-notes/0.23#fixes",
     "title": "Zero 0.23",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4372,7 +4483,7 @@
     "kind": "section"
   },
   {
-    "id": "354-release-notes/0.23#zbugs",
+    "id": "363-release-notes/0.23#zbugs",
     "title": "Zero 0.23",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -4382,7 +4493,7 @@
     "kind": "section"
   },
   {
-    "id": "355-release-notes/0.23#breaking-changes",
+    "id": "364-release-notes/0.23#breaking-changes",
     "title": "Zero 0.23",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4422,7 +4533,7 @@
     "kind": "page"
   },
   {
-    "id": "356-release-notes/0.24#installation",
+    "id": "365-release-notes/0.24#installation",
     "title": "Zero 0.24",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -4432,7 +4543,7 @@
     "kind": "section"
   },
   {
-    "id": "357-release-notes/0.24#features",
+    "id": "366-release-notes/0.24#features",
     "title": "Zero 0.24",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4442,7 +4553,7 @@
     "kind": "section"
   },
   {
-    "id": "358-release-notes/0.24#fixes",
+    "id": "367-release-notes/0.24#fixes",
     "title": "Zero 0.24",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4452,7 +4563,7 @@
     "kind": "section"
   },
   {
-    "id": "359-release-notes/0.24#breaking-changes",
+    "id": "368-release-notes/0.24#breaking-changes",
     "title": "Zero 0.24",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4462,7 +4573,7 @@
     "kind": "section"
   },
   {
-    "id": "360-release-notes/0.24#example-upgrades",
+    "id": "369-release-notes/0.24#example-upgrades",
     "title": "Zero 0.24",
     "searchTitle": "Example Upgrades",
     "sectionTitle": "Example Upgrades",
@@ -4510,7 +4621,7 @@
     "kind": "page"
   },
   {
-    "id": "361-release-notes/0.25#installation",
+    "id": "370-release-notes/0.25#installation",
     "title": "Zero 0.25",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -4520,7 +4631,7 @@
     "kind": "section"
   },
   {
-    "id": "362-release-notes/0.25#overview",
+    "id": "371-release-notes/0.25#overview",
     "title": "Zero 0.25",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -4530,7 +4641,7 @@
     "kind": "section"
   },
   {
-    "id": "363-release-notes/0.25#upgrading",
+    "id": "372-release-notes/0.25#upgrading",
     "title": "Zero 0.25",
     "searchTitle": "Upgrading",
     "sectionTitle": "Upgrading",
@@ -4540,7 +4651,7 @@
     "kind": "section"
   },
   {
-    "id": "364-release-notes/0.25#features",
+    "id": "373-release-notes/0.25#features",
     "title": "Zero 0.25",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4550,7 +4661,7 @@
     "kind": "section"
   },
   {
-    "id": "365-release-notes/0.25#performance",
+    "id": "374-release-notes/0.25#performance",
     "title": "Zero 0.25",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
@@ -4560,7 +4671,7 @@
     "kind": "section"
   },
   {
-    "id": "366-release-notes/0.25#fixes",
+    "id": "375-release-notes/0.25#fixes",
     "title": "Zero 0.25",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4570,7 +4681,7 @@
     "kind": "section"
   },
   {
-    "id": "367-release-notes/0.25#breaking-changes",
+    "id": "376-release-notes/0.25#breaking-changes",
     "title": "Zero 0.25",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4606,7 +4717,7 @@
     "kind": "page"
   },
   {
-    "id": "368-release-notes/0.26#installation",
+    "id": "377-release-notes/0.26#installation",
     "title": "Zero 0.26",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -4616,7 +4727,7 @@
     "kind": "section"
   },
   {
-    "id": "369-release-notes/0.26#features",
+    "id": "378-release-notes/0.26#features",
     "title": "Zero 0.26",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4626,7 +4737,7 @@
     "kind": "section"
   },
   {
-    "id": "370-release-notes/0.26#fixes",
+    "id": "379-release-notes/0.26#fixes",
     "title": "Zero 0.26",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4636,7 +4747,7 @@
     "kind": "section"
   },
   {
-    "id": "371-release-notes/0.26#breaking-changes",
+    "id": "380-release-notes/0.26#breaking-changes",
     "title": "Zero 0.26",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4680,7 +4791,7 @@
     "kind": "page"
   },
   {
-    "id": "372-release-notes/0.3#install",
+    "id": "381-release-notes/0.3#install",
     "title": "Zero 0.3",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4690,7 +4801,7 @@
     "kind": "section"
   },
   {
-    "id": "373-release-notes/0.3#breaking-changes",
+    "id": "382-release-notes/0.3#breaking-changes",
     "title": "Zero 0.3",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
@@ -4700,7 +4811,7 @@
     "kind": "section"
   },
   {
-    "id": "374-release-notes/0.3#features",
+    "id": "383-release-notes/0.3#features",
     "title": "Zero 0.3",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4710,7 +4821,7 @@
     "kind": "section"
   },
   {
-    "id": "375-release-notes/0.3#fixes",
+    "id": "384-release-notes/0.3#fixes",
     "title": "Zero 0.3",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4720,7 +4831,7 @@
     "kind": "section"
   },
   {
-    "id": "376-release-notes/0.3#docs",
+    "id": "385-release-notes/0.3#docs",
     "title": "Zero 0.3",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -4730,7 +4841,7 @@
     "kind": "section"
   },
   {
-    "id": "377-release-notes/0.3#zbugs",
+    "id": "386-release-notes/0.3#zbugs",
     "title": "Zero 0.3",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -4774,7 +4885,7 @@
     "kind": "page"
   },
   {
-    "id": "378-release-notes/0.4#install",
+    "id": "387-release-notes/0.4#install",
     "title": "Zero 0.4",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4784,7 +4895,7 @@
     "kind": "section"
   },
   {
-    "id": "379-release-notes/0.4#breaking-changes",
+    "id": "388-release-notes/0.4#breaking-changes",
     "title": "Zero 0.4",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
@@ -4794,7 +4905,7 @@
     "kind": "section"
   },
   {
-    "id": "380-release-notes/0.4#added-or--and--and-not-to-zql-documentation",
+    "id": "389-release-notes/0.4#added-or--and--and-not-to-zql-documentation",
     "title": "Zero 0.4",
     "searchTitle": "Added or , and , and not to ZQL (documentation).",
     "sectionTitle": "Added or , and , and not to ZQL (documentation).",
@@ -4804,7 +4915,7 @@
     "kind": "section"
   },
   {
-    "id": "381-release-notes/0.4#fixes",
+    "id": "390-release-notes/0.4#fixes",
     "title": "Zero 0.4",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4814,7 +4925,7 @@
     "kind": "section"
   },
   {
-    "id": "382-release-notes/0.4#docs",
+    "id": "391-release-notes/0.4#docs",
     "title": "Zero 0.4",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -4824,7 +4935,7 @@
     "kind": "section"
   },
   {
-    "id": "383-release-notes/0.4#zbugs",
+    "id": "392-release-notes/0.4#zbugs",
     "title": "Zero 0.4",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -4868,7 +4979,7 @@
     "kind": "page"
   },
   {
-    "id": "384-release-notes/0.5#install",
+    "id": "393-release-notes/0.5#install",
     "title": "Zero 0.5",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4878,7 +4989,7 @@
     "kind": "section"
   },
   {
-    "id": "385-release-notes/0.5#breaking-changes",
+    "id": "394-release-notes/0.5#breaking-changes",
     "title": "Zero 0.5",
     "searchTitle": "Breaking changes",
     "sectionTitle": "Breaking changes",
@@ -4888,7 +4999,7 @@
     "kind": "section"
   },
   {
-    "id": "386-release-notes/0.5#features",
+    "id": "395-release-notes/0.5#features",
     "title": "Zero 0.5",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -4898,7 +5009,7 @@
     "kind": "section"
   },
   {
-    "id": "387-release-notes/0.5#fixes",
+    "id": "396-release-notes/0.5#fixes",
     "title": "Zero 0.5",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -4908,7 +5019,7 @@
     "kind": "section"
   },
   {
-    "id": "388-release-notes/0.5#docs",
+    "id": "397-release-notes/0.5#docs",
     "title": "Zero 0.5",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -4918,7 +5029,7 @@
     "kind": "section"
   },
   {
-    "id": "389-release-notes/0.5#zbugs",
+    "id": "398-release-notes/0.5#zbugs",
     "title": "Zero 0.5",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -4962,7 +5073,7 @@
     "kind": "page"
   },
   {
-    "id": "390-release-notes/0.6#install",
+    "id": "399-release-notes/0.6#install",
     "title": "Zero 0.6",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -4972,7 +5083,7 @@
     "kind": "section"
   },
   {
-    "id": "391-release-notes/0.6#upgrade-guide",
+    "id": "400-release-notes/0.6#upgrade-guide",
     "title": "Zero 0.6",
     "searchTitle": "Upgrade Guide",
     "sectionTitle": "Upgrade Guide",
@@ -4982,7 +5093,7 @@
     "kind": "section"
   },
   {
-    "id": "392-release-notes/0.6#breaking-changes",
+    "id": "401-release-notes/0.6#breaking-changes",
     "title": "Zero 0.6",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -4992,7 +5103,7 @@
     "kind": "section"
   },
   {
-    "id": "393-release-notes/0.6#features",
+    "id": "402-release-notes/0.6#features",
     "title": "Zero 0.6",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5002,7 +5113,7 @@
     "kind": "section"
   },
   {
-    "id": "394-release-notes/0.6#zbugs",
+    "id": "403-release-notes/0.6#zbugs",
     "title": "Zero 0.6",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -5012,7 +5123,7 @@
     "kind": "section"
   },
   {
-    "id": "395-release-notes/0.6#docs",
+    "id": "404-release-notes/0.6#docs",
     "title": "Zero 0.6",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -5052,7 +5163,7 @@
     "kind": "page"
   },
   {
-    "id": "396-release-notes/0.7#install",
+    "id": "405-release-notes/0.7#install",
     "title": "Zero 0.7",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -5062,7 +5173,7 @@
     "kind": "section"
   },
   {
-    "id": "397-release-notes/0.7#features",
+    "id": "406-release-notes/0.7#features",
     "title": "Zero 0.7",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5072,7 +5183,7 @@
     "kind": "section"
   },
   {
-    "id": "398-release-notes/0.7#breaking-changes",
+    "id": "407-release-notes/0.7#breaking-changes",
     "title": "Zero 0.7",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5082,7 +5193,7 @@
     "kind": "section"
   },
   {
-    "id": "399-release-notes/0.7#zbugs",
+    "id": "408-release-notes/0.7#zbugs",
     "title": "Zero 0.7",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -5092,7 +5203,7 @@
     "kind": "section"
   },
   {
-    "id": "400-release-notes/0.7#docs",
+    "id": "409-release-notes/0.7#docs",
     "title": "Zero 0.7",
     "searchTitle": "Docs",
     "sectionTitle": "Docs",
@@ -5128,7 +5239,7 @@
     "kind": "page"
   },
   {
-    "id": "401-release-notes/0.8#install",
+    "id": "410-release-notes/0.8#install",
     "title": "Zero 0.8",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -5138,7 +5249,7 @@
     "kind": "section"
   },
   {
-    "id": "402-release-notes/0.8#features",
+    "id": "411-release-notes/0.8#features",
     "title": "Zero 0.8",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5148,7 +5259,7 @@
     "kind": "section"
   },
   {
-    "id": "403-release-notes/0.8#fixes",
+    "id": "412-release-notes/0.8#fixes",
     "title": "Zero 0.8",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5158,7 +5269,7 @@
     "kind": "section"
   },
   {
-    "id": "404-release-notes/0.8#breaking-changes",
+    "id": "413-release-notes/0.8#breaking-changes",
     "title": "Zero 0.8",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5194,7 +5305,7 @@
     "kind": "page"
   },
   {
-    "id": "405-release-notes/0.9#install",
+    "id": "414-release-notes/0.9#install",
     "title": "Zero 0.9",
     "searchTitle": "Install",
     "sectionTitle": "Install",
@@ -5204,7 +5315,7 @@
     "kind": "section"
   },
   {
-    "id": "406-release-notes/0.9#features",
+    "id": "415-release-notes/0.9#features",
     "title": "Zero 0.9",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5214,7 +5325,7 @@
     "kind": "section"
   },
   {
-    "id": "407-release-notes/0.9#fixes",
+    "id": "416-release-notes/0.9#fixes",
     "title": "Zero 0.9",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5224,7 +5335,7 @@
     "kind": "section"
   },
   {
-    "id": "408-release-notes/0.9#breaking-changes",
+    "id": "417-release-notes/0.9#breaking-changes",
     "title": "Zero 0.9",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5264,7 +5375,7 @@
     "kind": "page"
   },
   {
-    "id": "409-release-notes/1.0#installation",
+    "id": "418-release-notes/1.0#installation",
     "title": "Zero 1.0",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -5274,7 +5385,7 @@
     "kind": "section"
   },
   {
-    "id": "410-release-notes/1.0#overview",
+    "id": "419-release-notes/1.0#overview",
     "title": "Zero 1.0",
     "searchTitle": "Overview",
     "sectionTitle": "Overview",
@@ -5284,7 +5395,7 @@
     "kind": "section"
   },
   {
-    "id": "411-release-notes/1.0#features",
+    "id": "420-release-notes/1.0#features",
     "title": "Zero 1.0",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5294,7 +5405,7 @@
     "kind": "section"
   },
   {
-    "id": "412-release-notes/1.0#fixes",
+    "id": "421-release-notes/1.0#fixes",
     "title": "Zero 1.0",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5304,7 +5415,7 @@
     "kind": "section"
   },
   {
-    "id": "413-release-notes/1.0#breaking-changes",
+    "id": "422-release-notes/1.0#breaking-changes",
     "title": "Zero 1.0",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5340,7 +5451,7 @@
     "kind": "page"
   },
   {
-    "id": "414-release-notes/1.1#installation",
+    "id": "423-release-notes/1.1#installation",
     "title": "Zero 1.1",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -5350,7 +5461,7 @@
     "kind": "section"
   },
   {
-    "id": "415-release-notes/1.1#features",
+    "id": "424-release-notes/1.1#features",
     "title": "Zero 1.1",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5360,7 +5471,7 @@
     "kind": "section"
   },
   {
-    "id": "416-release-notes/1.1#fixes",
+    "id": "425-release-notes/1.1#fixes",
     "title": "Zero 1.1",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5370,7 +5481,7 @@
     "kind": "section"
   },
   {
-    "id": "417-release-notes/1.1#breaking-changes",
+    "id": "426-release-notes/1.1#breaking-changes",
     "title": "Zero 1.1",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5410,7 +5521,7 @@
     "kind": "page"
   },
   {
-    "id": "418-release-notes/1.2#installation",
+    "id": "427-release-notes/1.2#installation",
     "title": "Zero 1.2",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -5420,7 +5531,7 @@
     "kind": "section"
   },
   {
-    "id": "419-release-notes/1.2#features",
+    "id": "428-release-notes/1.2#features",
     "title": "Zero 1.2",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5430,7 +5541,7 @@
     "kind": "section"
   },
   {
-    "id": "420-release-notes/1.2#performance",
+    "id": "429-release-notes/1.2#performance",
     "title": "Zero 1.2",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
@@ -5440,7 +5551,7 @@
     "kind": "section"
   },
   {
-    "id": "421-release-notes/1.2#fixes",
+    "id": "430-release-notes/1.2#fixes",
     "title": "Zero 1.2",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5450,7 +5561,7 @@
     "kind": "section"
   },
   {
-    "id": "422-release-notes/1.2#breaking-changes",
+    "id": "431-release-notes/1.2#breaking-changes",
     "title": "Zero 1.2",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5490,7 +5601,7 @@
     "kind": "page"
   },
   {
-    "id": "423-release-notes/1.3#installation",
+    "id": "432-release-notes/1.3#installation",
     "title": "Zero 1.3",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -5500,7 +5611,7 @@
     "kind": "section"
   },
   {
-    "id": "424-release-notes/1.3#features",
+    "id": "433-release-notes/1.3#features",
     "title": "Zero 1.3",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5510,7 +5621,7 @@
     "kind": "section"
   },
   {
-    "id": "425-release-notes/1.3#performance",
+    "id": "434-release-notes/1.3#performance",
     "title": "Zero 1.3",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
@@ -5520,7 +5631,7 @@
     "kind": "section"
   },
   {
-    "id": "426-release-notes/1.3#fixes",
+    "id": "435-release-notes/1.3#fixes",
     "title": "Zero 1.3",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5530,7 +5641,7 @@
     "kind": "section"
   },
   {
-    "id": "427-release-notes/1.3#breaking-changes",
+    "id": "436-release-notes/1.3#breaking-changes",
     "title": "Zero 1.3",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -5544,11 +5655,19 @@
     "title": "Zero 1.4",
     "searchTitle": "Zero 1.4",
     "url": "/docs/release-notes/1.4",
-    "content": "Installation npm install @rocicorp/zero@1.4 Features Kysely Adapter: Added zeroKysely, so Zero server mutators can run against a Kysely transaction. Analyze Query Library: Added @rocicorp/zero/analyze, for easier CLI-based query analysis. Shadow Sync: zero-cache can now periodically test initial sync in the background, to catch schema drift and full-resync failures earlier. Client Log Sink: Added a logSink param to Zero constructor for redirecting Zero client logs. Cloud Zero Ad 🙃: Added a small notice about Cloud Zero in the zero-cache-dev startup output. Disable with ZERO_ENABLE_STARTUP_MESSAGE=0. Performance 7x faster client-side index construction 2x faster backfills by switching zero-cache to binary COPY Various optimizations to query hydration and updates: +9-16% hydration and +3-18% updates by reducing polymorphism +8-14% updates by reducing allocations +5-16% hydration by reducing allocations +7% hydration for queries with joins Avoid full table scans from reordered compound primary keys Fixes Pagination on non-null columns could trigger full scans (thanks @utkarsh-611!) Include details in query/mutator validation errors (thanks @tjenkinson!) Inspector query analysis wasn't using Zero's planner Add query name to hydration spans in otel PgBouncer causing cached plan must not change result type error Transient litestream restore failures were incorrectly alerting Nullable array columns silently converted to [] (thanks @kvnkusch!) Change-log entries could be incorrectly purged during handoff Concurrent, nested, and CREATE/DROP INDEX CONCURRENTLY DDL were breaking schema replication Event-trigger upgrade permission errors sometimes swallowed Replication slot creation hanging during startup Autoreset during startup could deadlock while recreating a replication slot Original SQLite transaction failures hidden behind rollback errors Columns with complex Postgres backfilled incorrectly Latency histograms buckets are too broad Inspector parse and analyze errors incorrectly emitting ERROR logs Stalled change-streamer transactions could hang progress indefinitely OTel metrics from multiple worker processes clobbering each other Drain-mode SIGTERM exited uncleanly during startup Breaking Changes None.",
+    "content": "Installation npm install @rocicorp/zero@1.4 Upgrading userID: \"anon\" If you are using userID: 'anon' for logged-out users, change it to userID: null or userID: undefined. Passing userID: 'anon' is being deprecated in advance of upcoming security work in Zero 1.5. Change this: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={userID ?? 'anon'}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={userID ?? 'anon'}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' const zero = new Zero({ userID: userID ?? 'anon' // ... }) To this: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={userID}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={userID}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' const zero = new Zero({ userID // ... }) Features Kysely Adapter: Added zeroKysely, so Zero server mutators can run against a Kysely transaction. Analyze Query Library: Added @rocicorp/zero/analyze, for easier CLI-based query analysis. Shadow Sync: zero-cache can now periodically test initial sync in the background, to catch schema drift and full-resync failures earlier. Client Log Sink: Added a logSink param to Zero constructor for redirecting Zero client logs. Cloud Zero Ad 🙃: Added a small notice about Cloud Zero in the zero-cache-dev startup output. Disable with ZERO_ENABLE_STARTUP_MESSAGE=0. Performance 7x faster client-side index construction 2x faster backfills by switching zero-cache to binary COPY Various optimizations to query hydration and updates: +9-16% hydration and +3-18% updates by reducing polymorphism +8-14% updates by reducing allocations +5-16% hydration by reducing allocations +7% hydration for queries with joins Avoid full table scans from reordered compound primary keys Fixes Pagination on non-null columns could trigger full scans (thanks @utkarsh-611!) Include details in query/mutator validation errors (thanks @tjenkinson!) Inspector query analysis wasn't using Zero's planner Add query name to hydration spans in otel PgBouncer causing cached plan must not change result type error Transient litestream restore failures were incorrectly alerting Nullable array columns silently converted to [] (thanks @kvnkusch!) Change-log entries could be incorrectly purged during handoff Concurrent, nested, and CREATE/DROP INDEX CONCURRENTLY DDL were breaking schema replication Event-trigger upgrade permission errors sometimes swallowed Replication slot creation hanging during startup Autoreset during startup could deadlock while recreating a replication slot Original SQLite transaction failures hidden behind rollback errors Columns with complex Postgres backfilled incorrectly Latency histograms buckets are too broad Inspector parse and analyze errors incorrectly emitting ERROR logs Stalled change-streamer transactions could hang progress indefinitely OTel metrics from multiple worker processes clobbering each other Drain-mode SIGTERM exited uncleanly during startup Breaking Changes None. One API was deprecated: userID: 'anon' for logged-out clients See Upgrading for more information.",
     "headings": [
       {
         "text": "Installation",
         "id": "installation"
+      },
+      {
+        "text": "Upgrading",
+        "id": "upgrading"
+      },
+      {
+        "text": "userID: \"anon\"",
+        "id": "userid-anon"
       },
       {
         "text": "Features",
@@ -5570,7 +5689,7 @@
     "kind": "page"
   },
   {
-    "id": "428-release-notes/1.4#installation",
+    "id": "437-release-notes/1.4#installation",
     "title": "Zero 1.4",
     "searchTitle": "Installation",
     "sectionTitle": "Installation",
@@ -5580,7 +5699,27 @@
     "kind": "section"
   },
   {
-    "id": "429-release-notes/1.4#features",
+    "id": "438-release-notes/1.4#upgrading",
+    "title": "Zero 1.4",
+    "searchTitle": "Upgrading",
+    "sectionTitle": "Upgrading",
+    "sectionId": "upgrading",
+    "url": "/docs/release-notes/1.4",
+    "content": "userID: \"anon\" If you are using userID: 'anon' for logged-out users, change it to userID: null or userID: undefined. Passing userID: 'anon' is being deprecated in advance of upcoming security work in Zero 1.5. Change this: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={userID ?? 'anon'}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={userID ?? 'anon'}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' const zero = new Zero({ userID: userID ?? 'anon' // ... }) To this: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={userID}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={userID}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' const zero = new Zero({ userID // ... })",
+    "kind": "section"
+  },
+  {
+    "id": "439-release-notes/1.4#userid-anon",
+    "title": "Zero 1.4",
+    "searchTitle": "userID: \"anon\"",
+    "sectionTitle": "userID: \"anon\"",
+    "sectionId": "userid-anon",
+    "url": "/docs/release-notes/1.4",
+    "content": "If you are using userID: 'anon' for logged-out users, change it to userID: null or userID: undefined. Passing userID: 'anon' is being deprecated in advance of upcoming security work in Zero 1.5. Change this: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={userID ?? 'anon'}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={userID ?? 'anon'}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' const zero = new Zero({ userID: userID ?? 'anon' // ... }) To this: import {ZeroProvider} from '@rocicorp/zero/react' return ( <ZeroProvider userID={userID}> <App /> </ZeroProvider> )import {ZeroProvider} from '@rocicorp/zero/solid' return ( <ZeroProvider userID={userID}> <App /> </ZeroProvider> )import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' const zero = new Zero({ userID // ... })",
+    "kind": "section"
+  },
+  {
+    "id": "440-release-notes/1.4#features",
     "title": "Zero 1.4",
     "searchTitle": "Features",
     "sectionTitle": "Features",
@@ -5590,7 +5729,7 @@
     "kind": "section"
   },
   {
-    "id": "430-release-notes/1.4#performance",
+    "id": "441-release-notes/1.4#performance",
     "title": "Zero 1.4",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
@@ -5600,7 +5739,7 @@
     "kind": "section"
   },
   {
-    "id": "431-release-notes/1.4#fixes",
+    "id": "442-release-notes/1.4#fixes",
     "title": "Zero 1.4",
     "searchTitle": "Fixes",
     "sectionTitle": "Fixes",
@@ -5610,26 +5749,148 @@
     "kind": "section"
   },
   {
-    "id": "432-release-notes/1.4#breaking-changes",
+    "id": "443-release-notes/1.4#breaking-changes",
     "title": "Zero 1.4",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
     "sectionId": "breaking-changes",
     "url": "/docs/release-notes/1.4",
-    "content": "None.",
+    "content": "None. One API was deprecated: userID: 'anon' for logged-out clients See Upgrading for more information.",
     "kind": "section"
   },
   {
-    "id": "57-release-notes",
+    "id": "57-release-notes/1.5",
+    "title": "Zero 1.5",
+    "searchTitle": "Zero 1.5",
+    "url": "/docs/release-notes/1.5",
+    "content": "Installation npm install @rocicorp/zero@1.5 Upgrading See ztunes and hello-zero-solid for examples of how to upgrade to Zero 1.5. Authenticated Client Groups The handleQueryRequest and handleMutateRequest helpers now take an options object instead of multiple arguments. They also require a new userID parameter. Change this: // query handler handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) // mutate handler handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) To this: // query handler handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID }) // mutate handler handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID }) This is a security enhancement and is recommended for all users. See Why pass userID back to Zero? and PR 5836 for more information. The old signature is still supported but deprecated. Deploy Order Make sure to deploy zero-cache before your API server. This is existing standard practice for Zero, but it matters for this release because the 1.5 handleQueryRequest and handleMutateRequest helpers return a new response shape that zero-cache 1.4 cannot parse. Features Schema Change Hooks: Added zero_<shard>.update_schemas(), so databases that do not support or allow event triggers can manually notify Zero after schema changes. Authenticated Client Groups: handleQueryRequest and handleMutateRequest now takes a userID parameter. This enables Zero to enforce that only tabs belonging to the same user can be in the same client group. Performance Faster flipped-join fetches when the parent key is unique Fixes CREATE/DROP INDEX CONCURRENTLY could break replication Long-lived connections could miss periodic auth revalidation Allow omitting ctx param when no context type is defined Make /keepalive timeout + graceful-shutdown opt-in except in ECSs Error: pipelines must be initialized during transform or drain Shadow sync could miss its first run before replication-manager restarted Row-set drift across view-syncer re-hydration could result in stale rows Make WebSocket compression and max-payload settings client-only Breaking Changes None. One API was deprecated: The positional signatures of handleQueryRequest and handleMutateRequest See Upgrading for more information.",
+    "headings": [
+      {
+        "text": "Installation",
+        "id": "installation"
+      },
+      {
+        "text": "Upgrading",
+        "id": "upgrading"
+      },
+      {
+        "text": "Authenticated Client Groups",
+        "id": "authenticated-client-groups"
+      },
+      {
+        "text": "Deploy Order",
+        "id": "deploy-order"
+      },
+      {
+        "text": "Features",
+        "id": "features"
+      },
+      {
+        "text": "Performance",
+        "id": "performance"
+      },
+      {
+        "text": "Fixes",
+        "id": "fixes"
+      },
+      {
+        "text": "Breaking Changes",
+        "id": "breaking-changes"
+      }
+    ],
+    "kind": "page"
+  },
+  {
+    "id": "444-release-notes/1.5#installation",
+    "title": "Zero 1.5",
+    "searchTitle": "Installation",
+    "sectionTitle": "Installation",
+    "sectionId": "installation",
+    "url": "/docs/release-notes/1.5",
+    "content": "npm install @rocicorp/zero@1.5",
+    "kind": "section"
+  },
+  {
+    "id": "445-release-notes/1.5#upgrading",
+    "title": "Zero 1.5",
+    "searchTitle": "Upgrading",
+    "sectionTitle": "Upgrading",
+    "sectionId": "upgrading",
+    "url": "/docs/release-notes/1.5",
+    "content": "See ztunes and hello-zero-solid for examples of how to upgrade to Zero 1.5. Authenticated Client Groups The handleQueryRequest and handleMutateRequest helpers now take an options object instead of multiple arguments. They also require a new userID parameter. Change this: // query handler handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) // mutate handler handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) To this: // query handler handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID }) // mutate handler handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID }) This is a security enhancement and is recommended for all users. See Why pass userID back to Zero? and PR 5836 for more information. The old signature is still supported but deprecated. Deploy Order Make sure to deploy zero-cache before your API server. This is existing standard practice for Zero, but it matters for this release because the 1.5 handleQueryRequest and handleMutateRequest helpers return a new response shape that zero-cache 1.4 cannot parse.",
+    "kind": "section"
+  },
+  {
+    "id": "446-release-notes/1.5#authenticated-client-groups",
+    "title": "Zero 1.5",
+    "searchTitle": "Authenticated Client Groups",
+    "sectionTitle": "Authenticated Client Groups",
+    "sectionId": "authenticated-client-groups",
+    "url": "/docs/release-notes/1.5",
+    "content": "The handleQueryRequest and handleMutateRequest helpers now take an options object instead of multiple arguments. They also require a new userID parameter. Change this: // query handler handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) // mutate handler handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) To this: // query handler handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID }) // mutate handler handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID }) This is a security enhancement and is recommended for all users. See Why pass userID back to Zero? and PR 5836 for more information. The old signature is still supported but deprecated.",
+    "kind": "section"
+  },
+  {
+    "id": "447-release-notes/1.5#deploy-order",
+    "title": "Zero 1.5",
+    "searchTitle": "Deploy Order",
+    "sectionTitle": "Deploy Order",
+    "sectionId": "deploy-order",
+    "url": "/docs/release-notes/1.5",
+    "content": "Make sure to deploy zero-cache before your API server. This is existing standard practice for Zero, but it matters for this release because the 1.5 handleQueryRequest and handleMutateRequest helpers return a new response shape that zero-cache 1.4 cannot parse.",
+    "kind": "section"
+  },
+  {
+    "id": "448-release-notes/1.5#features",
+    "title": "Zero 1.5",
+    "searchTitle": "Features",
+    "sectionTitle": "Features",
+    "sectionId": "features",
+    "url": "/docs/release-notes/1.5",
+    "content": "Schema Change Hooks: Added zero_<shard>.update_schemas(), so databases that do not support or allow event triggers can manually notify Zero after schema changes. Authenticated Client Groups: handleQueryRequest and handleMutateRequest now takes a userID parameter. This enables Zero to enforce that only tabs belonging to the same user can be in the same client group.",
+    "kind": "section"
+  },
+  {
+    "id": "449-release-notes/1.5#performance",
+    "title": "Zero 1.5",
+    "searchTitle": "Performance",
+    "sectionTitle": "Performance",
+    "sectionId": "performance",
+    "url": "/docs/release-notes/1.5",
+    "content": "Faster flipped-join fetches when the parent key is unique",
+    "kind": "section"
+  },
+  {
+    "id": "450-release-notes/1.5#fixes",
+    "title": "Zero 1.5",
+    "searchTitle": "Fixes",
+    "sectionTitle": "Fixes",
+    "sectionId": "fixes",
+    "url": "/docs/release-notes/1.5",
+    "content": "CREATE/DROP INDEX CONCURRENTLY could break replication Long-lived connections could miss periodic auth revalidation Allow omitting ctx param when no context type is defined Make /keepalive timeout + graceful-shutdown opt-in except in ECSs Error: pipelines must be initialized during transform or drain Shadow sync could miss its first run before replication-manager restarted Row-set drift across view-syncer re-hydration could result in stale rows Make WebSocket compression and max-payload settings client-only",
+    "kind": "section"
+  },
+  {
+    "id": "451-release-notes/1.5#breaking-changes",
+    "title": "Zero 1.5",
+    "searchTitle": "Breaking Changes",
+    "sectionTitle": "Breaking Changes",
+    "sectionId": "breaking-changes",
+    "url": "/docs/release-notes/1.5",
+    "content": "None. One API was deprecated: The positional signatures of handleQueryRequest and handleMutateRequest See Upgrading for more information.",
+    "kind": "section"
+  },
+  {
+    "id": "58-release-notes",
     "title": "Release Notes",
     "searchTitle": "Release Notes",
     "url": "/docs/release-notes",
-    "content": "Zero 1.4: Performance and Reliability Improvements Zero 1.3: Faster Initial Sync and Other Perf Improvements Zero 1.2: IVM Performance and Bug Fixes Zero 1.1: Replication Monitoring Zero 1.0: First Stable Release Zero 0.26: Schema Backfill and Scalar Subqueries Zero 0.25: DX Overhaul, Query Planning Zero 0.24: Join Flipping, Cookie Auth, Inspector Updates Zero 0.23: Synced Queries and React Native Support Zero 0.22: Simplified TTLs Zero 0.21: PG arrays, TanStack starter, and more Zero 0.20: Full Supabase support, performance improvements Zero 0.19: Many, many bugfixes and cleanups Zero 0.18: Custom Mutators Zero 0.17: Background Queries Zero 0.16: Lambda-Based Permission Deployment Zero 0.15: Live Permission Updates Zero 0.14: Name Mapping and Multischema Zero 0.13: Multinode and SST Zero 0.12: Circular Relationships Zero 0.11: Windows Zero 0.10: Remove Top-Level Await Zero 0.9: JWK Support Zero 0.8: Schema Autobuild, Result Types, and Enums Zero 0.7: Read Perms and Docker Zero 0.6: Relationship Filters Zero 0.5: JSON Columns Zero 0.4: Compound Filters Zero 0.3: Schema Migrations and Write Perms Zero 0.2: Skip Mode and Computed PKs Zero 0.1: First Release",
+    "content": "Zero 1.5: Schema Change Improvements and Client Group Auth Zero 1.4: Performance and Reliability Improvements Zero 1.3: Faster Initial Sync and Other Perf Improvements Zero 1.2: IVM Performance and Bug Fixes Zero 1.1: Replication Monitoring Zero 1.0: First Stable Release Zero 0.26: Schema Backfill and Scalar Subqueries Zero 0.25: DX Overhaul, Query Planning Zero 0.24: Join Flipping, Cookie Auth, Inspector Updates Zero 0.23: Synced Queries and React Native Support Zero 0.22: Simplified TTLs Zero 0.21: PG arrays, TanStack starter, and more Zero 0.20: Full Supabase support, performance improvements Zero 0.19: Many, many bugfixes and cleanups Zero 0.18: Custom Mutators Zero 0.17: Background Queries Zero 0.16: Lambda-Based Permission Deployment Zero 0.15: Live Permission Updates Zero 0.14: Name Mapping and Multischema Zero 0.13: Multinode and SST Zero 0.12: Circular Relationships Zero 0.11: Windows Zero 0.10: Remove Top-Level Await Zero 0.9: JWK Support Zero 0.8: Schema Autobuild, Result Types, and Enums Zero 0.7: Read Perms and Docker Zero 0.6: Relationship Filters Zero 0.5: JSON Columns Zero 0.4: Compound Filters Zero 0.3: Schema Migrations and Write Perms Zero 0.2: Skip Mode and Computed PKs Zero 0.1: First Release",
     "headings": [],
     "kind": "page"
   },
   {
-    "id": "58-reporting-bugs",
+    "id": "59-reporting-bugs",
     "title": "Reporting Bugs",
     "searchTitle": "Reporting Bugs",
     "url": "/docs/reporting-bugs",
@@ -5647,7 +5908,7 @@
     "kind": "page"
   },
   {
-    "id": "433-reporting-bugs#zbugs",
+    "id": "452-reporting-bugs#zbugs",
     "title": "Reporting Bugs",
     "searchTitle": "zbugs",
     "sectionTitle": "zbugs",
@@ -5657,7 +5918,7 @@
     "kind": "section"
   },
   {
-    "id": "434-reporting-bugs#discord",
+    "id": "453-reporting-bugs#discord",
     "title": "Reporting Bugs",
     "searchTitle": "Discord",
     "sectionTitle": "Discord",
@@ -5667,7 +5928,7 @@
     "kind": "section"
   },
   {
-    "id": "59-rest",
+    "id": "60-rest",
     "title": "REST",
     "searchTitle": "REST",
     "url": "/docs/rest",
@@ -5693,7 +5954,7 @@
     "kind": "page"
   },
   {
-    "id": "435-rest#pattern",
+    "id": "454-rest#pattern",
     "title": "REST",
     "searchTitle": "Pattern",
     "sectionTitle": "Pattern",
@@ -5703,7 +5964,7 @@
     "kind": "section"
   },
   {
-    "id": "436-rest#tanstack-start-example",
+    "id": "455-rest#tanstack-start-example",
     "title": "REST",
     "searchTitle": "TanStack Start Example",
     "sectionTitle": "TanStack Start Example",
@@ -5713,7 +5974,7 @@
     "kind": "section"
   },
   {
-    "id": "437-rest#openapi-generation",
+    "id": "456-rest#openapi-generation",
     "title": "REST",
     "searchTitle": "OpenAPI Generation",
     "sectionTitle": "OpenAPI Generation",
@@ -5723,7 +5984,7 @@
     "kind": "section"
   },
   {
-    "id": "438-rest#full-working-example",
+    "id": "457-rest#full-working-example",
     "title": "REST",
     "searchTitle": "Full Working Example",
     "sectionTitle": "Full Working Example",
@@ -5733,7 +5994,7 @@
     "kind": "section"
   },
   {
-    "id": "60-roadmap",
+    "id": "61-roadmap",
     "title": "Roadmap",
     "searchTitle": "Roadmap",
     "url": "/docs/roadmap",
@@ -5751,7 +6012,7 @@
     "kind": "page"
   },
   {
-    "id": "439-roadmap#q4-2025",
+    "id": "458-roadmap#q4-2025",
     "title": "Roadmap",
     "searchTitle": "Q4 2025",
     "sectionTitle": "Q4 2025",
@@ -5761,7 +6022,7 @@
     "kind": "section"
   },
   {
-    "id": "440-roadmap#beyond",
+    "id": "459-roadmap#beyond",
     "title": "Roadmap",
     "searchTitle": "Beyond",
     "sectionTitle": "Beyond",
@@ -5771,7 +6032,7 @@
     "kind": "section"
   },
   {
-    "id": "61-samples",
+    "id": "62-samples",
     "title": "Samples",
     "searchTitle": "Samples",
     "url": "/docs/samples",
@@ -5797,7 +6058,7 @@
     "kind": "page"
   },
   {
-    "id": "441-samples#gigabugs",
+    "id": "460-samples#gigabugs",
     "title": "Samples",
     "searchTitle": "Gigabugs",
     "sectionTitle": "Gigabugs",
@@ -5807,7 +6068,7 @@
     "kind": "section"
   },
   {
-    "id": "442-samples#ztunes",
+    "id": "461-samples#ztunes",
     "title": "Samples",
     "searchTitle": "ztunes",
     "sectionTitle": "ztunes",
@@ -5817,7 +6078,7 @@
     "kind": "section"
   },
   {
-    "id": "443-samples#zslack",
+    "id": "462-samples#zslack",
     "title": "Samples",
     "searchTitle": "zslack",
     "sectionTitle": "zslack",
@@ -5827,7 +6088,7 @@
     "kind": "section"
   },
   {
-    "id": "444-samples#onboarding",
+    "id": "463-samples#onboarding",
     "title": "Samples",
     "searchTitle": "onboarding",
     "sectionTitle": "onboarding",
@@ -5837,7 +6098,7 @@
     "kind": "section"
   },
   {
-    "id": "62-schema",
+    "id": "63-schema",
     "title": "Zero Schema",
     "searchTitle": "Zero Schema",
     "url": "/docs/schema",
@@ -5963,7 +6224,7 @@
     "kind": "page"
   },
   {
-    "id": "445-schema#generating-from-database",
+    "id": "464-schema#generating-from-database",
     "title": "Zero Schema",
     "searchTitle": "Generating from Database",
     "sectionTitle": "Generating from Database",
@@ -5973,7 +6234,7 @@
     "kind": "section"
   },
   {
-    "id": "446-schema#writing-by-hand",
+    "id": "465-schema#writing-by-hand",
     "title": "Zero Schema",
     "searchTitle": "Writing by Hand",
     "sectionTitle": "Writing by Hand",
@@ -5983,7 +6244,7 @@
     "kind": "section"
   },
   {
-    "id": "447-schema#table-schemas",
+    "id": "466-schema#table-schemas",
     "title": "Zero Schema",
     "searchTitle": "Table Schemas",
     "sectionTitle": "Table Schemas",
@@ -5993,7 +6254,7 @@
     "kind": "section"
   },
   {
-    "id": "448-schema#name-mapping",
+    "id": "467-schema#name-mapping",
     "title": "Zero Schema",
     "searchTitle": "Name Mapping",
     "sectionTitle": "Name Mapping",
@@ -6003,7 +6264,7 @@
     "kind": "section"
   },
   {
-    "id": "449-schema#multiple-schemas",
+    "id": "468-schema#multiple-schemas",
     "title": "Zero Schema",
     "searchTitle": "Multiple Schemas",
     "sectionTitle": "Multiple Schemas",
@@ -6013,7 +6274,7 @@
     "kind": "section"
   },
   {
-    "id": "450-schema#optional-columns",
+    "id": "469-schema#optional-columns",
     "title": "Zero Schema",
     "searchTitle": "Optional Columns",
     "sectionTitle": "Optional Columns",
@@ -6023,7 +6284,7 @@
     "kind": "section"
   },
   {
-    "id": "451-schema#enumerations",
+    "id": "470-schema#enumerations",
     "title": "Zero Schema",
     "searchTitle": "Enumerations",
     "sectionTitle": "Enumerations",
@@ -6033,7 +6294,7 @@
     "kind": "section"
   },
   {
-    "id": "452-schema#custom-json-types",
+    "id": "471-schema#custom-json-types",
     "title": "Zero Schema",
     "searchTitle": "Custom JSON Types",
     "sectionTitle": "Custom JSON Types",
@@ -6043,7 +6304,7 @@
     "kind": "section"
   },
   {
-    "id": "453-schema#compound-primary-keys",
+    "id": "472-schema#compound-primary-keys",
     "title": "Zero Schema",
     "searchTitle": "Compound Primary Keys",
     "sectionTitle": "Compound Primary Keys",
@@ -6053,7 +6314,7 @@
     "kind": "section"
   },
   {
-    "id": "454-schema#relationships",
+    "id": "473-schema#relationships",
     "title": "Zero Schema",
     "searchTitle": "Relationships",
     "sectionTitle": "Relationships",
@@ -6063,7 +6324,7 @@
     "kind": "section"
   },
   {
-    "id": "455-schema#many-to-many-relationships",
+    "id": "474-schema#many-to-many-relationships",
     "title": "Zero Schema",
     "searchTitle": "Many-to-Many Relationships",
     "sectionTitle": "Many-to-Many Relationships",
@@ -6073,7 +6334,7 @@
     "kind": "section"
   },
   {
-    "id": "456-schema#compound-keys-relationships",
+    "id": "475-schema#compound-keys-relationships",
     "title": "Zero Schema",
     "searchTitle": "Compound Keys Relationships",
     "sectionTitle": "Compound Keys Relationships",
@@ -6083,7 +6344,7 @@
     "kind": "section"
   },
   {
-    "id": "457-schema#circular-relationships",
+    "id": "476-schema#circular-relationships",
     "title": "Zero Schema",
     "searchTitle": "Circular Relationships",
     "sectionTitle": "Circular Relationships",
@@ -6093,7 +6354,7 @@
     "kind": "section"
   },
   {
-    "id": "458-schema#database-schemas",
+    "id": "477-schema#database-schemas",
     "title": "Zero Schema",
     "searchTitle": "Database Schemas",
     "sectionTitle": "Database Schemas",
@@ -6103,7 +6364,7 @@
     "kind": "section"
   },
   {
-    "id": "459-schema#register-schema-type",
+    "id": "478-schema#register-schema-type",
     "title": "Zero Schema",
     "searchTitle": "Register Schema Type",
     "sectionTitle": "Register Schema Type",
@@ -6113,7 +6374,7 @@
     "kind": "section"
   },
   {
-    "id": "460-schema#schema-changes",
+    "id": "479-schema#schema-changes",
     "title": "Zero Schema",
     "searchTitle": "Schema Changes",
     "sectionTitle": "Schema Changes",
@@ -6123,7 +6384,7 @@
     "kind": "section"
   },
   {
-    "id": "461-schema#development",
+    "id": "480-schema#development",
     "title": "Zero Schema",
     "searchTitle": "Development",
     "sectionTitle": "Development",
@@ -6133,7 +6394,7 @@
     "kind": "section"
   },
   {
-    "id": "462-schema#production",
+    "id": "481-schema#production",
     "title": "Zero Schema",
     "searchTitle": "Production",
     "sectionTitle": "Production",
@@ -6143,7 +6404,7 @@
     "kind": "section"
   },
   {
-    "id": "463-schema#expand-changes",
+    "id": "482-schema#expand-changes",
     "title": "Zero Schema",
     "searchTitle": "Expand Changes",
     "sectionTitle": "Expand Changes",
@@ -6153,7 +6414,7 @@
     "kind": "section"
   },
   {
-    "id": "464-schema#contract-changes",
+    "id": "483-schema#contract-changes",
     "title": "Zero Schema",
     "searchTitle": "Contract Changes",
     "sectionTitle": "Contract Changes",
@@ -6163,7 +6424,7 @@
     "kind": "section"
   },
   {
-    "id": "465-schema#compound-changes",
+    "id": "484-schema#compound-changes",
     "title": "Zero Schema",
     "searchTitle": "Compound Changes",
     "sectionTitle": "Compound Changes",
@@ -6173,7 +6434,7 @@
     "kind": "section"
   },
   {
-    "id": "466-schema#examples",
+    "id": "485-schema#examples",
     "title": "Zero Schema",
     "searchTitle": "Examples",
     "sectionTitle": "Examples",
@@ -6183,7 +6444,7 @@
     "kind": "section"
   },
   {
-    "id": "467-schema#adding-a-column",
+    "id": "486-schema#adding-a-column",
     "title": "Zero Schema",
     "searchTitle": "Adding a Column",
     "sectionTitle": "Adding a Column",
@@ -6193,7 +6454,7 @@
     "kind": "section"
   },
   {
-    "id": "468-schema#removing-a-column",
+    "id": "487-schema#removing-a-column",
     "title": "Zero Schema",
     "searchTitle": "Removing a Column",
     "sectionTitle": "Removing a Column",
@@ -6203,7 +6464,7 @@
     "kind": "section"
   },
   {
-    "id": "469-schema#renaming-a-column",
+    "id": "488-schema#renaming-a-column",
     "title": "Zero Schema",
     "searchTitle": "Renaming a Column",
     "sectionTitle": "Renaming a Column",
@@ -6213,7 +6474,7 @@
     "kind": "section"
   },
   {
-    "id": "470-schema#making-a-column-optional",
+    "id": "489-schema#making-a-column-optional",
     "title": "Zero Schema",
     "searchTitle": "Making a Column Optional",
     "sectionTitle": "Making a Column Optional",
@@ -6223,7 +6484,7 @@
     "kind": "section"
   },
   {
-    "id": "471-schema#quick-reference",
+    "id": "490-schema#quick-reference",
     "title": "Zero Schema",
     "searchTitle": "Quick Reference",
     "sectionTitle": "Quick Reference",
@@ -6233,7 +6494,7 @@
     "kind": "section"
   },
   {
-    "id": "472-schema#backfill",
+    "id": "491-schema#backfill",
     "title": "Zero Schema",
     "searchTitle": "Backfill",
     "sectionTitle": "Backfill",
@@ -6243,7 +6504,7 @@
     "kind": "section"
   },
   {
-    "id": "473-schema#monitoring-backfill-progress",
+    "id": "492-schema#monitoring-backfill-progress",
     "title": "Zero Schema",
     "searchTitle": "Monitoring Backfill Progress",
     "sectionTitle": "Monitoring Backfill Progress",
@@ -6253,7 +6514,7 @@
     "kind": "section"
   },
   {
-    "id": "63-self-host",
+    "id": "64-self-host",
     "title": "Self-Hosting Zero",
     "searchTitle": "Self-Hosting Zero",
     "url": "/docs/self-host",
@@ -6311,7 +6572,7 @@
     "kind": "page"
   },
   {
-    "id": "474-self-host#minimum-viable-strategy",
+    "id": "493-self-host#minimum-viable-strategy",
     "title": "Self-Hosting Zero",
     "searchTitle": "Minimum Viable Strategy",
     "sectionTitle": "Minimum Viable Strategy",
@@ -6321,7 +6582,7 @@
     "kind": "section"
   },
   {
-    "id": "475-self-host#maximal-strategy",
+    "id": "494-self-host#maximal-strategy",
     "title": "Self-Hosting Zero",
     "searchTitle": "Maximal Strategy",
     "sectionTitle": "Maximal Strategy",
@@ -6331,7 +6592,7 @@
     "kind": "section"
   },
   {
-    "id": "476-self-host#replica-lifecycle",
+    "id": "495-self-host#replica-lifecycle",
     "title": "Self-Hosting Zero",
     "searchTitle": "Replica Lifecycle",
     "sectionTitle": "Replica Lifecycle",
@@ -6341,7 +6602,7 @@
     "kind": "section"
   },
   {
-    "id": "477-self-host#performance",
+    "id": "496-self-host#performance",
     "title": "Self-Hosting Zero",
     "searchTitle": "Performance",
     "sectionTitle": "Performance",
@@ -6351,7 +6612,7 @@
     "kind": "section"
   },
   {
-    "id": "478-self-host#hydration",
+    "id": "497-self-host#hydration",
     "title": "Self-Hosting Zero",
     "searchTitle": "Hydration",
     "sectionTitle": "Hydration",
@@ -6361,7 +6622,7 @@
     "kind": "section"
   },
   {
-    "id": "479-self-host#ivm-advancement",
+    "id": "498-self-host#ivm-advancement",
     "title": "Self-Hosting Zero",
     "searchTitle": "IVM advancement",
     "sectionTitle": "IVM advancement",
@@ -6371,7 +6632,7 @@
     "kind": "section"
   },
   {
-    "id": "480-self-host#system-level",
+    "id": "499-self-host#system-level",
     "title": "Self-Hosting Zero",
     "searchTitle": "System-level",
     "sectionTitle": "System-level",
@@ -6381,7 +6642,7 @@
     "kind": "section"
   },
   {
-    "id": "481-self-host#networking",
+    "id": "500-self-host#networking",
     "title": "Self-Hosting Zero",
     "searchTitle": "Networking",
     "sectionTitle": "Networking",
@@ -6391,7 +6652,7 @@
     "kind": "section"
   },
   {
-    "id": "482-self-host#sticky-sessions",
+    "id": "501-self-host#sticky-sessions",
     "title": "Self-Hosting Zero",
     "searchTitle": "Sticky Sessions",
     "sectionTitle": "Sticky Sessions",
@@ -6401,7 +6662,7 @@
     "kind": "section"
   },
   {
-    "id": "483-self-host#rolling-updates",
+    "id": "502-self-host#rolling-updates",
     "title": "Self-Hosting Zero",
     "searchTitle": "Rolling Updates",
     "sectionTitle": "Rolling Updates",
@@ -6411,7 +6672,7 @@
     "kind": "section"
   },
   {
-    "id": "484-self-host#clientserver-version-compatibility",
+    "id": "503-self-host#clientserver-version-compatibility",
     "title": "Self-Hosting Zero",
     "searchTitle": "Client/Server Version Compatibility",
     "sectionTitle": "Client/Server Version Compatibility",
@@ -6421,7 +6682,7 @@
     "kind": "section"
   },
   {
-    "id": "485-self-host#configuration",
+    "id": "504-self-host#configuration",
     "title": "Self-Hosting Zero",
     "searchTitle": "Configuration",
     "sectionTitle": "Configuration",
@@ -6431,7 +6692,7 @@
     "kind": "section"
   },
   {
-    "id": "64-server-zql",
+    "id": "65-server-zql",
     "title": "ZQL on the Server",
     "searchTitle": "ZQL on the Server",
     "url": "/docs/server-zql",
@@ -6457,7 +6718,7 @@
     "kind": "page"
   },
   {
-    "id": "486-server-zql#creating-a-database",
+    "id": "505-server-zql#creating-a-database",
     "title": "ZQL on the Server",
     "searchTitle": "Creating a Database",
     "sectionTitle": "Creating a Database",
@@ -6467,7 +6728,7 @@
     "kind": "section"
   },
   {
-    "id": "487-server-zql#custom-database",
+    "id": "506-server-zql#custom-database",
     "title": "ZQL on the Server",
     "searchTitle": "Custom Database",
     "sectionTitle": "Custom Database",
@@ -6477,7 +6738,7 @@
     "kind": "section"
   },
   {
-    "id": "488-server-zql#running-zql",
+    "id": "507-server-zql#running-zql",
     "title": "ZQL on the Server",
     "searchTitle": "Running ZQL",
     "sectionTitle": "Running ZQL",
@@ -6487,7 +6748,7 @@
     "kind": "section"
   },
   {
-    "id": "489-server-zql#ssr",
+    "id": "508-server-zql#ssr",
     "title": "ZQL on the Server",
     "searchTitle": "SSR",
     "sectionTitle": "SSR",
@@ -6497,7 +6758,7 @@
     "kind": "section"
   },
   {
-    "id": "65-solidjs",
+    "id": "66-solidjs",
     "title": "SolidJS",
     "searchTitle": "SolidJS",
     "url": "/docs/solidjs",
@@ -6519,7 +6780,7 @@
     "kind": "page"
   },
   {
-    "id": "490-solidjs#setup",
+    "id": "509-solidjs#setup",
     "title": "SolidJS",
     "searchTitle": "Setup",
     "sectionTitle": "Setup",
@@ -6529,7 +6790,7 @@
     "kind": "section"
   },
   {
-    "id": "491-solidjs#usage",
+    "id": "510-solidjs#usage",
     "title": "SolidJS",
     "searchTitle": "Usage",
     "sectionTitle": "Usage",
@@ -6539,7 +6800,7 @@
     "kind": "section"
   },
   {
-    "id": "492-solidjs#examples",
+    "id": "511-solidjs#examples",
     "title": "SolidJS",
     "searchTitle": "Examples",
     "sectionTitle": "Examples",
@@ -6549,7 +6810,7 @@
     "kind": "section"
   },
   {
-    "id": "66-status",
+    "id": "67-status",
     "title": "Project Status",
     "searchTitle": "Project Status",
     "url": "/docs/status",
@@ -6575,7 +6836,7 @@
     "kind": "page"
   },
   {
-    "id": "493-status#breaking-changes",
+    "id": "512-status#breaking-changes",
     "title": "Project Status",
     "searchTitle": "Breaking Changes",
     "sectionTitle": "Breaking Changes",
@@ -6585,7 +6846,7 @@
     "kind": "section"
   },
   {
-    "id": "494-status#roadmap",
+    "id": "513-status#roadmap",
     "title": "Project Status",
     "searchTitle": "Roadmap",
     "sectionTitle": "Roadmap",
@@ -6595,7 +6856,7 @@
     "kind": "section"
   },
   {
-    "id": "495-status#2026",
+    "id": "514-status#2026",
     "title": "Project Status",
     "searchTitle": "2026",
     "sectionTitle": "2026",
@@ -6605,7 +6866,7 @@
     "kind": "section"
   },
   {
-    "id": "496-status#soon",
+    "id": "515-status#soon",
     "title": "Project Status",
     "searchTitle": "Soon",
     "sectionTitle": "Soon",
@@ -6615,7 +6876,7 @@
     "kind": "section"
   },
   {
-    "id": "67-sync",
+    "id": "68-sync",
     "title": "What is Sync?",
     "searchTitle": "What is Sync?",
     "url": "/docs/sync",
@@ -6637,7 +6898,7 @@
     "kind": "page"
   },
   {
-    "id": "497-sync#problem",
+    "id": "516-sync#problem",
     "title": "What is Sync?",
     "searchTitle": "Problem",
     "sectionTitle": "Problem",
@@ -6647,7 +6908,7 @@
     "kind": "section"
   },
   {
-    "id": "498-sync#solution",
+    "id": "517-sync#solution",
     "title": "What is Sync?",
     "searchTitle": "Solution",
     "sectionTitle": "Solution",
@@ -6657,7 +6918,7 @@
     "kind": "section"
   },
   {
-    "id": "499-sync#history-of-sync",
+    "id": "518-sync#history-of-sync",
     "title": "What is Sync?",
     "searchTitle": "History of Sync",
     "sectionTitle": "History of Sync",
@@ -6667,11 +6928,11 @@
     "kind": "section"
   },
   {
-    "id": "68-tutorial",
+    "id": "69-tutorial",
     "title": "Tutorial",
     "searchTitle": "Tutorial",
     "url": "/docs/tutorial",
-    "content": "Let's build a small music app with Zero from scratch. It's a nice way to get a feel for how Zero works and takes about 15 minutes to complete. You will seed a Postgres database with artists and albums, run zero-cache, add a query and a mutator, and watch data sync across clients in realtime. If you want to wire Zero into your own app, see Installation. Setup Create a Project Start with a TypeScript frontend framework: npx @tanstack/cli@latest create zero-music \\ --package-manager npm --yes --no-intent cd zero-musicpnpm dlx @tanstack/cli@latest create zero-music \\ --package-manager pnpm --yes --no-intent cd zero-musicbunx @tanstack/cli@latest create zero-music \\ --package-manager bun --yes --no-intent cd zero-musicnpx create-next-app@latest zero-music --yes --use-npm cd zero-musicpnpm create next-app zero-music --yes --use-pnpm cd zero-musicnpx create-next-app@latest zero-music --yes --use-bun cd zero-musicnpm init solid -- zero-music basic --solidstart --ts --v2 cd zero-music npm installpnpm create solid zero-music basic --solidstart --ts --v2 cd zero-music pnpm installbun create solid zero-music basic --solidstart --ts --v2 cd zero-music bun install Set Up Your Database You'll need a Postgres database with logical replication enabled. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Connecting to Postgres and make sure wal_level is logical. Then, create some music-themed tables and seed them with data (this step uses psql if you don't already have it). # Creates new albums, artists, fans, # and favorites tables with sample music data curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \\ | psql postgres://postgres:pass@localhost:5432/zero Create a .env file so your app server and zero-cache-dev use the same Postgres connection: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install and Run Zero-Cache Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] These examples use Zod; any Standard Schema-compatible validator works. Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\" Integrate Zero Set Up Your Zero Schema Zero uses a schema.ts file to provide a type-safe query API on the client. Download the music-app schema: mkdir -p src/zero curl https://raw.githubusercontent.com/rocicorp/zero-music/1-install/packages/zero/src/schema.ts \\ -o src/zero/schema.ts This quickstart uses a premade schema.ts so you can stay focused on how Zero works. In a real app, you would usually generate schema.ts from your own Drizzle or Prisma schema, or manually add it alongside your application schema. See Installation and Zero Schema. Set Up the Zero Client Zero has first-class support for React and SolidJS. There is also a low-level API you can use in any TypeScript-based project. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero Music</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero} Sync Data Define Query Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev Invoke Query Use the seeded data to fetch albums for The Beatles under artist_1. // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export default function Page() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery} from '@rocicorp/zero/solid' import {queries} from '../zero/queries' export default function Home() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {queries} from './zero/queries' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) This query will run against the zero-cache replica and return Abbey Road and Revolver. The client will update its local datastore with these new albums, and future queries will run optimistically against the local data. Also, Zero queries are reactive, so if you edit data in Postgres directly, you will see it replicate to the Zero replica and the UI: Mutate Data Define Mutators Now let's add a write path that inserts a new album: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. Mutations are written directly to Postgres and replicated to the client. Your other code that writes to the same tables will also sync instantly to the client. First, create a dbProvider with node-postgres: // src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Add the mutate endpoint itself: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) } Restart zero-cache with ZERO_MUTATE_URL configured: ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-dev Invoke Mutators Now add a button to create an album: // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Page() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery, useZero} from '@rocicorp/zero/solid' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Home() { const zero = useZero() const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero().mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {mutators} from './zero/mutators' import {queries} from './zero/queries' const client = await zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log( 'albums', albums.map(album => album.title) ) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Please Please Me will appear in the album list immediately. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients: That's it! You now have a simple, Zero-powered music app. Try opening multiple browser windows to see the realtime sync in action! Next Steps Learn how to add auth Try adding Zero to your existing app Play with fully-fleshed out samples",
+    "content": "Let's build a small music app with Zero from scratch. It's a nice way to get a feel for how Zero works and takes about 15 minutes to complete. You will seed a Postgres database with artists and albums, run zero-cache, add a query and a mutator, and watch data sync across clients in realtime. If you want to wire Zero into your own app, see Installation. Setup Create a Project Start with a TypeScript frontend framework: npx @tanstack/cli@latest create zero-music \\ --package-manager npm --yes --no-intent cd zero-musicpnpm dlx @tanstack/cli@latest create zero-music \\ --package-manager pnpm --yes --no-intent cd zero-musicbunx @tanstack/cli@latest create zero-music \\ --package-manager bun --yes --no-intent cd zero-musicnpx create-next-app@latest zero-music --yes --use-npm cd zero-musicpnpm create next-app zero-music --yes --use-pnpm cd zero-musicnpx create-next-app@latest zero-music --yes --use-bun cd zero-musicnpm init solid -- zero-music basic --solidstart --ts --v2 cd zero-music npm installpnpm create solid zero-music basic --solidstart --ts --v2 cd zero-music pnpm installbun create solid zero-music basic --solidstart --ts --v2 cd zero-music bun install Set Up Your Database You'll need a Postgres database with logical replication enabled. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Connecting to Postgres and make sure wal_level is logical. Then, create some music-themed tables and seed them with data (this step uses psql if you don't already have it). # Creates new albums, artists, fans, # and favorites tables with sample music data curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \\ | psql postgres://postgres:pass@localhost:5432/zero Create a .env file so your app server and zero-cache-dev use the same Postgres connection: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install and Run Zero-Cache Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] This tutorial uses Zod; any Standard Schema-compatible validator works. Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\" Integrate Zero Set Up Your Zero Schema Zero uses a schema.ts file to provide a type-safe query API on the client. Download the music-app schema: mkdir -p src/zero curl https://raw.githubusercontent.com/rocicorp/zero-music/1-install/packages/zero/src/schema.ts \\ -o src/zero/schema.ts This quickstart uses a premade schema.ts so you can stay focused on how Zero works. In a real app, you would usually generate schema.ts from your own Drizzle or Prisma schema, or manually add it alongside your application schema. See Installation and Zero Schema. Set Up the Zero Client Zero has first-class support for React and SolidJS. There is also a low-level API you can use in any TypeScript-based project. // src/routes/__root.tsx import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export const Route = createRootRoute({ shellComponent: RootDocument }) function RootDocument({children}: {children: ReactNode}) { return ( <html lang=\"en\"> <head> <HeadContent /> </head> <body> <ZeroProvider {...opts}>{children}</ZeroProvider> <Scripts /> </body> </html> ) }// src/app/providers.tsx 'use client' import {ZeroProvider} from '@rocicorp/zero/react' import type {ZeroOptions} from '@rocicorp/zero' import type {ReactNode} from 'react' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export function Providers({ children }: { children: ReactNode }) { return <ZeroProvider {...opts}>{children}</ZeroProvider> } // src/app/layout.tsx import type {ReactNode} from 'react' import {Providers} from './providers' export default function RootLayout({ children }: { children: ReactNode }) { return ( <html lang=\"en\"> <body> <Providers>{children}</Providers> </body> </html> ) }// src/app.tsx import {MetaProvider, Title} from '@solidjs/meta' import {Router} from '@solidjs/router' import {FileRoutes} from '@solidjs/start/router' import {ZeroProvider} from '@rocicorp/zero/solid' import type {ZeroOptions} from '@rocicorp/zero' import {Suspense} from 'solid-js' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } export default function App() { return ( <ZeroProvider {...opts}> <Router root={props => ( <MetaProvider> <Title>Zero Music</Title> <Suspense>{props.children}</Suspense> </MetaProvider> )} > <FileRoutes /> </Router> </ZeroProvider> ) }// src/zero.ts import {Zero} from '@rocicorp/zero' import type {ZeroOptions} from '@rocicorp/zero' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema } const zero = new Zero(opts) export {zero} Sync Data Define Query Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) These are defined using Zero Query Language (ZQL) - it allows you to build queries with filters, sorts, relationships, and more: See Reading Data for more on how ZQL works. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. This prevents clients from reading arbitrary data and is the basis of permissions. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(request: Request) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: event.request, userID: null }) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev Invoke Query Use the seeded data to fetch albums for The Beatles under artist_1. // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export default function Page() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery} from '@rocicorp/zero/solid' import {queries} from '../zero/queries' export default function Home() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {queries} from './zero/queries' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) This query will run against the zero-cache replica and return Abbey Road and Revolver. The client will update its local datastore with these new albums, and future queries will run optimistically against the local data. Also, Zero queries are reactive, so if you edit data in Postgres directly, you will see it replicate to the Zero replica and the UI: Mutate Data Define Mutators Now let's add a write path that inserts a new album: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. Mutations are written directly to Postgres and replicated to the client. Your other code that writes to the same tables will also sync instantly to the client. First, create a dbProvider with node-postgres: // src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Add the mutate endpoint itself: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(request: Request) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: event.request, userID: null }) return Response.json(result) } Restart zero-cache with ZERO_MUTATE_URL configured: ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-dev Invoke Mutators Now add a button to create an album: // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Page() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery, useZero} from '@rocicorp/zero/solid' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Home() { const zero = useZero() const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero().mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {mutators} from './zero/mutators' import {queries} from './zero/queries' const client = await zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log( 'albums', albums.map(album => album.title) ) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Please Please Me will appear in the album list immediately. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients: That's it! You now have a simple, Zero-powered music app. Try opening multiple browser windows to see the realtime sync in action! Next Steps Learn how to add auth Try adding Zero to your existing app Play with fully-fleshed out samples",
     "headings": [
       {
         "text": "Setup",
@@ -6741,17 +7002,17 @@
     "kind": "page"
   },
   {
-    "id": "500-tutorial#setup",
+    "id": "519-tutorial#setup",
     "title": "Tutorial",
     "searchTitle": "Setup",
     "sectionTitle": "Setup",
     "sectionId": "setup",
     "url": "/docs/tutorial",
-    "content": "Create a Project Start with a TypeScript frontend framework: npx @tanstack/cli@latest create zero-music \\ --package-manager npm --yes --no-intent cd zero-musicpnpm dlx @tanstack/cli@latest create zero-music \\ --package-manager pnpm --yes --no-intent cd zero-musicbunx @tanstack/cli@latest create zero-music \\ --package-manager bun --yes --no-intent cd zero-musicnpx create-next-app@latest zero-music --yes --use-npm cd zero-musicpnpm create next-app zero-music --yes --use-pnpm cd zero-musicnpx create-next-app@latest zero-music --yes --use-bun cd zero-musicnpm init solid -- zero-music basic --solidstart --ts --v2 cd zero-music npm installpnpm create solid zero-music basic --solidstart --ts --v2 cd zero-music pnpm installbun create solid zero-music basic --solidstart --ts --v2 cd zero-music bun install Set Up Your Database You'll need a Postgres database with logical replication enabled. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Connecting to Postgres and make sure wal_level is logical. Then, create some music-themed tables and seed them with data (this step uses psql if you don't already have it). # Creates new albums, artists, fans, # and favorites tables with sample music data curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \\ | psql postgres://postgres:pass@localhost:5432/zero Create a .env file so your app server and zero-cache-dev use the same Postgres connection: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install and Run Zero-Cache Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] These examples use Zod; any Standard Schema-compatible validator works. Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\"",
+    "content": "Create a Project Start with a TypeScript frontend framework: npx @tanstack/cli@latest create zero-music \\ --package-manager npm --yes --no-intent cd zero-musicpnpm dlx @tanstack/cli@latest create zero-music \\ --package-manager pnpm --yes --no-intent cd zero-musicbunx @tanstack/cli@latest create zero-music \\ --package-manager bun --yes --no-intent cd zero-musicnpx create-next-app@latest zero-music --yes --use-npm cd zero-musicpnpm create next-app zero-music --yes --use-pnpm cd zero-musicnpx create-next-app@latest zero-music --yes --use-bun cd zero-musicnpm init solid -- zero-music basic --solidstart --ts --v2 cd zero-music npm installpnpm create solid zero-music basic --solidstart --ts --v2 cd zero-music pnpm installbun create solid zero-music basic --solidstart --ts --v2 cd zero-music bun install Set Up Your Database You'll need a Postgres database with logical replication enabled. # IMPORTANT: logical WAL level is required for Zero # to sync data to its SQLite replica docker run -d --name zero-postgres \\ -e POSTGRES_DB=\"zero\" \\ -e POSTGRES_PASSWORD=\"pass\" \\ -p 5432:5432 \\ postgres:18 \\ postgres -c wal_level=logical# Start Postgres.app first. Requires Postgres 15 or higher. # If these already exist, you can skip those commands. createuser -s postgres createdb -O postgres zero psql -d postgres -c \"ALTER USER postgres WITH PASSWORD 'pass';\" psql -d postgres -c \"ALTER SYSTEM SET wal_level = 'logical';\" # Restart Postgres.app, then verify: psql -d postgres -c \"SHOW wal_level;\" See Connecting to Postgres and make sure wal_level is logical. Then, create some music-themed tables and seed them with data (this step uses psql if you don't already have it). # Creates new albums, artists, fans, # and favorites tables with sample music data curl -L https://raw.githubusercontent.com/rocicorp/zero-music/1-install/migrations/0000_seed_music.sql \\ | psql postgres://postgres:pass@localhost:5432/zero Create a .env file so your app server and zero-cache-dev use the same Postgres connection: ZERO_UPSTREAM_DB=\"postgres://postgres:pass@localhost:5432/zero\" Install and Run Zero-Cache Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] This tutorial uses Zod; any Standard Schema-compatible validator works. Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\"",
     "kind": "section"
   },
   {
-    "id": "501-tutorial#create-a-project",
+    "id": "520-tutorial#create-a-project",
     "title": "Tutorial",
     "searchTitle": "Create a Project",
     "sectionTitle": "Create a Project",
@@ -6761,7 +7022,7 @@
     "kind": "section"
   },
   {
-    "id": "502-tutorial#set-up-your-database",
+    "id": "521-tutorial#set-up-your-database",
     "title": "Tutorial",
     "searchTitle": "Set Up Your Database",
     "sectionTitle": "Set Up Your Database",
@@ -6771,17 +7032,17 @@
     "kind": "section"
   },
   {
-    "id": "503-tutorial#install-and-run-zero-cache",
+    "id": "522-tutorial#install-and-run-zero-cache",
     "title": "Tutorial",
     "searchTitle": "Install and Run Zero-Cache",
     "sectionTitle": "Install and Run Zero-Cache",
     "sectionId": "install-and-run-zero-cache",
     "url": "/docs/tutorial",
-    "content": "Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] These examples use Zod; any Standard Schema-compatible validator works. Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\"",
+    "content": "Add Zero and the dependencies used in this tutorial with your preferred package manager: npm install @rocicorp/zero zod pg npm install -D @types/pgpnpm add @rocicorp/zero zod pg pnpm add -D @types/pg # Note: pnpm disables postinstall scripts by default for security. # Approve @rocicorp/zero-sqlite3 before continuing: pnpm approve-builds # Or add to package.json, then rebuild the native packages: # \"pnpm\": { # \"onlyBuiltDependencies\": [ # \"@rocicorp/zero-sqlite3\" # ] # }bun add @rocicorp/zero zod pg bun add -d @types/pg # Note: Bun disables postinstall scripts by default for security. # Either approve the build: bun pm trust @rocicorp/zero-sqlite3 # Or add to package.json, then rebuild the native packages: # \"trustedDependencies\": [\"@rocicorp/zero-sqlite3\"] This tutorial uses Zod; any Standard Schema-compatible validator works. Start the development zero-cache: npx zero-cache-devpnpm exec zero-cache-devbunx zero-cache-dev Zero will start listening on port 4848 and continuously replicate your upstream database into a SQLite replica, which is created by default at zero.db. The replica is an implementation detail and you will not interact with it directly, but you can inspect the replica with zero-sqlite3 in another terminal to see how zero-cache syncs data: npx @rocicorp/zero-sqlite3 ./zero.db \"SELECT title FROM albums ORDER BY id;\" # Abbey Road # Kind of Blue # Random Access Memories # 21 # Revolver Or try reading from zero.db while connected to Postgres at postgres://postgres:pass@localhost:5432/zero. If you change something in Postgres, you'll see it immediately show up in the replica: # Uses watch, e.g.: brew install watch watch -n 0.5 \"npx @rocicorp/zero-sqlite3 ./zero.db \\ 'SELECT * FROM albums ORDER BY created_at;'\"",
     "kind": "section"
   },
   {
-    "id": "504-tutorial#integrate-zero",
+    "id": "523-tutorial#integrate-zero",
     "title": "Tutorial",
     "searchTitle": "Integrate Zero",
     "sectionTitle": "Integrate Zero",
@@ -6791,7 +7052,7 @@
     "kind": "section"
   },
   {
-    "id": "505-tutorial#set-up-your-zero-schema",
+    "id": "524-tutorial#set-up-your-zero-schema",
     "title": "Tutorial",
     "searchTitle": "Set Up Your Zero Schema",
     "sectionTitle": "Set Up Your Zero Schema",
@@ -6801,7 +7062,7 @@
     "kind": "section"
   },
   {
-    "id": "506-tutorial#set-up-the-zero-client",
+    "id": "525-tutorial#set-up-the-zero-client",
     "title": "Tutorial",
     "searchTitle": "Set Up the Zero Client",
     "sectionTitle": "Set Up the Zero Client",
@@ -6811,37 +7072,37 @@
     "kind": "section"
   },
   {
-    "id": "507-tutorial#sync-data",
+    "id": "526-tutorial#sync-data",
     "title": "Tutorial",
     "searchTitle": "Sync Data",
     "sectionTitle": "Sync Data",
     "sectionId": "sync-data",
     "url": "/docs/tutorial",
-    "content": "Define Query Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: See Reading Data for more on filters, sorting, relationships, and permissions. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev Invoke Query Use the seeded data to fetch albums for The Beatles under artist_1. // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export default function Page() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery} from '@rocicorp/zero/solid' import {queries} from '../zero/queries' export default function Home() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {queries} from './zero/queries' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) This query will run against the zero-cache replica and return Abbey Road and Revolver. The client will update its local datastore with these new albums, and future queries will run optimistically against the local data. Also, Zero queries are reactive, so if you edit data in Postgres directly, you will see it replicate to the Zero replica and the UI:",
+    "content": "Define Query Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) These are defined using Zero Query Language (ZQL) - it allows you to build queries with filters, sorts, relationships, and more: See Reading Data for more on how ZQL works. Add Query Endpoint Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. This prevents clients from reading arbitrary data and is the basis of permissions. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(request: Request) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: event.request, userID: null }) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev Invoke Query Use the seeded data to fetch albums for The Beatles under artist_1. // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery} from '@rocicorp/zero/react' import {queries} from '../zero/queries' export default function Page() { const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery} from '@rocicorp/zero/solid' import {queries} from '../zero/queries' export default function Home() { const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) return ( <main> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {queries} from './zero/queries' const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log('albums', albums) This query will run against the zero-cache replica and return Abbey Road and Revolver. The client will update its local datastore with these new albums, and future queries will run optimistically against the local data. Also, Zero queries are reactive, so if you edit data in Postgres directly, you will see it replicate to the Zero replica and the UI:",
     "kind": "section"
   },
   {
-    "id": "508-tutorial#define-query",
+    "id": "527-tutorial#define-query",
     "title": "Tutorial",
     "searchTitle": "Define Query",
     "sectionTitle": "Define Query",
     "sectionId": "define-query",
     "url": "/docs/tutorial",
-    "content": "Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) ZQL is quite powerful and allows you to build queries with filters, sorts, relationships, and more: See Reading Data for more on filters, sorting, relationships, and permissions.",
+    "content": "Let's add a way to sync albums by artist. In Zero, shared reads live in queries.ts. // src/zero/queries.ts import {defineQueries, defineQuery} from '@rocicorp/zero' import {z} from 'zod' import {zql} from './schema' export const queries = defineQueries({ albums: { byArtist: defineQuery( z.object({artistId: z.string()}), ({args: {artistId}}) => zql.albums .where('artistId', artistId) .orderBy('releaseYear', 'desc') .limit(10) .related('artist', q => q.one()) ) } }) These are defined using Zero Query Language (ZQL) - it allows you to build queries with filters, sorts, relationships, and more: See Reading Data for more on how ZQL works.",
     "kind": "section"
   },
   {
-    "id": "509-tutorial#add-query-endpoint",
+    "id": "528-tutorial#add-query-endpoint",
     "title": "Tutorial",
     "searchTitle": "Add Query Endpoint",
     "sectionTitle": "Add Query Endpoint",
     "sectionId": "add-query-endpoint",
     "url": "/docs/tutorial",
-    "content": "Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request ) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(req: Request) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, req ) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest( (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, event.request ) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev",
+    "content": "Zero doesn't allow clients to send arbitrary ZQL to zero-cache. Instead, Zero sends the query name and arguments to the query endpoint on your server, which responds to zero-cache with the authoritative ZQL. This prevents clients from reading arbitrary data and is the basis of permissions. // src/routes/api/query.ts import {createFileRoute} from '@tanstack/react-router' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export const Route = createFileRoute('/api/query')({ server: { handlers: { POST: async ({request}) => { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) } } } })// src/app/api/query/route.ts import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../../zero/queries' import {schema} from '../../../zero/schema' export async function POST(request: Request) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request, userID: null }) return Response.json(result) }// src/routes/api/query.ts import type {APIEvent} from '@solidjs/start/server' import {handleQueryRequest} from '@rocicorp/zero/server' import {mustGetQuery} from '@rocicorp/zero' import {queries} from '../../zero/queries' import {schema} from '../../zero/schema' export async function POST(event: APIEvent) { const result = await handleQueryRequest({ handler: (name, args) => { const query = mustGetQuery(queries, name) return query.fn({args}) }, schema, request: event.request, userID: null }) return Response.json(result) } Start your app server in another terminal so zero-cache can reach the query endpoint: npm run devpnpm devbun run dev Restart zero-cache with ZERO_QUERY_URL so it knows about the new query endpoint: # Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ npx zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ pnpm exec zero-cache-dev# Update localhost:3000 with your local server ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ bunx zero-cache-dev",
     "kind": "section"
   },
   {
-    "id": "510-tutorial#invoke-query",
+    "id": "529-tutorial#invoke-query",
     "title": "Tutorial",
     "searchTitle": "Invoke Query",
     "sectionTitle": "Invoke Query",
@@ -6851,17 +7112,17 @@
     "kind": "section"
   },
   {
-    "id": "511-tutorial#mutate-data",
+    "id": "530-tutorial#mutate-data",
     "title": "Tutorial",
     "searchTitle": "Mutate Data",
     "sectionTitle": "Mutate Data",
     "sectionId": "mutate-data",
     "url": "/docs/tutorial",
-    "content": "Define Mutators Now let's add a write path that inserts a new album: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. Mutations are written directly to Postgres and replicated to the client. Your other code that writes to the same tables will also sync instantly to the client. First, create a dbProvider with node-postgres: // src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Add the mutate endpoint itself: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) } Restart zero-cache with ZERO_MUTATE_URL configured: ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-dev Invoke Mutators Now add a button to create an album: // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Page() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery, useZero} from '@rocicorp/zero/solid' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Home() { const zero = useZero() const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero().mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {mutators} from './zero/mutators' import {queries} from './zero/queries' const client = await zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log( 'albums', albums.map(album => album.title) ) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Please Please Me will appear in the album list immediately. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients: That's it! You now have a simple, Zero-powered music app. Try opening multiple browser windows to see the realtime sync in action!",
+    "content": "Define Mutators Now let's add a write path that inserts a new album: // src/zero/mutators.ts import {defineMutators, defineMutator} from '@rocicorp/zero' import {z} from 'zod' export const mutators = defineMutators({ albums: { create: defineMutator( z.object({ id: z.string(), artistId: z.string(), title: z.string(), releaseYear: z.number() }), async ({args, tx}) => { await tx.mutate.albums.insert({ ...args, createdAt: Date.now() }) } ) } }) You can use the CRUD-style API with tx.mutate.<table>.<method>() to write data. You can also use tx.run(zql.<table>.<method>) to run queries within your mutator. Register the mutators where you create the Zero client: // src/routes/__root.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app/providers.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from '../zero/mutators' import {schema} from '../zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/app.tsx import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators }// src/zero.ts import type {ZeroOptions} from '@rocicorp/zero' import {mutators} from './zero/mutators' import {schema} from './zero/schema' const opts: ZeroOptions = { cacheURL: 'http://localhost:4848', schema, mutators } Add Mutate Endpoint Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. Mutations are written directly to Postgres and replicated to the client. Your other code that writes to the same tables will also sync instantly to the client. First, create a dbProvider with node-postgres: // src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Add the mutate endpoint itself: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(request: Request) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: event.request, userID: null }) return Response.json(result) } Restart zero-cache with ZERO_MUTATE_URL configured: ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-dev Invoke Mutators Now add a button to create an album: // src/routes/index.tsx import {createFileRoute} from '@tanstack/react-router' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export const Route = createFileRoute('/')({ component: Home }) function Home() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/app/page.tsx 'use client' import {useQuery, useZero} from '@rocicorp/zero/react' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Page() { const zero = useZero() const [albums] = useQuery( queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> {albums.map(album => ( <li key={album.id}>{album.title}</li> ))} </ul> </main> ) }// src/routes/index.tsx import {For} from 'solid-js' import {useQuery, useZero} from '@rocicorp/zero/solid' import {mutators} from '../zero/mutators' import {queries} from '../zero/queries' export default function Home() { const zero = useZero() const [albums] = useQuery(() => queries.albums.byArtist({artistId: 'artist_1'}) ) const onClick = () => { zero().mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ) } return ( <main> <button onClick={onClick}>Create Album</button> <ul> <For each={albums()}> {album => <li>{album.title}</li>} </For> </ul> </main> ) }// src/albums.ts import {zero} from './zero' import {mutators} from './zero/mutators' import {queries} from './zero/queries' const client = await zero.mutate( mutators.albums.create({ id: crypto.randomUUID(), artistId: 'artist_1', title: 'Please Please Me', releaseYear: 1963 }) ).client const albums = await zero.run( queries.albums.byArtist({artistId: 'artist_1'}) ) console.log( 'albums', albums.map(album => album.title) ) When you run the mutator, Zero writes to the local database, updates queries optimistically, and then syncs in the background to your mutate endpoint. Please Please Me will appear in the album list immediately. Your mutate endpoint writes to Postgres and zero-cache will instantly replicate those changes to other clients: That's it! You now have a simple, Zero-powered music app. Try opening multiple browser windows to see the realtime sync in action!",
     "kind": "section"
   },
   {
-    "id": "512-tutorial#define-mutators",
+    "id": "531-tutorial#define-mutators",
     "title": "Tutorial",
     "searchTitle": "Define Mutators",
     "sectionTitle": "Define Mutators",
@@ -6871,17 +7132,17 @@
     "kind": "section"
   },
   {
-    "id": "513-tutorial#add-mutate-endpoint",
+    "id": "532-tutorial#add-mutate-endpoint",
     "title": "Tutorial",
     "searchTitle": "Add Mutate Endpoint",
     "sectionTitle": "Add Mutate Endpoint",
     "sectionId": "add-mutate-endpoint",
     "url": "/docs/tutorial",
-    "content": "Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. Mutations are written directly to Postgres and replicated to the client. Your other code that writes to the same tables will also sync instantly to the client. First, create a dbProvider with node-postgres: // src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Add the mutate endpoint itself: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request ) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(req: Request) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), req ) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest( dbProvider, transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), event.request ) return Response.json(result) } Restart zero-cache with ZERO_MUTATE_URL configured: ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-dev",
+    "content": "Zero requires a mutate endpoint that runs on your server and connects directly to Postgres. Mutations are written directly to Postgres and replicated to the client. Your other code that writes to the same tables will also sync instantly to the client. First, create a dbProvider with node-postgres: // src/zero/db-provider.ts import {zeroNodePg} from '@rocicorp/zero/server/adapters/pg' import {Pool} from 'pg' import {schema} from './schema' const connectionString = process.env.ZERO_UPSTREAM_DB if (!connectionString) { throw new Error('ZERO_UPSTREAM_DB is not set') } const pool = new Pool({ connectionString }) export const dbProvider = zeroNodePg(schema, pool) // Register global types for mutators on the server declare module '@rocicorp/zero' { interface DefaultTypes { dbProvider: typeof dbProvider } } Add the mutate endpoint itself: // src/routes/api/mutate.ts import {createFileRoute} from '@tanstack/react-router' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export const Route = createFileRoute('/api/mutate')({ server: { handlers: { POST: async ({request}) => { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) } } } })// src/app/api/mutate/route.ts import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../../zero/mutators' import {dbProvider} from '../../../zero/db-provider' export async function POST(request: Request) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request, userID: null }) return Response.json(result) }// src/routes/api/mutate.ts import type {APIEvent} from '@solidjs/start/server' import {handleMutateRequest} from '@rocicorp/zero/server' import {mustGetMutator} from '@rocicorp/zero' import {mutators} from '../../zero/mutators' import {dbProvider} from '../../zero/db-provider' export async function POST(event: APIEvent) { const result = await handleMutateRequest({ dbProvider, handler: transact => transact((tx, name, args) => { const mutator = mustGetMutator(mutators, name) return mutator.fn({args, tx}) }), request: event.request, userID: null }) return Response.json(result) } Restart zero-cache with ZERO_MUTATE_URL configured: ZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ npx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ pnpm exec zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-devZERO_QUERY_URL=\"http://localhost:3000/api/query\" \\ ZERO_MUTATE_URL=\"http://localhost:3000/api/mutate\" \\ bunx zero-cache-dev",
     "kind": "section"
   },
   {
-    "id": "514-tutorial#invoke-mutators",
+    "id": "533-tutorial#invoke-mutators",
     "title": "Tutorial",
     "searchTitle": "Invoke Mutators",
     "sectionTitle": "Invoke Mutators",
@@ -6891,7 +7152,7 @@
     "kind": "section"
   },
   {
-    "id": "515-tutorial#next-steps",
+    "id": "534-tutorial#next-steps",
     "title": "Tutorial",
     "searchTitle": "Next Steps",
     "sectionTitle": "Next Steps",
@@ -6901,7 +7162,7 @@
     "kind": "section"
   },
   {
-    "id": "69-when-to-use",
+    "id": "70-when-to-use",
     "title": "When To Use Zero",
     "searchTitle": "When To Use Zero",
     "url": "/docs/when-to-use",
@@ -6967,7 +7228,7 @@
     "kind": "page"
   },
   {
-    "id": "516-when-to-use#zero-might-be-a-good-fit",
+    "id": "535-when-to-use#zero-might-be-a-good-fit",
     "title": "When To Use Zero",
     "searchTitle": "Zero Might be a Good Fit",
     "sectionTitle": "Zero Might be a Good Fit",
@@ -6977,7 +7238,7 @@
     "kind": "section"
   },
   {
-    "id": "517-when-to-use#you-want-to-sync-only-a-small-subset-of-data-to-client",
+    "id": "536-when-to-use#you-want-to-sync-only-a-small-subset-of-data-to-client",
     "title": "When To Use Zero",
     "searchTitle": "You want to sync only a small subset of data to client",
     "sectionTitle": "You want to sync only a small subset of data to client",
@@ -6987,7 +7248,7 @@
     "kind": "section"
   },
   {
-    "id": "518-when-to-use#you-need-fine-grained-read-or-write-permissions",
+    "id": "537-when-to-use#you-need-fine-grained-read-or-write-permissions",
     "title": "When To Use Zero",
     "searchTitle": "You need fine-grained read or write permissions",
     "sectionTitle": "You need fine-grained read or write permissions",
@@ -6997,7 +7258,7 @@
     "kind": "section"
   },
   {
-    "id": "519-when-to-use#you-are-building-a-traditional-client-server-web-app",
+    "id": "538-when-to-use#you-are-building-a-traditional-client-server-web-app",
     "title": "When To Use Zero",
     "searchTitle": "You are building a traditional client-server web app",
     "sectionTitle": "You are building a traditional client-server web app",
@@ -7007,7 +7268,7 @@
     "kind": "section"
   },
   {
-    "id": "520-when-to-use#you-use-postgresql",
+    "id": "539-when-to-use#you-use-postgresql",
     "title": "When To Use Zero",
     "searchTitle": "You use PostgreSQL",
     "sectionTitle": "You use PostgreSQL",
@@ -7017,7 +7278,7 @@
     "kind": "section"
   },
   {
-    "id": "521-when-to-use#your-app-is-broadly-like-linear",
+    "id": "540-when-to-use#your-app-is-broadly-like-linear",
     "title": "When To Use Zero",
     "searchTitle": "Your app is broadly \"like Linear\"",
     "sectionTitle": "Your app is broadly \"like Linear\"",
@@ -7027,7 +7288,7 @@
     "kind": "section"
   },
   {
-    "id": "522-when-to-use#interaction-performance-is-very-important-to-you",
+    "id": "541-when-to-use#interaction-performance-is-very-important-to-you",
     "title": "When To Use Zero",
     "searchTitle": "Interaction performance is very important to you",
     "sectionTitle": "Interaction performance is very important to you",
@@ -7037,7 +7298,7 @@
     "kind": "section"
   },
   {
-    "id": "523-when-to-use#zero-might-not-be-a-good-fit",
+    "id": "542-when-to-use#zero-might-not-be-a-good-fit",
     "title": "When To Use Zero",
     "searchTitle": "Zero Might Not be a Good Fit",
     "sectionTitle": "Zero Might Not be a Good Fit",
@@ -7047,7 +7308,7 @@
     "kind": "section"
   },
   {
-    "id": "524-when-to-use#you-need-the-privacy-or-data-ownership-benefits-of-local-first",
+    "id": "543-when-to-use#you-need-the-privacy-or-data-ownership-benefits-of-local-first",
     "title": "When To Use Zero",
     "searchTitle": "You need the privacy or data ownership benefits of local-first",
     "sectionTitle": "You need the privacy or data ownership benefits of local-first",
@@ -7057,7 +7318,7 @@
     "kind": "section"
   },
   {
-    "id": "525-when-to-use#you-need-to-support-offline-writes-or-long-periods-offline",
+    "id": "544-when-to-use#you-need-to-support-offline-writes-or-long-periods-offline",
     "title": "When To Use Zero",
     "searchTitle": "You need to support offline writes or long periods offline",
     "sectionTitle": "You need to support offline writes or long periods offline",
@@ -7067,7 +7328,7 @@
     "kind": "section"
   },
   {
-    "id": "526-when-to-use#you-are-building-a-native-mobile-app",
+    "id": "545-when-to-use#you-are-building-a-native-mobile-app",
     "title": "When To Use Zero",
     "searchTitle": "You are building a native mobile app",
     "sectionTitle": "You are building a native mobile app",
@@ -7077,7 +7338,7 @@
     "kind": "section"
   },
   {
-    "id": "527-when-to-use#the-total-backend-dataset-is--100gb",
+    "id": "546-when-to-use#the-total-backend-dataset-is--100gb",
     "title": "When To Use Zero",
     "searchTitle": "The total backend dataset is > ~100GB",
     "sectionTitle": "The total backend dataset is > ~100GB",
@@ -7087,7 +7348,7 @@
     "kind": "section"
   },
   {
-    "id": "528-when-to-use#zero-might-not-be-a-good-fit-yet",
+    "id": "547-when-to-use#zero-might-not-be-a-good-fit-yet",
     "title": "When To Use Zero",
     "searchTitle": "Zero Might Not be a Good Fit Yet",
     "sectionTitle": "Zero Might Not be a Good Fit Yet",
@@ -7097,7 +7358,7 @@
     "kind": "section"
   },
   {
-    "id": "529-when-to-use#alternatives",
+    "id": "548-when-to-use#alternatives",
     "title": "When To Use Zero",
     "searchTitle": "Alternatives",
     "sectionTitle": "Alternatives",
@@ -7107,7 +7368,7 @@
     "kind": "section"
   },
   {
-    "id": "70-zero-cache-config",
+    "id": "71-zero-cache-config",
     "title": "zero-cache Config",
     "searchTitle": "zero-cache Config",
     "url": "/docs/zero-cache-config",
@@ -7433,7 +7694,7 @@
     "kind": "page"
   },
   {
-    "id": "530-zero-cache-config#required-flags",
+    "id": "549-zero-cache-config#required-flags",
     "title": "zero-cache Config",
     "searchTitle": "Required Flags",
     "sectionTitle": "Required Flags",
@@ -7443,7 +7704,7 @@
     "kind": "section"
   },
   {
-    "id": "531-zero-cache-config#upstream-db",
+    "id": "550-zero-cache-config#upstream-db",
     "title": "zero-cache Config",
     "searchTitle": "Upstream DB",
     "sectionTitle": "Upstream DB",
@@ -7453,7 +7714,7 @@
     "kind": "section"
   },
   {
-    "id": "532-zero-cache-config#admin-password",
+    "id": "551-zero-cache-config#admin-password",
     "title": "zero-cache Config",
     "searchTitle": "Admin Password",
     "sectionTitle": "Admin Password",
@@ -7463,7 +7724,7 @@
     "kind": "section"
   },
   {
-    "id": "533-zero-cache-config#optional-flags",
+    "id": "552-zero-cache-config#optional-flags",
     "title": "zero-cache Config",
     "searchTitle": "Optional Flags",
     "sectionTitle": "Optional Flags",
@@ -7473,7 +7734,7 @@
     "kind": "section"
   },
   {
-    "id": "534-zero-cache-config#app-id",
+    "id": "553-zero-cache-config#app-id",
     "title": "zero-cache Config",
     "searchTitle": "App ID",
     "sectionTitle": "App ID",
@@ -7483,7 +7744,7 @@
     "kind": "section"
   },
   {
-    "id": "535-zero-cache-config#app-publications",
+    "id": "554-zero-cache-config#app-publications",
     "title": "zero-cache Config",
     "searchTitle": "App Publications",
     "sectionTitle": "App Publications",
@@ -7493,7 +7754,7 @@
     "kind": "section"
   },
   {
-    "id": "536-zero-cache-config#auth-revalidate-interval-seconds",
+    "id": "555-zero-cache-config#auth-revalidate-interval-seconds",
     "title": "zero-cache Config",
     "searchTitle": "Auth Revalidate Interval Seconds",
     "sectionTitle": "Auth Revalidate Interval Seconds",
@@ -7503,7 +7764,7 @@
     "kind": "section"
   },
   {
-    "id": "537-zero-cache-config#auth-retransform-interval-seconds",
+    "id": "556-zero-cache-config#auth-retransform-interval-seconds",
     "title": "zero-cache Config",
     "searchTitle": "Auth Retransform Interval Seconds",
     "sectionTitle": "Auth Retransform Interval Seconds",
@@ -7513,7 +7774,7 @@
     "kind": "section"
   },
   {
-    "id": "538-zero-cache-config#auto-reset",
+    "id": "557-zero-cache-config#auto-reset",
     "title": "zero-cache Config",
     "searchTitle": "Auto Reset",
     "sectionTitle": "Auto Reset",
@@ -7523,7 +7784,7 @@
     "kind": "section"
   },
   {
-    "id": "539-zero-cache-config#change-db",
+    "id": "558-zero-cache-config#change-db",
     "title": "zero-cache Config",
     "searchTitle": "Change DB",
     "sectionTitle": "Change DB",
@@ -7533,7 +7794,7 @@
     "kind": "section"
   },
   {
-    "id": "540-zero-cache-config#change-max-connections",
+    "id": "559-zero-cache-config#change-max-connections",
     "title": "zero-cache Config",
     "searchTitle": "Change Max Connections",
     "sectionTitle": "Change Max Connections",
@@ -7543,7 +7804,7 @@
     "kind": "section"
   },
   {
-    "id": "541-zero-cache-config#change-streamer-back-pressure-limit-heap-proportion",
+    "id": "560-zero-cache-config#change-streamer-back-pressure-limit-heap-proportion",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Back Pressure Limit Heap Proportion",
     "sectionTitle": "Change Streamer Back Pressure Limit Heap Proportion",
@@ -7553,7 +7814,7 @@
     "kind": "section"
   },
   {
-    "id": "542-zero-cache-config#change-streamer-flow-control-consensus-padding-seconds",
+    "id": "561-zero-cache-config#change-streamer-flow-control-consensus-padding-seconds",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Flow Control Consensus Padding Seconds",
     "sectionTitle": "Change Streamer Flow Control Consensus Padding Seconds",
@@ -7563,7 +7824,7 @@
     "kind": "section"
   },
   {
-    "id": "543-zero-cache-config#change-streamer-mode",
+    "id": "562-zero-cache-config#change-streamer-mode",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Mode",
     "sectionTitle": "Change Streamer Mode",
@@ -7573,7 +7834,7 @@
     "kind": "section"
   },
   {
-    "id": "544-zero-cache-config#change-streamer-port",
+    "id": "563-zero-cache-config#change-streamer-port",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Port",
     "sectionTitle": "Change Streamer Port",
@@ -7583,7 +7844,7 @@
     "kind": "section"
   },
   {
-    "id": "545-zero-cache-config#change-streamer-startup-delay-ms",
+    "id": "564-zero-cache-config#change-streamer-startup-delay-ms",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer Startup Delay (ms)",
     "sectionTitle": "Change Streamer Startup Delay (ms)",
@@ -7593,7 +7854,7 @@
     "kind": "section"
   },
   {
-    "id": "546-zero-cache-config#change-streamer-uri",
+    "id": "565-zero-cache-config#change-streamer-uri",
     "title": "zero-cache Config",
     "searchTitle": "Change Streamer URI",
     "sectionTitle": "Change Streamer URI",
@@ -7603,7 +7864,7 @@
     "kind": "section"
   },
   {
-    "id": "547-zero-cache-config#cvr-db",
+    "id": "566-zero-cache-config#cvr-db",
     "title": "zero-cache Config",
     "searchTitle": "CVR DB",
     "sectionTitle": "CVR DB",
@@ -7613,7 +7874,7 @@
     "kind": "section"
   },
   {
-    "id": "548-zero-cache-config#cvr-garbage-collection-inactivity-threshold-hours",
+    "id": "567-zero-cache-config#cvr-garbage-collection-inactivity-threshold-hours",
     "title": "zero-cache Config",
     "searchTitle": "CVR Garbage Collection Inactivity Threshold Hours",
     "sectionTitle": "CVR Garbage Collection Inactivity Threshold Hours",
@@ -7623,7 +7884,7 @@
     "kind": "section"
   },
   {
-    "id": "549-zero-cache-config#cvr-garbage-collection-initial-batch-size",
+    "id": "568-zero-cache-config#cvr-garbage-collection-initial-batch-size",
     "title": "zero-cache Config",
     "searchTitle": "CVR Garbage Collection Initial Batch Size",
     "sectionTitle": "CVR Garbage Collection Initial Batch Size",
@@ -7633,7 +7894,7 @@
     "kind": "section"
   },
   {
-    "id": "550-zero-cache-config#cvr-garbage-collection-initial-interval-seconds",
+    "id": "569-zero-cache-config#cvr-garbage-collection-initial-interval-seconds",
     "title": "zero-cache Config",
     "searchTitle": "CVR Garbage Collection Initial Interval Seconds",
     "sectionTitle": "CVR Garbage Collection Initial Interval Seconds",
@@ -7643,7 +7904,7 @@
     "kind": "section"
   },
   {
-    "id": "551-zero-cache-config#cvr-max-connections",
+    "id": "570-zero-cache-config#cvr-max-connections",
     "title": "zero-cache Config",
     "searchTitle": "CVR Max Connections",
     "sectionTitle": "CVR Max Connections",
@@ -7653,7 +7914,7 @@
     "kind": "section"
   },
   {
-    "id": "552-zero-cache-config#enable-query-planner",
+    "id": "571-zero-cache-config#enable-query-planner",
     "title": "zero-cache Config",
     "searchTitle": "Enable Query Planner",
     "sectionTitle": "Enable Query Planner",
@@ -7663,7 +7924,7 @@
     "kind": "section"
   },
   {
-    "id": "553-zero-cache-config#enable-crud-mutations",
+    "id": "572-zero-cache-config#enable-crud-mutations",
     "title": "zero-cache Config",
     "searchTitle": "Enable CRUD Mutations",
     "sectionTitle": "Enable CRUD Mutations",
@@ -7673,7 +7934,7 @@
     "kind": "section"
   },
   {
-    "id": "554-zero-cache-config#enable-telemetry",
+    "id": "573-zero-cache-config#enable-telemetry",
     "title": "zero-cache Config",
     "searchTitle": "Enable Telemetry",
     "sectionTitle": "Enable Telemetry",
@@ -7683,7 +7944,7 @@
     "kind": "section"
   },
   {
-    "id": "555-zero-cache-config#initial-sync-table-copy-workers",
+    "id": "574-zero-cache-config#initial-sync-table-copy-workers",
     "title": "zero-cache Config",
     "searchTitle": "Initial Sync Table Copy Workers",
     "sectionTitle": "Initial Sync Table Copy Workers",
@@ -7693,7 +7954,7 @@
     "kind": "section"
   },
   {
-    "id": "556-zero-cache-config#lazy-startup",
+    "id": "575-zero-cache-config#lazy-startup",
     "title": "zero-cache Config",
     "searchTitle": "Lazy Startup",
     "sectionTitle": "Lazy Startup",
@@ -7703,7 +7964,7 @@
     "kind": "section"
   },
   {
-    "id": "557-zero-cache-config#litestream-backup-url",
+    "id": "576-zero-cache-config#litestream-backup-url",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Backup URL",
     "sectionTitle": "Litestream Backup URL",
@@ -7713,7 +7974,7 @@
     "kind": "section"
   },
   {
-    "id": "558-zero-cache-config#litestream-endpoint",
+    "id": "577-zero-cache-config#litestream-endpoint",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Endpoint",
     "sectionTitle": "Litestream Endpoint",
@@ -7723,7 +7984,7 @@
     "kind": "section"
   },
   {
-    "id": "559-zero-cache-config#litestream-checkpoint-threshold-mb",
+    "id": "578-zero-cache-config#litestream-checkpoint-threshold-mb",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Checkpoint Threshold MB",
     "sectionTitle": "Litestream Checkpoint Threshold MB",
@@ -7733,7 +7994,7 @@
     "kind": "section"
   },
   {
-    "id": "560-zero-cache-config#litestream-config-path",
+    "id": "579-zero-cache-config#litestream-config-path",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Config Path",
     "sectionTitle": "Litestream Config Path",
@@ -7743,7 +8004,7 @@
     "kind": "section"
   },
   {
-    "id": "561-zero-cache-config#litestream-executable",
+    "id": "580-zero-cache-config#litestream-executable",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Executable",
     "sectionTitle": "Litestream Executable",
@@ -7753,7 +8014,7 @@
     "kind": "section"
   },
   {
-    "id": "562-zero-cache-config#litestream-incremental-backup-interval-minutes",
+    "id": "581-zero-cache-config#litestream-incremental-backup-interval-minutes",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Incremental Backup Interval Minutes",
     "sectionTitle": "Litestream Incremental Backup Interval Minutes",
@@ -7763,7 +8024,7 @@
     "kind": "section"
   },
   {
-    "id": "563-zero-cache-config#litestream-maximum-checkpoint-page-count",
+    "id": "582-zero-cache-config#litestream-maximum-checkpoint-page-count",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Maximum Checkpoint Page Count",
     "sectionTitle": "Litestream Maximum Checkpoint Page Count",
@@ -7773,7 +8034,7 @@
     "kind": "section"
   },
   {
-    "id": "564-zero-cache-config#litestream-minimum-checkpoint-page-count",
+    "id": "583-zero-cache-config#litestream-minimum-checkpoint-page-count",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Minimum Checkpoint Page Count",
     "sectionTitle": "Litestream Minimum Checkpoint Page Count",
@@ -7783,7 +8044,7 @@
     "kind": "section"
   },
   {
-    "id": "565-zero-cache-config#litestream-multipart-concurrency",
+    "id": "584-zero-cache-config#litestream-multipart-concurrency",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Multipart Concurrency",
     "sectionTitle": "Litestream Multipart Concurrency",
@@ -7793,7 +8054,7 @@
     "kind": "section"
   },
   {
-    "id": "566-zero-cache-config#litestream-multipart-size",
+    "id": "585-zero-cache-config#litestream-multipart-size",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Multipart Size",
     "sectionTitle": "Litestream Multipart Size",
@@ -7803,7 +8064,7 @@
     "kind": "section"
   },
   {
-    "id": "567-zero-cache-config#litestream-log-level",
+    "id": "586-zero-cache-config#litestream-log-level",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Log Level",
     "sectionTitle": "Litestream Log Level",
@@ -7813,7 +8074,7 @@
     "kind": "section"
   },
   {
-    "id": "568-zero-cache-config#litestream-port",
+    "id": "587-zero-cache-config#litestream-port",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Port",
     "sectionTitle": "Litestream Port",
@@ -7823,7 +8084,7 @@
     "kind": "section"
   },
   {
-    "id": "569-zero-cache-config#litestream-restore-parallelism",
+    "id": "588-zero-cache-config#litestream-restore-parallelism",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Restore Parallelism",
     "sectionTitle": "Litestream Restore Parallelism",
@@ -7833,7 +8094,7 @@
     "kind": "section"
   },
   {
-    "id": "570-zero-cache-config#litestream-snapshot-backup-interval-hours",
+    "id": "589-zero-cache-config#litestream-snapshot-backup-interval-hours",
     "title": "zero-cache Config",
     "searchTitle": "Litestream Snapshot Backup Interval Hours",
     "sectionTitle": "Litestream Snapshot Backup Interval Hours",
@@ -7843,7 +8104,7 @@
     "kind": "section"
   },
   {
-    "id": "571-zero-cache-config#log-format",
+    "id": "590-zero-cache-config#log-format",
     "title": "zero-cache Config",
     "searchTitle": "Log Format",
     "sectionTitle": "Log Format",
@@ -7853,7 +8114,7 @@
     "kind": "section"
   },
   {
-    "id": "572-zero-cache-config#log-ivm-sampling",
+    "id": "591-zero-cache-config#log-ivm-sampling",
     "title": "zero-cache Config",
     "searchTitle": "Log IVM Sampling",
     "sectionTitle": "Log IVM Sampling",
@@ -7863,7 +8124,7 @@
     "kind": "section"
   },
   {
-    "id": "573-zero-cache-config#log-level",
+    "id": "592-zero-cache-config#log-level",
     "title": "zero-cache Config",
     "searchTitle": "Log Level",
     "sectionTitle": "Log Level",
@@ -7873,7 +8134,7 @@
     "kind": "section"
   },
   {
-    "id": "574-zero-cache-config#log-slow-hydrate-threshold",
+    "id": "593-zero-cache-config#log-slow-hydrate-threshold",
     "title": "zero-cache Config",
     "searchTitle": "Log Slow Hydrate Threshold",
     "sectionTitle": "Log Slow Hydrate Threshold",
@@ -7883,7 +8144,7 @@
     "kind": "section"
   },
   {
-    "id": "575-zero-cache-config#log-slow-row-threshold",
+    "id": "594-zero-cache-config#log-slow-row-threshold",
     "title": "zero-cache Config",
     "searchTitle": "Log Slow Row Threshold",
     "sectionTitle": "Log Slow Row Threshold",
@@ -7893,7 +8154,7 @@
     "kind": "section"
   },
   {
-    "id": "576-zero-cache-config#mutate-api-key",
+    "id": "595-zero-cache-config#mutate-api-key",
     "title": "zero-cache Config",
     "searchTitle": "Mutate API Key",
     "sectionTitle": "Mutate API Key",
@@ -7903,7 +8164,7 @@
     "kind": "section"
   },
   {
-    "id": "577-zero-cache-config#mutate-allowed-client-headers",
+    "id": "596-zero-cache-config#mutate-allowed-client-headers",
     "title": "zero-cache Config",
     "searchTitle": "Mutate Allowed Client Headers",
     "sectionTitle": "Mutate Allowed Client Headers",
@@ -7913,7 +8174,7 @@
     "kind": "section"
   },
   {
-    "id": "578-zero-cache-config#mutate-forward-cookies",
+    "id": "597-zero-cache-config#mutate-forward-cookies",
     "title": "zero-cache Config",
     "searchTitle": "Mutate Forward Cookies",
     "sectionTitle": "Mutate Forward Cookies",
@@ -7923,7 +8184,7 @@
     "kind": "section"
   },
   {
-    "id": "579-zero-cache-config#mutate-url",
+    "id": "598-zero-cache-config#mutate-url",
     "title": "zero-cache Config",
     "searchTitle": "Mutate URL",
     "sectionTitle": "Mutate URL",
@@ -7933,7 +8194,7 @@
     "kind": "section"
   },
   {
-    "id": "580-zero-cache-config#number-of-sync-workers",
+    "id": "599-zero-cache-config#number-of-sync-workers",
     "title": "zero-cache Config",
     "searchTitle": "Number of Sync Workers",
     "sectionTitle": "Number of Sync Workers",
@@ -7943,7 +8204,7 @@
     "kind": "section"
   },
   {
-    "id": "581-zero-cache-config#per-user-mutation-limit-max",
+    "id": "600-zero-cache-config#per-user-mutation-limit-max",
     "title": "zero-cache Config",
     "searchTitle": "Per User Mutation Limit Max",
     "sectionTitle": "Per User Mutation Limit Max",
@@ -7953,7 +8214,7 @@
     "kind": "section"
   },
   {
-    "id": "582-zero-cache-config#per-user-mutation-limit-window-ms",
+    "id": "601-zero-cache-config#per-user-mutation-limit-window-ms",
     "title": "zero-cache Config",
     "searchTitle": "Per User Mutation Limit Window (ms)",
     "sectionTitle": "Per User Mutation Limit Window (ms)",
@@ -7963,7 +8224,7 @@
     "kind": "section"
   },
   {
-    "id": "583-zero-cache-config#port",
+    "id": "602-zero-cache-config#port",
     "title": "zero-cache Config",
     "searchTitle": "Port",
     "sectionTitle": "Port",
@@ -7973,7 +8234,7 @@
     "kind": "section"
   },
   {
-    "id": "584-zero-cache-config#query-api-key",
+    "id": "603-zero-cache-config#query-api-key",
     "title": "zero-cache Config",
     "searchTitle": "Query API Key",
     "sectionTitle": "Query API Key",
@@ -7983,7 +8244,7 @@
     "kind": "section"
   },
   {
-    "id": "585-zero-cache-config#query-allowed-client-headers",
+    "id": "604-zero-cache-config#query-allowed-client-headers",
     "title": "zero-cache Config",
     "searchTitle": "Query Allowed Client Headers",
     "sectionTitle": "Query Allowed Client Headers",
@@ -7993,7 +8254,7 @@
     "kind": "section"
   },
   {
-    "id": "586-zero-cache-config#query-forward-cookies",
+    "id": "605-zero-cache-config#query-forward-cookies",
     "title": "zero-cache Config",
     "searchTitle": "Query Forward Cookies",
     "sectionTitle": "Query Forward Cookies",
@@ -8003,7 +8264,7 @@
     "kind": "section"
   },
   {
-    "id": "587-zero-cache-config#query-hydration-stats",
+    "id": "606-zero-cache-config#query-hydration-stats",
     "title": "zero-cache Config",
     "searchTitle": "Query Hydration Stats",
     "sectionTitle": "Query Hydration Stats",
@@ -8013,7 +8274,7 @@
     "kind": "section"
   },
   {
-    "id": "588-zero-cache-config#query-url",
+    "id": "607-zero-cache-config#query-url",
     "title": "zero-cache Config",
     "searchTitle": "Query URL",
     "sectionTitle": "Query URL",
@@ -8023,7 +8284,7 @@
     "kind": "section"
   },
   {
-    "id": "589-zero-cache-config#replica-file",
+    "id": "608-zero-cache-config#replica-file",
     "title": "zero-cache Config",
     "searchTitle": "Replica File",
     "sectionTitle": "Replica File",
@@ -8033,7 +8294,7 @@
     "kind": "section"
   },
   {
-    "id": "590-zero-cache-config#replica-vacuum-interval-hours",
+    "id": "609-zero-cache-config#replica-vacuum-interval-hours",
     "title": "zero-cache Config",
     "searchTitle": "Replica Vacuum Interval Hours",
     "sectionTitle": "Replica Vacuum Interval Hours",
@@ -8043,7 +8304,7 @@
     "kind": "section"
   },
   {
-    "id": "591-zero-cache-config#replication-lag-report-interval-ms",
+    "id": "610-zero-cache-config#replication-lag-report-interval-ms",
     "title": "zero-cache Config",
     "searchTitle": "Replication Lag Report Interval (ms)",
     "sectionTitle": "Replication Lag Report Interval (ms)",
@@ -8053,7 +8314,7 @@
     "kind": "section"
   },
   {
-    "id": "592-zero-cache-config#server-version",
+    "id": "611-zero-cache-config#server-version",
     "title": "zero-cache Config",
     "searchTitle": "Server Version",
     "sectionTitle": "Server Version",
@@ -8063,7 +8324,7 @@
     "kind": "section"
   },
   {
-    "id": "593-zero-cache-config#shadow-sync-enabled",
+    "id": "612-zero-cache-config#shadow-sync-enabled",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Enabled",
     "sectionTitle": "Shadow Sync Enabled",
@@ -8073,7 +8334,7 @@
     "kind": "section"
   },
   {
-    "id": "594-zero-cache-config#shadow-sync-interval-hours",
+    "id": "613-zero-cache-config#shadow-sync-interval-hours",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Interval Hours",
     "sectionTitle": "Shadow Sync Interval Hours",
@@ -8083,7 +8344,7 @@
     "kind": "section"
   },
   {
-    "id": "595-zero-cache-config#shadow-sync-sample-rate",
+    "id": "614-zero-cache-config#shadow-sync-sample-rate",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Sample Rate",
     "sectionTitle": "Shadow Sync Sample Rate",
@@ -8093,7 +8354,7 @@
     "kind": "section"
   },
   {
-    "id": "596-zero-cache-config#shadow-sync-max-rows-per-table",
+    "id": "615-zero-cache-config#shadow-sync-max-rows-per-table",
     "title": "zero-cache Config",
     "searchTitle": "Shadow Sync Max Rows Per Table",
     "sectionTitle": "Shadow Sync Max Rows Per Table",
@@ -8103,7 +8364,7 @@
     "kind": "section"
   },
   {
-    "id": "597-zero-cache-config#storage-db-temp-dir",
+    "id": "616-zero-cache-config#storage-db-temp-dir",
     "title": "zero-cache Config",
     "searchTitle": "Storage DB Temp Dir",
     "sectionTitle": "Storage DB Temp Dir",
@@ -8113,7 +8374,7 @@
     "kind": "section"
   },
   {
-    "id": "598-zero-cache-config#task-id",
+    "id": "617-zero-cache-config#task-id",
     "title": "zero-cache Config",
     "searchTitle": "Task ID",
     "sectionTitle": "Task ID",
@@ -8123,7 +8384,7 @@
     "kind": "section"
   },
   {
-    "id": "599-zero-cache-config#upstream-max-connections",
+    "id": "618-zero-cache-config#upstream-max-connections",
     "title": "zero-cache Config",
     "searchTitle": "Upstream Max Connections",
     "sectionTitle": "Upstream Max Connections",
@@ -8133,7 +8394,7 @@
     "kind": "section"
   },
   {
-    "id": "600-zero-cache-config#upstream-pg-replication-slot-failover",
+    "id": "619-zero-cache-config#upstream-pg-replication-slot-failover",
     "title": "zero-cache Config",
     "searchTitle": "Upstream PG Replication Slot Failover",
     "sectionTitle": "Upstream PG Replication Slot Failover",
@@ -8143,7 +8404,7 @@
     "kind": "section"
   },
   {
-    "id": "601-zero-cache-config#websocket-compression",
+    "id": "620-zero-cache-config#websocket-compression",
     "title": "zero-cache Config",
     "searchTitle": "Websocket Compression",
     "sectionTitle": "Websocket Compression",
@@ -8153,7 +8414,7 @@
     "kind": "section"
   },
   {
-    "id": "602-zero-cache-config#websocket-compression-options",
+    "id": "621-zero-cache-config#websocket-compression-options",
     "title": "zero-cache Config",
     "searchTitle": "Websocket Compression Options",
     "sectionTitle": "Websocket Compression Options",
@@ -8163,7 +8424,7 @@
     "kind": "section"
   },
   {
-    "id": "603-zero-cache-config#websocket-max-payload-bytes",
+    "id": "622-zero-cache-config#websocket-max-payload-bytes",
     "title": "zero-cache Config",
     "searchTitle": "Websocket Max Payload Bytes",
     "sectionTitle": "Websocket Max Payload Bytes",
@@ -8173,7 +8434,7 @@
     "kind": "section"
   },
   {
-    "id": "604-zero-cache-config#yield-threshold-ms",
+    "id": "623-zero-cache-config#yield-threshold-ms",
     "title": "zero-cache Config",
     "searchTitle": "Yield Threshold (ms)",
     "sectionTitle": "Yield Threshold (ms)",
@@ -8183,7 +8444,7 @@
     "kind": "section"
   },
   {
-    "id": "605-zero-cache-config#deprecated-flags",
+    "id": "624-zero-cache-config#deprecated-flags",
     "title": "zero-cache Config",
     "searchTitle": "Deprecated Flags",
     "sectionTitle": "Deprecated Flags",
@@ -8193,7 +8454,7 @@
     "kind": "section"
   },
   {
-    "id": "606-zero-cache-config#auth-jwk",
+    "id": "625-zero-cache-config#auth-jwk",
     "title": "zero-cache Config",
     "searchTitle": "Auth JWK",
     "sectionTitle": "Auth JWK",
@@ -8203,7 +8464,7 @@
     "kind": "section"
   },
   {
-    "id": "607-zero-cache-config#auth-jwks-url",
+    "id": "626-zero-cache-config#auth-jwks-url",
     "title": "zero-cache Config",
     "searchTitle": "Auth JWKS URL",
     "sectionTitle": "Auth JWKS URL",
@@ -8213,7 +8474,7 @@
     "kind": "section"
   },
   {
-    "id": "608-zero-cache-config#auth-secret",
+    "id": "627-zero-cache-config#auth-secret",
     "title": "zero-cache Config",
     "searchTitle": "Auth Secret",
     "sectionTitle": "Auth Secret",
@@ -8223,7 +8484,7 @@
     "kind": "section"
   },
   {
-    "id": "71-zql",
+    "id": "72-zql",
     "title": "ZQL",
     "searchTitle": "ZQL",
     "url": "/docs/zql",
@@ -8333,7 +8594,7 @@
     "kind": "page"
   },
   {
-    "id": "609-zql#create-a-builder",
+    "id": "628-zql#create-a-builder",
     "title": "ZQL",
     "searchTitle": "Create a Builder",
     "sectionTitle": "Create a Builder",
@@ -8343,7 +8604,7 @@
     "kind": "section"
   },
   {
-    "id": "610-zql#select",
+    "id": "629-zql#select",
     "title": "ZQL",
     "searchTitle": "Select",
     "sectionTitle": "Select",
@@ -8353,7 +8614,7 @@
     "kind": "section"
   },
   {
-    "id": "611-zql#ordering",
+    "id": "630-zql#ordering",
     "title": "ZQL",
     "searchTitle": "Ordering",
     "sectionTitle": "Ordering",
@@ -8363,7 +8624,7 @@
     "kind": "section"
   },
   {
-    "id": "612-zql#limit",
+    "id": "631-zql#limit",
     "title": "ZQL",
     "searchTitle": "Limit",
     "sectionTitle": "Limit",
@@ -8373,7 +8634,7 @@
     "kind": "section"
   },
   {
-    "id": "613-zql#paging",
+    "id": "632-zql#paging",
     "title": "ZQL",
     "searchTitle": "Paging",
     "sectionTitle": "Paging",
@@ -8383,7 +8644,7 @@
     "kind": "section"
   },
   {
-    "id": "614-zql#getting-a-single-result",
+    "id": "633-zql#getting-a-single-result",
     "title": "ZQL",
     "searchTitle": "Getting a Single Result",
     "sectionTitle": "Getting a Single Result",
@@ -8393,7 +8654,7 @@
     "kind": "section"
   },
   {
-    "id": "615-zql#relationships",
+    "id": "634-zql#relationships",
     "title": "ZQL",
     "searchTitle": "Relationships",
     "sectionTitle": "Relationships",
@@ -8403,7 +8664,7 @@
     "kind": "section"
   },
   {
-    "id": "616-zql#refining-relationships",
+    "id": "635-zql#refining-relationships",
     "title": "ZQL",
     "searchTitle": "Refining Relationships",
     "sectionTitle": "Refining Relationships",
@@ -8413,7 +8674,7 @@
     "kind": "section"
   },
   {
-    "id": "617-zql#nested-relationships",
+    "id": "636-zql#nested-relationships",
     "title": "ZQL",
     "searchTitle": "Nested Relationships",
     "sectionTitle": "Nested Relationships",
@@ -8423,7 +8684,7 @@
     "kind": "section"
   },
   {
-    "id": "618-zql#where",
+    "id": "637-zql#where",
     "title": "ZQL",
     "searchTitle": "Where",
     "sectionTitle": "Where",
@@ -8433,7 +8694,7 @@
     "kind": "section"
   },
   {
-    "id": "619-zql#comparison-operators",
+    "id": "638-zql#comparison-operators",
     "title": "ZQL",
     "searchTitle": "Comparison Operators",
     "sectionTitle": "Comparison Operators",
@@ -8443,7 +8704,7 @@
     "kind": "section"
   },
   {
-    "id": "620-zql#equals-is-the-default-comparison-operator",
+    "id": "639-zql#equals-is-the-default-comparison-operator",
     "title": "ZQL",
     "searchTitle": "Equals is the Default Comparison Operator",
     "sectionTitle": "Equals is the Default Comparison Operator",
@@ -8453,7 +8714,7 @@
     "kind": "section"
   },
   {
-    "id": "621-zql#comparing-to-null",
+    "id": "640-zql#comparing-to-null",
     "title": "ZQL",
     "searchTitle": "Comparing to null",
     "sectionTitle": "Comparing to null",
@@ -8463,7 +8724,7 @@
     "kind": "section"
   },
   {
-    "id": "622-zql#comparing-to-undefined",
+    "id": "641-zql#comparing-to-undefined",
     "title": "ZQL",
     "searchTitle": "Comparing to undefined",
     "sectionTitle": "Comparing to undefined",
@@ -8473,7 +8734,7 @@
     "kind": "section"
   },
   {
-    "id": "623-zql#compound-filters",
+    "id": "642-zql#compound-filters",
     "title": "ZQL",
     "searchTitle": "Compound Filters",
     "sectionTitle": "Compound Filters",
@@ -8483,7 +8744,7 @@
     "kind": "section"
   },
   {
-    "id": "624-zql#comparing-literal-values",
+    "id": "643-zql#comparing-literal-values",
     "title": "ZQL",
     "searchTitle": "Comparing Literal Values",
     "sectionTitle": "Comparing Literal Values",
@@ -8493,7 +8754,7 @@
     "kind": "section"
   },
   {
-    "id": "625-zql#relationship-filters",
+    "id": "644-zql#relationship-filters",
     "title": "ZQL",
     "searchTitle": "Relationship Filters",
     "sectionTitle": "Relationship Filters",
@@ -8503,7 +8764,7 @@
     "kind": "section"
   },
   {
-    "id": "626-zql#type-helpers",
+    "id": "645-zql#type-helpers",
     "title": "ZQL",
     "searchTitle": "Type Helpers",
     "sectionTitle": "Type Helpers",
@@ -8513,7 +8774,7 @@
     "kind": "section"
   },
   {
-    "id": "627-zql#planning",
+    "id": "646-zql#planning",
     "title": "ZQL",
     "searchTitle": "Planning",
     "sectionTitle": "Planning",
@@ -8523,7 +8784,7 @@
     "kind": "section"
   },
   {
-    "id": "628-zql#inspecting-query-plans",
+    "id": "647-zql#inspecting-query-plans",
     "title": "ZQL",
     "searchTitle": "Inspecting Query Plans",
     "sectionTitle": "Inspecting Query Plans",
@@ -8533,7 +8794,7 @@
     "kind": "section"
   },
   {
-    "id": "629-zql#manually-flipping-joins",
+    "id": "648-zql#manually-flipping-joins",
     "title": "ZQL",
     "searchTitle": "Manually Flipping Joins",
     "sectionTitle": "Manually Flipping Joins",
@@ -8543,7 +8804,7 @@
     "kind": "section"
   },
   {
-    "id": "630-zql#scalar-subqueries",
+    "id": "649-zql#scalar-subqueries",
     "title": "ZQL",
     "searchTitle": "Scalar Subqueries",
     "sectionTitle": "Scalar Subqueries",
@@ -8553,7 +8814,7 @@
     "kind": "section"
   },
   {
-    "id": "631-zql#why-it-matters",
+    "id": "650-zql#why-it-matters",
     "title": "ZQL",
     "searchTitle": "Why It Matters",
     "sectionTitle": "Why It Matters",
@@ -8563,7 +8824,7 @@
     "kind": "section"
   },
   {
-    "id": "632-zql#trade-offs",
+    "id": "651-zql#trade-offs",
     "title": "ZQL",
     "searchTitle": "Trade-offs",
     "sectionTitle": "Trade-offs",
@@ -8573,7 +8834,7 @@
     "kind": "section"
   },
   {
-    "id": "633-zql#future-work",
+    "id": "652-zql#future-work",
     "title": "ZQL",
     "searchTitle": "Future Work",
     "sectionTitle": "Future Work",

--- a/contents/docs/connecting-to-postgres.mdx
+++ b/contents/docs/connecting-to-postgres.mdx
@@ -71,12 +71,438 @@ This configuration can cause problems like `slot has been invalidated because it
 
 ### PlanetScale for Postgres
 
-You should use the `default` role that PlanetScale provides, because PlanetScale user-defined roles cannot create replication slots.
-
 Planetscale Postgres defaults `max_connections` to 25, which can easily be exhausted by Zero's connection pools. This will result in an error like `remaining connection slots are reserved for roles with the SUPERUSER attribute`.
 You should increase this value in the Parameters section of the PlanetScale dashboard to 100 or more.
 
 Make sure to only use a direct connection for the `ZERO_UPSTREAM_DB`, and use pooled URLs for `ZERO_CVR_DB`, `ZERO_CHANGE_DB`, and your API (see [Deployment](/docs/self-host)).
+
+<Note type="note" heading="Optional hardening step">
+  You do not need role-scoped IP restrictions to use Zero with PlanetScale
+  Postgres. Zero works with a normal direct `ZERO_UPSTREAM_DB` connection and
+  the usual role and password setup.
+
+The rest of this section describes an optional hardening pattern that is
+especially useful for [Cloud Zero](/docs/cloud-zero), and can also be useful
+for self-hosted Zero when the database connection still crosses the public
+internet instead of a private path such as PrivateLink. The goal is to
+restrict the Zero upstream role to a small set of known egress IPs while
+preserving existing application access.
+
+For the smoothest rollout, get Zero working first, then add these hardening
+steps one layer at a time.
+
+</Note>
+
+#### Suggested order
+
+The easiest setup is to get Zero running first, then add security from lowest
+to highest operational overhead:
+
+1. During setup: get Zero working with a direct `ZERO_UPSTREAM_DB` connection
+   and the recommended role grants below.
+2. During setup or later: use a dedicated `zero` role instead of the
+   PlanetScale `default` role if you want cleaner credential rotation and
+   role-scoped IP restrictions.
+3. Later: add PlanetScale role-scoped IP restrictions so existing app roles can
+   stay open while `zero` is limited to Cloud Zero egress IPs.
+4. Later, and only if you want tighter least privilege: replace
+   `pg_read_all_data` with publication-scoped app-table grants and optionally
+   automate them with an admin-owned helper.
+
+#### Custom Zero roles
+
+You can use PlanetScale's `default` role for Zero if you want the simplest
+setup. For production, a dedicated `zero` role is usually better because it
+separates Zero from the rest of your application for credential rotation and
+role-scoped IP restrictions.
+
+A dedicated Zero role needs three things:
+
+- `LOGIN` and `REPLICATION` so it can connect and read the replication stream
+- read access to the application tables it replicates, because initial sync
+  copies rows with `COPY (SELECT ...)`
+- ownership or write access to Zero's internal `z_%` metadata schemas, because
+  tables like `replicas` track Zero state
+
+Zero's internal schema names are not fixed. Current deployments commonly use
+schemas named like `z_abcd1234` and `z_abcd1234_0`. If those metadata
+privileges are missing, Zero can still connect and read app tables but later
+fail with errors such as `permission denied for table replicas`.
+
+#### Recommended role setup
+
+If you want the low-maintenance setup, give the dedicated role replication
+access, broad read access for app tables, and the ability to create future
+internal schemas. `pg_read_all_data` is the simplest option because publication
+changes keep working without table-grant churn. `pg_read_all_settings` and
+`pg_read_all_stats` give Zero read-only visibility into the upstream database
+state it inspects during setup and operation. This is the best first setup. Get
+it working before you add IP restrictions or tighter app-data grants.
+
+```sql
+CREATE ROLE zero WITH LOGIN REPLICATION PASSWORD 'replace-me';
+
+GRANT CONNECT ON DATABASE "app" TO zero;
+GRANT CREATE ON DATABASE "app" TO zero;
+
+GRANT pg_read_all_data TO zero;
+GRANT pg_read_all_settings TO zero;
+GRANT pg_read_all_stats TO zero;
+```
+
+If the role already exists, use `ALTER ROLE` instead:
+
+```sql
+ALTER ROLE zero WITH LOGIN REPLICATION PASSWORD 'replace-me';
+```
+
+#### Existing `z_%` schemas
+
+If Zero has already run against this database and `z_%` schemas already exist,
+grant the role access to those current schemas and tables too. This gives Zero
+write access to existing metadata tables such as `replicas`. If the schemas do
+not exist yet, `zero` can create them later because it has database `CREATE`,
+but any existing `z_%` schemas still need this retroactive grant loop.
+
+```sql
+DO $$
+DECLARE
+  schema_name text;
+BEGIN
+  FOR schema_name IN
+    SELECT nspname
+    FROM pg_namespace
+    WHERE nspname LIKE 'z\_%' ESCAPE '\'
+    ORDER BY nspname
+  LOOP
+    EXECUTE format('GRANT USAGE, CREATE ON SCHEMA %I TO zero', schema_name);
+    EXECUTE format(
+      'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I TO zero',
+      schema_name
+    );
+    EXECUTE format(
+      'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO zero',
+      schema_name
+    );
+  END LOOP;
+END $$;
+```
+
+If Zero creates future `z_%` schemas itself, it owns them. If an admin role
+creates a future `z_%` schema instead, rerun the block. The publication-scoped
+helper below only manages app-table `SELECT`. It does not replace `REPLICATION`,
+database `CREATE`, `pg_read_all_settings`, `pg_read_all_stats`, or these
+retroactive `z_%` metadata grants.
+
+#### Optional: keep app data grants publication-scoped
+
+If you want tighter app-table reads than `pg_read_all_data`, grant `SELECT`
+only on the tables currently exposed by your app publications. PostgreSQL does
+not have a native `GRANT ... ON PUBLICATION`, so this path is generated from
+`pg_publication_tables` and must be rerun when publication membership changes.
+Treat this as a later hardening step after the recommended setup already works.
+
+```sql
+DO $$
+DECLARE
+  publication_names text[] := ARRAY[
+    'replace_with_app_publication',
+    'replace_with_another_publication'
+  ];
+  r record;
+BEGIN
+  FOR r IN
+    SELECT DISTINCT schemaname
+    FROM pg_catalog.pg_publication_tables
+    WHERE pubname = ANY (publication_names)
+  LOOP
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO zero', r.schemaname);
+  END LOOP;
+
+  FOR r IN
+    SELECT DISTINCT schemaname, tablename
+    FROM pg_catalog.pg_publication_tables
+    WHERE pubname = ANY (publication_names)
+  LOOP
+    EXECUTE format('GRANT SELECT ON TABLE %I.%I TO zero', r.schemaname, r.tablename);
+  END LOOP;
+END $$;
+```
+
+If you are migrating away from `pg_read_all_data`, the safe order is: generate
+the explicit publication grants first, validate that `zero` can still read the
+published app tables, then revoke `pg_read_all_data` in the same transaction.
+
+If you want to keep those grants in sync automatically, wrap the same logic in
+admin-owned automation. The helper must be owned by an admin or table-owner
+role with grant authority, not by `zero`, and `SECURITY DEFINER` should pin
+`search_path` to `pg_catalog`. A practical shape is to keep the helper in a
+dedicated admin-owned schema, track which table grants it manages, and revoke
+`SELECT` from tables that leave the publication later.
+
+```sql
+CREATE SCHEMA IF NOT EXISTS zero_publication_grants;
+
+CREATE TABLE IF NOT EXISTS zero_publication_grants.synced_tables (
+  schemaname text NOT NULL,
+  tablename text NOT NULL,
+  PRIMARY KEY (schemaname, tablename)
+);
+
+CREATE OR REPLACE FUNCTION zero_publication_grants.sync_zero_publication_read_grants()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  publication_names text[] := ARRAY[
+    'replace_with_app_publication',
+    'replace_with_another_publication'
+  ];
+  r record;
+BEGIN
+  FOR r IN
+    SELECT DISTINCT schemaname
+    FROM pg_catalog.pg_publication_tables
+    WHERE pubname = ANY (publication_names)
+  LOOP
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO zero', r.schemaname);
+  END LOOP;
+
+  FOR r IN
+    SELECT DISTINCT schemaname, tablename
+    FROM pg_catalog.pg_publication_tables
+    WHERE pubname = ANY (publication_names)
+  LOOP
+    EXECUTE format('GRANT SELECT ON TABLE %I.%I TO zero', r.schemaname, r.tablename);
+  END LOOP;
+
+  FOR r IN
+    WITH current_tables AS (
+      SELECT DISTINCT schemaname, tablename
+      FROM pg_catalog.pg_publication_tables
+      WHERE pubname = ANY (publication_names)
+    )
+    SELECT
+      st.schemaname,
+      st.tablename,
+      EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class AS c
+        JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = st.schemaname
+          AND c.relname = st.tablename
+          AND c.relkind IN ('r', 'p')
+      ) AS table_exists
+    FROM zero_publication_grants.synced_tables AS st
+    LEFT JOIN current_tables AS ct
+      ON ct.schemaname = st.schemaname
+     AND ct.tablename = st.tablename
+    WHERE ct.tablename IS NULL
+  LOOP
+    IF r.table_exists THEN
+      EXECUTE format('REVOKE SELECT ON TABLE %I.%I FROM zero', r.schemaname, r.tablename);
+    END IF;
+  END LOOP;
+
+  DELETE FROM zero_publication_grants.synced_tables AS st
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_publication_tables AS pt
+    WHERE pt.pubname = ANY (publication_names)
+      AND pt.schemaname = st.schemaname
+      AND pt.tablename = st.tablename
+  );
+
+  INSERT INTO zero_publication_grants.synced_tables (schemaname, tablename)
+  SELECT DISTINCT schemaname, tablename
+  FROM pg_catalog.pg_publication_tables
+  WHERE pubname = ANY (publication_names)
+  ON CONFLICT DO NOTHING;
+END;
+$$;
+
+SELECT zero_publication_grants.sync_zero_publication_read_grants();
+
+CREATE OR REPLACE FUNCTION zero_publication_grants.sync_zero_publication_read_grants_event()
+RETURNS event_trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  PERFORM zero_publication_grants.sync_zero_publication_read_grants();
+END;
+$$;
+
+CREATE EVENT TRIGGER sync_zero_publication_read_grants_trigger
+ON ddl_command_end
+WHEN TAG IN (
+  'CREATE TABLE',
+  'ALTER TABLE',
+  'DROP TABLE',
+  'CREATE PUBLICATION',
+  'ALTER PUBLICATION',
+  'DROP PUBLICATION',
+  'DROP SCHEMA'
+)
+EXECUTE FUNCTION zero_publication_grants.sync_zero_publication_read_grants_event();
+```
+
+This is optional operational machinery for teams that want tighter app-data
+reads than `pg_read_all_data`. The recommended default stays `pg_read_all_data`.
+Verify that your provider permits event triggers. If it does not, rerun the
+helper after publication changes from your deployment or migration step instead.
+If you use this path, revoke `EXECUTE` from `PUBLIC` on the helper functions.
+Also audit for existing grants to `PUBLIC`: those apply to every role,
+including `zero`, and sit outside this role-specific grant model.
+
+#### How PlanetScale IP restrictions behave
+
+Once the role and grants work, you can add network restrictions.
+
+PlanetScale Postgres IP restrictions are allow rules. Once a branch has any IP
+restriction, new connections must match at least one rule. A blank-role
+`0.0.0.0/0` rule allows every role, including `zero`, so it defeats a
+restricted Zero role while it exists.
+
+To keep existing application access unchanged while restricting only `zero`,
+add explicit role-scoped `0.0.0.0/0` rules for the app and user roles that
+should stay public, then add narrow CIDR rules only for `zero`.
+
+In PlanetScale, go to **Settings → IP restrictions** and create or edit rules
+there. Use the role username, not a descriptive label, and enter IPv4
+addresses as `/32` CIDRs such as `203.0.113.10/32`. If PlanetScale shows a
+username like `pscale_api_<suffix>.<branch_id>`, use only the first part,
+`pscale_api_<suffix>`.
+
+If you are using Cloud Zero, you can find the current egress IPs in the Cloud
+Zero dashboard under **Instances → Cluster → Egress IPs**. Use those addresses
+as `/32` CIDRs. This applies both to hosted Cloud Zero and AWS-managed
+instances. Keep that console-provided list current. During an egress IP change,
+temporarily allowing both the old and new listed addresses can prevent
+accidental breakage while you validate fresh connections. If you are
+self-hosting, use the public egress IPs of your own deployment.
+
+PlanetScale internal service roles are not usually part of your app role model.
+Do not add custom rules for internal `pscale_*` roles unless PlanetScale tells
+you to. The exception is app or automation roles you actually use, such as a
+`pscale_api_*` role that backs production automation.
+
+One common final rule layout looks like this:
+
+| Role                | CIDRs                                                   | Purpose                                                                          |
+| ------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `app`               | `0.0.0.0/0`                                             | Keep the main application role publicly reachable                                |
+| `analytics`         | `0.0.0.0/0`                                             | Keep BI or human-operated access working                                         |
+| `pscale_api_abc123` | `0.0.0.0/0`                                             | Preserve a PlanetScale API-managed role that production automation actually uses |
+| `zero`              | `203.0.113.10/32`, `203.0.113.11/32`, `203.0.113.12/32` | Restrict Zero to the hosted egress IPs only                                      |
+
+#### Safe rollout for role-scoped restrictions
+
+Use this order to avoid accidental lockouts:
+
+1. Inventory the roles that still need public access, including any `pscale_api_*` roles your automation actually uses.
+2. If the branch currently has no IP rules and you want a bridge while assembling the final rules, add a temporary blank-role `0.0.0.0/0`.
+3. Add explicit role-scoped `0.0.0.0/0` rules for the existing app and user roles that should stay public, then validate fresh connections for those roles.
+4. Create or update the dedicated `zero` role and grants.
+5. Add the `zero` IP rule with only the Cloud Zero egress CIDRs.
+6. If you need to test from your laptop, temporarily append your operator `/32` to that same `zero` rule, validate, then remove it.
+7. Remove the temporary blank-role catchall last, then validate fresh app connections again and confirm that `zero` is blocked from a non-allowlisted IP.
+
+<Note
+  type="warning"
+  heading="Edit the Zero role rule, do not add a duplicate"
+>
+  PlanetScale may reject a second IP restriction record for
+  the same database and role. If you need to temporarily
+  allow an operator IP for testing, edit the existing Zero
+  rule and add one more CIDR, then remove it after testing.
+</Note>
+
+#### Practical validation checks
+
+After creating the role and applying the IP rule, validate it with a fresh
+`psql` connection as the `zero` role. Supply one replicated app table and check
+that the role can read app data, perform a no-op write against `replicas`
+inside a transaction, and create a temporary logical replication slot.
+
+```bash
+export ZERO_PROBE_DSN='postgres://zero:<password>@db.example.com:5432/app'
+export ZERO_PROBE_SCHEMA='public'
+export ZERO_PROBE_TABLE='some_replicated_table'
+
+slot_name="zero_probe_$(date +%s)"
+
+psql "$ZERO_PROBE_DSN" \
+  -X \
+  -v ON_ERROR_STOP=1 \
+  -v zero_probe_schema="$ZERO_PROBE_SCHEMA" \
+  -v zero_probe_table="$ZERO_PROBE_TABLE" \
+  -v zero_probe_slot="$slot_name" <<'SQL'
+SELECT current_user, inet_client_addr();
+SELECT has_database_privilege(current_user, current_database(), 'CREATE');
+
+SELECT format(
+  'SELECT 1 FROM %I.%I LIMIT 1',
+  :'zero_probe_schema',
+  :'zero_probe_table'
+)
+WHERE :'zero_probe_schema' <> '' AND :'zero_probe_table' <> '' \gexec
+
+BEGIN;
+SELECT format(
+  'UPDATE %I.%I SET version = version WHERE false',
+  n.nspname,
+  c.relname
+)
+FROM pg_class AS c
+JOIN pg_namespace AS n ON n.oid = c.relnamespace
+WHERE n.nspname LIKE 'z\_%' ESCAPE '\'
+  AND c.relname = 'replicas'
+  AND c.relkind IN ('r', 'p')
+ORDER BY n.nspname
+LIMIT 1 \gexec
+ROLLBACK;
+
+SELECT *
+FROM pg_create_logical_replication_slot(
+  :'zero_probe_slot',
+  'pgoutput',
+  true
+);
+SQL
+```
+
+PlanetScale currently supports PostgreSQL 17 and 18, so the third argument
+`true` form shown here is supported there. It requests a temporary logical
+replication slot. Choose a unique slot name.
+
+The no-op `UPDATE ... WHERE false` runs inside a transaction and rolls back, so
+it validates `replicas` write access without changing data.
+
+If no `z_%` schemas exist yet, that `UPDATE` check does nothing. Let Zero start
+once so it can create its own internal schemas, then rerun the script.
+
+Cleanup is automatic: the replication slot is temporary, so PostgreSQL drops it
+when the `psql` session ends.
+
+If you need to validate from a laptop, temporarily append your operator `/32` to the existing Zero role rule, run the script, then remove that `/32` and rerun the connection. The second run should fail before any SQL executes, which is the expected negative control.
+
+#### Common pitfalls
+
+- App-table `SELECT` alone is not enough. Zero also needs write access to its
+  internal `z_%` schemas or you may see errors like
+  `permission denied for table replicas`.
+- A blank-role `0.0.0.0/0` rule defeats a restricted `zero` role while it
+  exists.
+- Preserve existing app and user roles with explicit role-scoped `0.0.0.0/0`
+  rules before narrowing `zero`.
+- PlanetScale may reject duplicate restriction records for the same database
+  and role. Edit the existing `zero` rule instead.
+- Validate fresh connections after each change. Long-lived existing
+  connections are not enough to prove the rollout is safe.
 
 ### Neon
 


### PR DESCRIPTION
## Summary
- replace the stale recommendation to use the default PlanetScale role for Zero
- document how PlanetScale Postgres IP restrictions behave for role-scoped rules
- add a safe rollout, validation flow, and copyable custom Zero role example for hosted Zero egress allowlisting

## Verification
- `npx prettier --check contents/docs/connecting-to-postgres.mdx`
- `npm run lint`
- `npm run check-types`
- `npm run build`

## Notes
- the PlanetScale-specific behavior is framed as current guidance and operationally verified behavior, not a universal guarantee forever
- egress CIDRs are described generically so users can copy the current values from their hosted Zero provider